### PR TITLE
fix(audit): read per-package CHANGELOGs, not stale root

### DIFF
--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -84,9 +84,16 @@ function getPackageVersion(pkg) {
   return pj.version
 }
 
-function getChangelogLatestVersion() {
-  const cl = readFileSync(join(ROOT, 'CHANGELOG.md'), 'utf-8')
-  const match = cl.match(/^## \[(\d+\.\d+\.\d+)\]/m)
+// Reads the latest version header from a package's changesets-managed
+// CHANGELOG.md. Changesets writes `## 0.37.1` (no brackets); the legacy
+// hand-maintained root CHANGELOG used Keep-a-Changelog `## [0.37.1]`.
+// Accept both. Skip prerelease entries (`## 0.37.0-next.1`) — pre-mode bypasses
+// this gate anyway, so stable-only matching keeps the regex simple.
+function getChangelogLatestVersion(pkg = 'core') {
+  const path = join(ROOT, 'packages', pkg, 'CHANGELOG.md')
+  if (!existsSync(path)) return null
+  const cl = readFileSync(path, 'utf-8')
+  const match = cl.match(/^## \[?(\d+\.\d+\.\d+)\]?\s*$/m)
   return match ? match[1] : null
 }
 
@@ -648,10 +655,9 @@ advisory('Components have Storybook stories', () => {
 advisory('Brand version matches CHANGELOG', () => {
   try {
     const brandVersion = getPackageVersion('brand')
-    const brandCL = readFileSync(join(ROOT, 'CHANGELOG.md'), 'utf-8')
-    const brandMatch = brandCL.match(/## \[(\d+\.\d+\.\d+)\].*brand/i)
-    if (!brandMatch) return true // No brand entry — acceptable
-    if (brandVersion !== brandMatch[1]) return `Brand ${brandVersion} vs CHANGELOG ${brandMatch[1]}`
+    const brandCLVersion = getChangelogLatestVersion('brand')
+    if (!brandCLVersion) return true // No brand CHANGELOG — acceptable
+    if (brandVersion !== brandCLVersion) return `Brand ${brandVersion} vs CHANGELOG ${brandCLVersion}`
     return true
   } catch {
     return true // Brand package may not exist


### PR DESCRIPTION
## Summary

- Fixes the pre-publish audit gate that blocked the 0.37.1 release
- `getChangelogLatestVersion()` now reads `packages/{pkg}/CHANGELOG.md` (changesets-managed) instead of the legacy hand-maintained root `CHANGELOG.md`
- Regex accepts both changesets format (`## 0.37.1`) and Keep-a-Changelog (`## [0.37.0]`) so existing legacy entries still parse

## Why this was broken

Changesets was adopted on 2026-04-06. Since then, `packages/core/CHANGELOG.md` is the source of truth — root `CHANGELOG.md` stopped getting version bumps. The audit kept reading root, so the 0.37.0 → 0.37.1 bump passed locally (both at 0.37.0) but failed on CI because package.json had been bumped to 0.37.1 while root CHANGELOG was still stuck at `[0.37.0]`.

0.37.0 release happened to pass because root CHANGELOG coincidentally still read `[0.37.0] - unreleased (core)` at the time.

## Test plan

- [x] Regex validated against real formats (`## 0.37.1`, `## [0.37.0]`, `## 0.37.0-next.1`) — prereleases correctly skipped (pre-mode bypasses the gate anyway)
- [x] Local dry-run: both `core` and `brand` version↔CHANGELOG pairs resolve correctly
- [ ] CI re-run on merge: release.yml audit passes → publishes 0.37.1

Once merged, `release.yml` will auto-fire on the merge commit. Package.json is already at 0.37.1 with the changesets consumed, so changesets/action will publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)