### PR TITLE
fix(chip): show all 13 colors in AllVariants story grid

### DIFF
--- a/src/ui/chip.stories.tsx
+++ b/src/ui/chip.stories.tsx
@@ -129,7 +129,7 @@ export const Disabled: Story = {
 
 const variants = ['filled', 'outlined'] as const
 const sizes = ['sm', 'md', 'lg'] as const
-const colors = ['default', 'primary', 'success', 'error', 'warning'] as const
+const colors = ['default', 'primary', 'success', 'error', 'warning', 'info', 'teal', 'amber', 'slate', 'indigo', 'cyan', 'orange', 'emerald'] as const
 
 export const AllVariants: Story = {
   render: () => (


### PR DESCRIPTION
Expands the `const colors` array in `AllVariants` story from 5 to all 13 — including `info` and all 7 Sapta Varna categorical colors (`teal`, `amber`, `slate`, `indigo`, `cyan`, `orange`, `emerald`).

The component already supported all 13; the showcase grid just wasn't showing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)