### PR TITLE
fix(brand): fix logo stories not rendering in Storybook

### DIFF
--- a/src/brand/devalok/devalok-logo.stories.tsx
+++ b/src/brand/devalok/devalok-logo.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { DevalokLogo } from './devalok-logo'
+import { DevalokLogo } from '.'
 
 const meta: Meta<typeof DevalokLogo> = {
   title: 'Brand/Devalok/Logo',

--- a/src/brand/devalok/devalok-logo.tsx
+++ b/src/brand/devalok/devalok-logo.tsx
@@ -1,5 +1,23 @@
 import * as React from 'react'
 import { cn } from '../../ui/lib/utils'
+import monogramBrand from '../assets/devalok/logos/monogram-brand.png'
+import monogramBlack from '../assets/devalok/logos/monogram-black.png'
+import monogramWhite from '../assets/devalok/logos/monogram-white.png'
+import monogramWordmarkBrand from '../assets/devalok/logos/monogram-wordmark-brand.png'
+import monogramWordmarkBlack from '../assets/devalok/logos/monogram-wordmark-black.png'
+import monogramWordmarkWhite from '../assets/devalok/logos/monogram-wordmark-white.png'
+import monogramShellBrand from '../assets/devalok/logos/monogram-shell-brand.png'
+import monogramShellBlack from '../assets/devalok/logos/monogram-shell-black.png'
+import monogramShellWhite from '../assets/devalok/logos/monogram-shell-white.png'
+import monogramShellWordmarkBrand from '../assets/devalok/logos/monogram-shell-wordmark-brand.png'
+import monogramShellWordmarkBlack from '../assets/devalok/logos/monogram-shell-wordmark-black.png'
+import monogramShellWordmarkWhite from '../assets/devalok/logos/monogram-shell-wordmark-white.png'
+import monogramCoinWordmarkBrand from '../assets/devalok/logos/monogram-coin-wordmark-brand.png'
+import monogramCoinWordmarkBlack from '../assets/devalok/logos/monogram-coin-wordmark-black.png'
+import monogramCoinWordmarkWhite from '../assets/devalok/logos/monogram-coin-wordmark-white.png'
+import shlokaBrand from '../assets/devalok/logos/shloka-brand.png'
+import shlokaBlack from '../assets/devalok/logos/shloka-black.png'
+import shlokaWhite from '../assets/devalok/logos/shloka-white.png'
 
 // --- Types ---
 
@@ -67,7 +85,7 @@ export function _registerSvg(key: string, component: SvgComponent) {
   svgComponents[key] = component
 }
 
-// --- Static asset types (large SVGs served as <img>) ---
+// --- Static asset types (large PNGs served as <img>) ---
 
 const staticTypes = new Set<DevalokLogoType>([
   'monogram',
@@ -78,11 +96,29 @@ const staticTypes = new Set<DevalokLogoType>([
   'shloka',
 ])
 
+const staticAssets: Record<string, string> = {
+  'monogram-brand': monogramBrand,
+  'monogram-black': monogramBlack,
+  'monogram-white': monogramWhite,
+  'monogram-wordmark-brand': monogramWordmarkBrand,
+  'monogram-wordmark-black': monogramWordmarkBlack,
+  'monogram-wordmark-white': monogramWordmarkWhite,
+  'monogram-shell-brand': monogramShellBrand,
+  'monogram-shell-black': monogramShellBlack,
+  'monogram-shell-white': monogramShellWhite,
+  'monogram-shell-wordmark-brand': monogramShellWordmarkBrand,
+  'monogram-shell-wordmark-black': monogramShellWordmarkBlack,
+  'monogram-shell-wordmark-white': monogramShellWordmarkWhite,
+  'monogram-coin-wordmark-brand': monogramCoinWordmarkBrand,
+  'monogram-coin-wordmark-black': monogramCoinWordmarkBlack,
+  'monogram-coin-wordmark-white': monogramCoinWordmarkWhite,
+  'shloka-brand': shlokaBrand,
+  'shloka-black': shlokaBlack,
+  'shloka-white': shlokaWhite,
+}
+
 function getStaticAssetPath(type: DevalokLogoType, color: string): string {
-  return new URL(
-    `../assets/devalok/logos/${type}-${color}.png`,
-    import.meta.url,
-  ).href
+  return staticAssets[`${type}-${color}`] ?? ''
 }
 
 // --- Utility ---

--- a/src/brand/karm/karm-logo.stories.tsx
+++ b/src/brand/karm/karm-logo.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { KarmLogo } from './karm-logo'
+import { KarmLogo } from '.'
 
 const meta: Meta<typeof KarmLogo> = {
   title: 'Brand/Karm/Logo',

--- a/src/css-modules.d.ts
+++ b/src/css-modules.d.ts
@@ -2,3 +2,8 @@ declare module '*.module.css' {
   const classes: { readonly [key: string]: string }
   export default classes
 }
+
+declare module '*.png' {
+  const url: string
+  export default url
+}


### PR DESCRIPTION
## Summary

- **Inline SVG types rendered nothing** (`wordmark`, `dass`, `chakra` for Devalok; all 3 types for Karm) — stories were importing directly from the component file (`'./devalok-logo'`), bypassing the `import './svg-components'` side-effect in the index. SVG registry stayed empty → component always returned `null`
- **PNG logos broken/unreliable** — `new URL(\`...${dynamic}...\`, import.meta.url)` uses a dynamic template literal that Vite cannot statically analyze, so PNGs weren't being bundled and may fail in some Storybook/build configs
- **No PNG type declaration** — TypeScript didn't know `.png` imports are strings

## Changes

- Story files now import from `'.'` (index) instead of the component directly, triggering SVG registration
- Replaced dynamic `import.meta.url` URL construction with 18 explicit static PNG imports + lookup map (correct Vite pattern)
- Added `declare module '*.png'` to `css-modules.d.ts`

## Test plan

- [ ] Brand/Devalok/Logo — all types render (monogram PNGs load, wordmark/dass/chakra SVGs render)
- [ ] Brand/Karm/Logo — all types render (icon/wordmark/wordmark-icon SVGs render)
- [ ] Color variants and size variants work for both

🤖 Generated with [Claude Code](https://claude.com/claude-code)