### PR TITLE
chore(storybook): freeze animations under Chromatic for deterministic snapshots

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,12 +1,33 @@
 import React from 'react'
 import { definePreview } from '@storybook/react-vite'
 import { parameters as docsParameters } from '@storybook/addon-docs/preview'
+import isChromatic from 'chromatic/isChromatic'
 import { TooltipProvider } from '../packages/core/src/ui/tooltip'
 import theme from './theme'
 // Single CSS entry — storybook.css @imports tailwindcss + shilp-sutra.css
 // (our TW4-native token bundle). The legacy tokens/index.css import that
 // used to live here was removed in 0.37 (avoided double-loading tokens).
 import '../storybook.css'
+
+// Freeze animations under Chromatic for deterministic visual snapshots.
+// Spinner, marching-ant Button, and other infinite animations otherwise
+// capture at random phases and produce false-positive diffs every build.
+// Trade-off: Chromatic loses the ability to catch easing-curve regressions.
+// Acceptable — visual diffs of static frames are far more valuable to gate.
+if (typeof document !== 'undefined' && isChromatic()) {
+  const style = document.createElement('style')
+  style.setAttribute('data-shilp-sutra', 'chromatic-freeze')
+  style.textContent = `
+    *, *::before, *::after {
+      animation-duration: 0s !important;
+      animation-delay: 0s !important;
+      animation-iteration-count: 1 !important;
+      animation-fill-mode: both !important;
+      transition-duration: 0s !important;
+    }
+  `
+  document.head.appendChild(style)
+}
 
 /* ── Dark-mode toolbar decorator ──────────────────────────────────
    Toggles the `.dark` class on <html> based on the toolbar selection.


### PR DESCRIPTION
## Summary

- Spinner, marching-ant Button, and other infinite CSS animations were being captured at random phases under Chromatic, producing false-positive visual diffs every build (review noise, not blocking — `chromatic.config.json` has `exitZeroOnChanges: true`).
- Adds an `isChromatic()`-gated style block to `.storybook/preview.ts` that pins all animations to first frame for deterministic captures.
- No npm-tarball impact (`.storybook/` doesn't ship). No changeset needed per [CONTRIBUTING.md § Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes) — this is internal storybook config.

## What changes

```ts
// .storybook/preview.ts
import isChromatic from 'chromatic/isChromatic'

if (typeof document !== 'undefined' && isChromatic()) {
  const style = document.createElement('style')
  style.setAttribute('data-shilp-sutra', 'chromatic-freeze')
  style.textContent = `
    *, *::before, *::after {
      animation-duration: 0s !important;
      animation-delay: 0s !important;
      animation-iteration-count: 1 !important;
      animation-fill-mode: both !important;
      transition-duration: 0s !important;
    }
  `
  document.head.appendChild(style)
}
```

`chromatic@^16.3.0` is already in root `devDependencies` (no install needed).

## Trade-off

Chromatic loses the ability to catch:
- Easing-curve regressions (e.g., wrong cubic-bezier)
- Motion-timing bugs (e.g., 200ms changed to 800ms)

We accept this. Motion bugs are typically caught in interactive Storybook + manual QA. Visual diffs of static frames are far more valuable to gate against.

## Test plan

- [ ] Chromatic run on this branch shows fewer (ideally zero) "false-positive" diffs vs. recent baselines on stories featuring Spinner / Button `processing` / Toast / animated transitions
- [ ] Spot-check Storybook locally: `pnpm dev` → confirm animations still play normally outside Chromatic env (the freeze only kicks in when `isChromatic()` returns true, which is false during local dev)
- [ ] Verify typecheck/lint/tests still pass (no regressions from the new import)
- [ ] Bonus: confirm the freeze element appears in DOM under Chromatic env via `data-shilp-sutra="chromatic-freeze"` selector (handy for debug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)