### PR TITLE
chore(storybook): fix orphaned Shared and Layout nav sections

### DIFF
--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -14,8 +14,8 @@ Welcome to **Shilp Sutra** -- the design system powering Devalok applications. I
 |-------|-------|-------------|
 | **Design Tokens** | 3 tiers | Primitives, semantic tokens, and Tailwind integration |
 | **UI Primitives** | 52 | Low-level Radix UI-based components |
-| **Shared Components** | 13 | Higher-level reusable patterns |
-| **Layout Components** | 6 | App shell and navigation structures |
+| **Composed Components** | 14 | Higher-level reusable patterns |
+| **Shell Components** | 6 | App shell and navigation structures |
 | **Karm Modules** | 43 | Domain-specific project management components |
 
 ---
@@ -25,8 +25,8 @@ Welcome to **Shilp Sutra** -- the design system powering Devalok applications. I
 - [**Foundations**](?path=/docs/foundations--docs) -- Color palettes, spacing, typography, shadows, and motion
 - [**Iconography**](?path=/docs/iconography--docs) -- 5,000+ Tabler Icons with sizes, strokes, and usage patterns
 - [**UI Primitives**](?path=/docs/ui-introduction--docs) -- Buttons, inputs, dialogs, tables, and more
-- [**Shared Components**](?path=/docs/shared-introduction--docs) -- PageHeader, DatePicker, RichTextEditor, and more
-- [**Layout**](?path=/docs/layout-introduction--docs) -- AppSidebar, TopBar, BottomNavbar, and more
+- [**Composed**](?path=/docs/composed-introduction--docs) -- PageHeader, DatePicker, RichTextEditor, and more
+- [**Shell**](?path=/docs/shell-introduction--docs) -- AppSidebar, TopBar, BottomNavbar, and more
 - [**Karm**](?path=/docs/karm-introduction--docs) -- Kanban boards, task details, chat, admin panels
 
 ---

--- a/src/composed/Introduction.mdx
+++ b/src/composed/Introduction.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Shared/Introduction" />
+<Meta title="Composed/Introduction" />
 
-# Shared Components
+# Composed Components
 
 Shilp Sutra provides **13 higher-level reusable components** built on top of the UI primitives. These handle common application patterns like page headers, status indicators, date selection, rich text editing, and loading states.
 
@@ -32,7 +32,7 @@ Shilp Sutra provides **13 higher-level reusable components** built on top of the
 
 ## Usage pattern
 
-Shared components are imported from the `shared` barrel:
+Composed components are imported from the `shared` barrel:
 
 ```tsx
 import { PageHeader, StatusBadge, EmptyState } from '@devalok/shilp-sutra/shared'

--- a/src/shell/Introduction.mdx
+++ b/src/shell/Introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/blocks'
 
-<Meta title="Layout/Introduction" />
+<Meta title="Shell/Introduction" />
 
 # Layout Components
 


### PR DESCRIPTION
## Summary

- The `src/composed/Introduction.mdx` had title `Shared/Introduction`, creating a phantom **Shared** top-level section separate from the actual **Composed** section where all the component stories live
- The `src/shell/Introduction.mdx` had title `Layout/Introduction`, creating a phantom **Layout** top-level section separate from the actual **Shell** section
- Fixed by aligning MDX titles with the story title prefix used by each directory

## Before → After (sidebar sections)

| Before | After |
|--------|-------|
| Getting Started | Getting Started |
| Foundations | Foundations |
| Brand | Brand |
| UI | UI |
| **Shared** ← orphaned intro only | ~~Shared~~ |
| Composed | Composed ← intro now lives here |
| **Layout** ← orphaned intro only | ~~Layout~~ |
| Shell | Shell ← intro now lives here |
| Karm | Karm |

Also updates the Getting Started page: links point to the correct doc paths, table uses consistent names, and composed component count corrected to 14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)