### PR TITLE
fix: resolve critical audit findings across core, karm, and playground

### DIFF
--- a/apps/playground/tsconfig.json
+++ b/apps/playground/tsconfig.json
@@ -11,6 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noEmit": true,
     "paths": {
       "@/*": ["../../packages/core/src/*"],
       "@primitives/*": ["../../packages/core/src/primitives/*"]

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -17,8 +17,8 @@
 **New motion system:**
 - `import { MotionProvider, springs, tweens } from '@devalok/shilp-sutra/motion'`
 - `import { MotionFade, MotionCollapse, MotionSlide, MotionPop, MotionScale, MotionStagger } from '@devalok/shilp-sutra/motion/primitives'`
-- Springs: `springs.bouncy`, `springs.smooth`, `springs.snappy`, `springs.gentle`, `springs.rigid`
-- Tweens: `tweens.fade`, `tweens.standard`, `tweens.gentle`
+- Springs: `springs.snappy`, `springs.smooth`, `springs.bouncy`, `springs.gentle`
+- Tweens: `tweens.fade`, `tweens.colorShift`
 
 **Spinner v2:** New props `state?: 'spinning' | 'success' | 'error'`, `variant?: 'filled' | 'bare'`, `delay?: number`, `onComplete?: () => void`
 
@@ -286,8 +286,8 @@ NOTIFICATION SELECTION GUIDE:
 ## Server-Safe Components (no "use client")
 
 These can be imported directly in Next.js Server Components:
-- UI: Text, Skeleton, Spinner, Stack, Container, Table (and sub-components), Code, VisuallyHidden
-- Composed: ContentCard, EmptyState, PageHeader, LoadingSkeleton, PageSkeletons, PriorityIndicator, StatusBadge
+- UI: Text, Skeleton, Stack, Container, Table (and sub-components), Code, VisuallyHidden
+- Composed: ContentCard, PageHeader, LoadingSkeleton, PageSkeletons, PriorityIndicator
 
 Use per-component imports for server components:
   import { Text } from '@devalok/shilp-sutra/ui/text'

--- a/packages/core/scripts/build-tailwind-cjs.mjs
+++ b/packages/core/scripts/build-tailwind-cjs.mjs
@@ -13,15 +13,19 @@ const presetSrc = await readFile(resolve(dist, 'preset.js'), 'utf8')
 
 // Convert: strip the ESM export, add module.exports
 // The file looks like: const r = { ... };\nexport {\n  r as default\n};
+const varMatch = presetSrc.match(/^const\s+(\w+)\s*=/m)
+if (!varMatch) {
+  console.error('ERROR: Could not find variable name in preset.js output. The Rollup output format may have changed.')
+  process.exit(1)
+}
+const varName = varMatch[1]
+
 const cjs = presetSrc
   .replace(/^export\s*\{\s*\w+\s+as\s+default\s*\}\s*;?\s*$/m, '')
   .trimEnd()
-  // Find the variable name (e.g., "const r = {")
   .replace(/^const\s+(\w+)\s*=/m, (_, name) => {
-    // Append module.exports at the end
     return `const ${name} =`
-  }) + '\nmodule.exports = ' +
-  presetSrc.match(/^const\s+(\w+)\s*=/m)[1] + ';\nmodule.exports.default = module.exports;\n'
+  }) + `\nmodule.exports = ${varName};\nmodule.exports.default = module.exports;\n`
 
 // Validate that the ESM→CJS conversion removed all export statements
 if (/\bexport\s/.test(cjs)) {

--- a/packages/core/scripts/copy-tokens.mjs
+++ b/packages/core/scripts/copy-tokens.mjs
@@ -1,9 +1,12 @@
 import { cpSync, mkdirSync, readdirSync } from 'fs'
-import { join } from 'path'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 // Copy only .css files from tokens (exclude .mdx, .tsx, .d.ts, etc.)
-const srcTokens = 'src/tokens'
-const distTokens = 'dist/tokens'
+const srcTokens = join(__dirname, '..', 'src', 'tokens')
+const distTokens = join(__dirname, '..', 'dist', 'tokens')
 
 mkdirSync(distTokens, { recursive: true })
 

--- a/packages/core/scripts/inject-use-client.mjs
+++ b/packages/core/scripts/inject-use-client.mjs
@@ -42,8 +42,13 @@ const SERVER_SAFE = new Set([
   // vendor-utils chunk — pure functions (clsx, cva, tailwind-merge), no React
   '_chunks/vendor-utils',
 
-  // shared utils chunk — cn() helper (clsx + tailwind-merge), pure function
+  // shared chunks — pure functions split out by Rollup, no React
   '_chunks/utils',
+  '_chunks/motion',
+
+  // utility modules — pure functions, no React
+  'ui/lib/date-utils',
+  'composed/lib/string-utils',
 ])
 
 // ── Directories to skip entirely ────────────────────────────────────────────

--- a/packages/core/src/composed/avatar-group.tsx
+++ b/packages/core/src/composed/avatar-group.tsx
@@ -69,7 +69,7 @@ const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
 
             const avatar = (
               <Avatar
-                key={index}
+                key={user.name}
                 className={cn(
                   avatarSizeVariants({ size }),
                   index > 0 && overlapClass,
@@ -90,7 +90,7 @@ const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
             if (!showTooltip) return avatar
 
             return (
-              <Tooltip key={index}>
+              <Tooltip key={user.name}>
                 <TooltipTrigger asChild>{avatar}</TooltipTrigger>
                 <TooltipContent
                   className="border-surface-border-strong bg-surface-1 text-surface-fg"

--- a/packages/core/src/motion/index.ts
+++ b/packages/core/src/motion/index.ts
@@ -1,2 +1,2 @@
 export { MotionProvider, useMotion, type MotionProviderProps } from './motion-provider'
-export { springs, tweens, stagger, type SpringPreset, type TweenPreset } from '../ui/lib/motion'
+export { springs, tweens, stagger, withReducedMotion, motionProps, type SpringPreset, type TweenPreset } from '../ui/lib/motion'

--- a/packages/core/src/ui/badge.test.tsx
+++ b/packages/core/src/ui/badge.test.tsx
@@ -25,7 +25,7 @@ describe('Badge', () => {
     const user = userEvent.setup()
     const onDismiss = vi.fn()
     render(<Badge onDismiss={onDismiss}>Removable</Badge>)
-    const removeBtn = screen.getByRole('button', { name: 'Remove' })
+    const removeBtn = screen.getByRole('button', { name: 'Remove Removable' })
     expect(removeBtn).toBeInTheDocument()
     await user.click(removeBtn)
     expect(onDismiss).toHaveBeenCalledOnce()

--- a/packages/core/src/ui/badge.tsx
+++ b/packages/core/src/ui/badge.tsx
@@ -159,7 +159,7 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
             type="button"
             onClick={onDismiss}
             className="ml-ds-01 min-h-ds-xs min-w-ds-xs flex items-center justify-center rounded-ds-full text-surface-fg-subtle hover:rotate-90 transition-[color,transform] duration-fast-02 hover:text-surface-fg-muted hover:bg-surface-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-9"
-            aria-label="Remove"
+            aria-label={`Remove ${typeof children === 'string' ? children : ''}`.trim() || 'Remove'}
           >
             <IconX className="h-ico-sm w-ico-sm" />
           </button>

--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -308,7 +308,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
                     aria-label={`Remove ${option.label}`}
                     tabIndex={-1}
                   >
-                    <IconX className="h-3 w-3" aria-hidden="true" />
+                    <IconX className="h-ico-sm w-ico-sm" aria-hidden="true" />
                   </button>
                 </span>
               )

--- a/packages/core/src/ui/lib/use-ripple.ts
+++ b/packages/core/src/ui/lib/use-ripple.ts
@@ -9,10 +9,10 @@ interface Ripple {
 
 export function useRipple(duration = 600) {
   const [ripples, setRipples] = useState<Ripple[]>([])
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+  const timeoutsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
 
   useEffect(() => {
-    return () => { clearTimeout(timeoutRef.current) }
+    return () => { timeoutsRef.current.forEach(clearTimeout) }
   }, [])
 
   const createRipple = useCallback((e: MouseEvent<HTMLElement>) => {
@@ -23,9 +23,11 @@ export function useRipple(duration = 600) {
     const id = Date.now()
 
     setRipples((prev) => [...prev, { id, x, y, size }])
-    timeoutRef.current = setTimeout(() => {
+    const t = setTimeout(() => {
       setRipples((prev) => prev.filter((r) => r.id !== id))
+      timeoutsRef.current.delete(t)
     }, duration)
+    timeoutsRef.current.add(t)
   }, [duration])
 
   return { ripples, createRipple }

--- a/packages/core/src/ui/segmented-control.tsx
+++ b/packages/core/src/ui/segmented-control.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useId } from 'react'
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion'
 import { cva } from 'class-variance-authority'
 import { cn } from './lib/utils'
@@ -207,6 +207,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
   ...props
 }, forwardedRef) {
   const resolved = resolveSize(size)
+  const instanceId = useId()
   const [focusedId, setFocusedId] = useState<string | null>(null)
   const tablistRef = useRef<HTMLDivElement | null>(null)
   const mergedRef = React.useCallback((node: HTMLDivElement | null) => {
@@ -277,6 +278,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
             isFocused={option.id === focusedId}
             onFocus={() => setFocusedId(option.id)}
             onBlur={() => setFocusedId(null)}
+            layoutId={`${instanceId}-segment-indicator`}
           />
         ))}
       </LayoutGroup>
@@ -329,6 +331,8 @@ export interface SegmentedControlItemProps {
   isFocused: boolean
   onFocus: () => void
   onBlur: () => void
+  /** @internal Unique layout animation ID — provided by the parent SegmentedControl. */
+  layoutId?: string
 }
 
 const SegmentedControlItem = React.forwardRef<HTMLButtonElement, SegmentedControlItemProps>(
@@ -343,6 +347,7 @@ const SegmentedControlItem = React.forwardRef<HTMLButtonElement, SegmentedContro
   isFocused,
   onFocus,
   onBlur,
+  layoutId = 'segment-indicator',
 }, ref) {
   const [state, setState] = useState<'default' | 'hover' | 'pressed'>('default')
   const { ripples, createRipple } = useRipple()
@@ -404,7 +409,7 @@ const SegmentedControlItem = React.forwardRef<HTMLButtonElement, SegmentedContro
       {/* Sliding active indicator — only mounted in the selected segment */}
       {isSelected && (
         <motion.span
-          layoutId="segment-indicator"
+          layoutId={layoutId}
           className={cn(
             'absolute inset-0 rounded-ds-full pointer-events-none',
             variant === 'filled'

--- a/packages/core/src/ui/stepper.tsx
+++ b/packages/core/src/ui/stepper.tsx
@@ -132,8 +132,9 @@ interface StepProps extends React.HTMLAttributes<HTMLDivElement> {
 
 type StepInternalProps = StepProps & { _index?: number }
 
-const Step = React.forwardRef<HTMLDivElement, StepInternalProps>(
-  ({ label, description, icon, className, _index = 0, ...props }, ref) => {
+const Step = React.forwardRef<HTMLDivElement, StepProps>(
+  ({ label, description, icon, className, ...props }, ref) => {
+    const { _index = 0, ...restProps } = props as StepInternalProps
     const { activeStep, orientation, stepperId } = React.useContext(StepperContext)
     const state: StepState = _index < activeStep ? 'completed' : _index === activeStep ? 'active' : 'pending'
 
@@ -148,7 +149,7 @@ const Step = React.forwardRef<HTMLDivElement, StepInternalProps>(
           orientation === 'vertical' && 'py-ds-02',
           className,
         )}
-        {...props}
+        {...restProps}
       >
         <div
           className={cn(

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -52,7 +52,6 @@ const autoEntries = collectEntries([
   'shell',
   'hooks',
   'tailwind',
-  'motion',
 ])
 
 // Subdirectory entries that aren't picked up by the top-level scan
@@ -60,8 +59,12 @@ const explicitEntries: Record<string, string> = {
   'ui/charts/index': resolve(__dirname, 'src/ui/charts/index.ts'),
   'ui/tree-view/index': resolve(__dirname, 'src/ui/tree-view/index.ts'),
   'ui/lib/utils': resolve(__dirname, 'src/ui/lib/utils.ts'),
+  'ui/lib/motion': resolve(__dirname, 'src/ui/lib/motion.ts'),
+  'ui/lib/date-utils': resolve(__dirname, 'src/ui/lib/date-utils.ts'),
   'composed/date-picker/index': resolve(__dirname, 'src/composed/date-picker/index.ts'),
   'composed/lib/string-utils': resolve(__dirname, 'src/composed/lib/string-utils.ts'),
+  'motion/index': resolve(__dirname, 'src/motion/index.ts'),
+  'motion/primitives-index': resolve(__dirname, 'src/motion/primitives-index.ts'),
 }
 
 export default defineConfig({
@@ -110,7 +113,7 @@ export default defineConfig({
               return 'tiptap'
             // Framer Motion — only loaded by Spinner and future animation components
             if (id.includes('framer-motion'))
-              return 'motion'
+              return 'framer'
             // Client-only deps that use React hooks/DOM — includes transitive deps
             if (
               id.includes('@floating-ui/') ||

--- a/packages/karm/package.json
+++ b/packages/karm/package.json
@@ -59,7 +59,7 @@
     "prepublishOnly": "pnpm build"
   },
   "peerDependencies": {
-    "@devalok/shilp-sutra": ">=0.7.0",
+    "@devalok/shilp-sutra": ">=0.18.0",
     "@tabler/icons-react": "^3.0.0",
     "framer-motion": "^12.0.0",
     "react": "^18 || ^19",

--- a/packages/karm/src/dashboard/daily-brief.tsx
+++ b/packages/karm/src/dashboard/daily-brief.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import ReactMarkdown from 'react-markdown'
+import { markdownComponents } from '../chat/markdown-components'
 import { IconChevronDown, IconRefresh, IconSparkles } from '@tabler/icons-react'
 import { springs } from '@/ui/lib/motion'
 import { cn } from '@/ui/lib/utils'
@@ -149,7 +150,7 @@ const DailyBrief = React.forwardRef<HTMLDivElement, DailyBriefProps>(
                     className={cn('mt-ds-02b h-2 w-2 shrink-0 rounded-ds-full', DOT_COLORS[index % DOT_COLORS.length])}
                   />
                   <div className="text-ds-md text-surface-fg-muted [&_p]:mb-0 [&_strong]:font-semibold [&_code]:rounded [&_code]:bg-surface-3 [&_code]:px-1 [&_code]:py-ds-01 [&_code]:text-ds-sm [&_a]:text-accent-11 [&_a]:underline">
-                    <ReactMarkdown>{item}</ReactMarkdown>
+                    <ReactMarkdown components={markdownComponents}>{item}</ReactMarkdown>
                   </div>
                 </div>
               ))}

--- a/packages/karm/src/tasks/files-tab.tsx
+++ b/packages/karm/src/tasks/files-tab.tsx
@@ -215,7 +215,7 @@ const FilesTab = React.forwardRef<HTMLDivElement, FilesTabProps>(
                 <div className="flex items-center gap-ds-02 opacity-0 transition-opacity group-hover:opacity-100">
                   {file.externalUrl && (
                     <a
-                      href={file.externalUrl}
+                      href={/^https?:\/\//.test(file.externalUrl) ? file.externalUrl : '#'}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex h-ds-xs-plus w-ds-xs-plus items-center justify-center rounded-ds-md transition-colors hover:bg-surface-2"

--- a/packages/karm/vite.config.ts
+++ b/packages/karm/vite.config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
         if (/^@devalok\/shilp-sutra($|\/)/.test(id)) return true
         if (/^@tabler\/icons-react($|\/)/.test(id)) return true
         if (/^next($|\/)/.test(id)) return true
+        if (/^framer-motion($|\/)/.test(id)) return true
         // Everything else gets bundled (@dnd-kit, react-markdown, date-fns, clsx, cva, tailwind-merge)
         return false
       },
@@ -59,7 +60,7 @@ export default defineConfig({
           if (coreMatch) {
             const subpath = coreMatch[1]
             // Map core subpaths to the correct package export, preserving per-component paths
-            const categories = ['ui', 'composed', 'shell', 'hooks', 'tailwind']
+            const categories = ['ui', 'composed', 'shell', 'hooks', 'tailwind', 'motion']
             for (const cat of categories) {
               if (subpath.startsWith(`${cat}/`)) {
                 // Check if this is a barrel index import (e.g. "ui/index")


### PR DESCRIPTION
## Summary
- **Security**: Validate `externalUrl` protocol in files-tab (XSS fix), sanitize markdown hrefs in daily-brief, fix `useRipple` timeout leak under rapid clicks
- **Build pipeline**: Fix root cause of stale `.js` files (playground `tsc` emitting via path aliases — added `noEmit`), add 4 missing package exports, move motion entries to `explicitEntries`, rename `manualChunks` chunk name collision, fix `SERVER_SAFE` allowlist for Rollup shared chunks (`_chunks/utils`, `_chunks/motion`, `composed/lib/string-utils`)
- **Component API**: Scope `SegmentedControl` `layoutId` via `useId()` for multi-instance safety, contextual Badge dismiss `aria-label`, fix Stepper `_index` type leak in public API, use DS icon token in Combobox dismiss, re-export `withReducedMotion` and `motionProps` from motion barrel
- **Karm**: Externalize `framer-motion` (was bundled despite being a peer dep — 183KB savings), add `motion` to path rewrite categories, bump peer dep floor to `>=0.18.0`
- **Docs**: Fix `llms.txt` non-existent motion preset names (`springs.rigid`, `tweens.standard`, `tweens.gentle`) and stale server-safe component list
- **Scripts**: Add null-check guard in `build-tailwind-cjs.mjs`, anchor `copy-tokens.mjs` paths to `import.meta.url`

## Test plan
- [x] `pnpm typecheck` — all 3 packages pass
- [x] `pnpm test` — 126 files, 1013 tests, 0 failures
- [x] `pnpm build` — all 4 packages build successfully
- [x] Zero stale `.js` files in `packages/core/src/ui/` after full workspace build
- [x] Server-safe chunks (`_chunks/utils`, `_chunks/motion`, `ui/lib/date-utils`, `composed/lib/string-utils`) confirmed no `"use client"` directive
- [x] Karm vendor chunk reduced from 492KB to 309KB (framer-motion externalized)
- [x] All 3 originally-broken import paths (`ui/lib/motion`, `ui/lib/date-utils`, `motion/primitives`) resolve to real files in core dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)