### PR TITLE
fix(brand): update test to use truly unregistered key

### DIFF
--- a/src/brand/devalok/devalok-logo.test.tsx
+++ b/src/brand/devalok/devalok-logo.test.tsx
@@ -96,7 +96,8 @@ describe('DevalokLogo (inline SVG types)', () => {
 
   it('returns null for unregistered SVG key', () => {
     const { container } = render(
-      <DevalokLogo type="dass" color="black" />,
+      // Cast to any to simulate an unknown type not in the registry
+      <DevalokLogo type={'unknown-type' as any} color="brand" />,
     )
     expect(container.firstChild).toBeNull()
   })


### PR DESCRIPTION
## Summary

- `dass-black` is now pre-loaded in the SVG registry, so the test that expected it to return `null` was failing
- Changed the test to cast an unknown type string instead, correctly verifying the null-return path

## Test plan

- [ ] `pnpm test run src/brand/devalok/devalok-logo.test.tsx` — 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)