### PR TITLE
chore(beta): foundations for 0.40.0 public beta

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-agent-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ai-agent-feedback.yml
@@ -1,20 +1,36 @@
 name: AI agent feedback
 description: An AI coding agent (Claude Code, Cursor, Copilot, Codex, Aider) hit a wall while using shilp-sutra in a consumer project.
 title: "[ai-agent] "
-labels: ["ai-agent-feedback", "needs-triage"]
+labels: ["ai-agent-feedback", "needs-triage", "beta-feedback", "agent-filed"]
 body:
   - type: markdown
     attributes:
       value: |
         File this when an agent: (a) followed a recipe and it broke, (b) the docs claim something the code doesn't do, (c) `llms.txt` / `llms-full.txt` / `AGENTS.md` is missing context the agent needed, OR (d) a constraint we documented turned out to be wrong.
 
+        **Beta SLA** (`@devalok/shilp-sutra@0.40.0`): bot ack < 1 min, urgent human ack ≤ 48h, normal triage weekly Mon. Full SLA: https://github.com/devalok-design/shilp-sutra/blob/main/CONTRIBUTING.md#beta-sla
+
+        **One issue per task.** Multiple problems hit during the same task → file ONE issue listing all. Do not split per file or per missing-doc.
+
+        **Search first.** Before filing, check open issues: https://github.com/devalok-design/shilp-sutra/issues?q=is%3Aopen+label%3Aai-agent-feedback — comment on near-duplicates instead of opening new.
+
         Karm's agent flow uses the `karm-ai-agent-feedback` label specifically — pick that label below if you're filing from Karm. Other consumer agents use the default `ai-agent-feedback`.
 
   - type: input
     id: agent
     attributes:
-      label: Which agent
-      placeholder: "Claude Code 2.x / Cursor 0.x / GitHub Copilot / Codex / Aider"
+      label: Which agent (model + version)
+      description: Include the model identifier, not just the product (e.g. "Claude Code 2.5 / Opus 4.7").
+      placeholder: "Claude Code 2.5 (Opus 4.7) / Cursor 0.x (gpt-5) / GitHub Copilot / Codex / Aider"
+    validations:
+      required: true
+
+  - type: input
+    id: human-prompt
+    attributes:
+      label: Human's original prompt (1 line)
+      description: What did the human ask the agent to do? Helps separate "agent went rogue" from "tooling actually failed".
+      placeholder: "Add shilp-sutra to my Next.js 16 app and build a dashboard with a sidebar"
     validations:
       required: true
 
@@ -22,7 +38,34 @@ body:
     id: package-version
     attributes:
       label: shilp-sutra version
-      placeholder: "0.38.0"
+      placeholder: "0.40.0"
+    validations:
+      required: true
+
+  - type: input
+    id: framework-os
+    attributes:
+      label: Framework + version + OS
+      description: Exact framework version (from lockfile), node version, OS. Helps repro.
+      placeholder: "Next.js 16.0.2 (App Router) / Node 22.4 / macOS 14.5 (arm64)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: urgency
+    attributes:
+      label: Urgency (self-classified)
+      description: |
+        **Urgent = ALL of:** reproduces on documented setup; breaks install / initial render / build / security; not solvable by re-reading existing docs.
+
+        **NOT urgent:** visual preference, feature request, doc confusion (= Normal), breaks only on undocumented setup, already-known issue with workaround.
+
+        Maintainer reserves the right to reclassify. Reclassification is the norm, not a slight.
+      options:
+        - "Normal — API ambiguity, agent-trap, doc gap, behavior contradicting docs"
+        - "Urgent — install-break, runtime crash on supported framework, or security"
+        - "Nice-to-have — polish, preference, feature request"
+      default: 0
     validations:
       required: true
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,52 @@
+<!--
+Thanks for the PR. Fill the checklist below; reviewers will use it to triage.
+For larger context, see CONTRIBUTING.md.
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what changed and why. Skip the play-by-play; the diff has that. -->
+
+## Linked issues
+
+<!-- Use "Closes #N" / "Fixes #N" for auto-close. List multiple if applicable. -->
+
+Closes #
+
+## Checklist
+
+### Always
+
+- [ ] `pnpm typecheck && pnpm lint && pnpm test` clean locally
+- [ ] Changeset added (`pnpm changeset`) at the right bump level — see [Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes)
+- [ ] Storybook stories updated if visuals changed
+- [ ] `pre-publish-audit.mjs` clean (CI runs it on `main`; run locally for risky changes)
+
+### If this PR fixes agent-filed feedback (`ai-agent-feedback` label)
+
+- [ ] `llms.txt` updated where the agent's expectation no longer matches reality
+- [ ] `llms-full.txt` updated if per-component prop/variant details changed
+- [ ] `docs/recipes/` updated if the install/setup path changed
+- [ ] `AGENTS.md` updated if a hard constraint or auth-tier order changed
+- [ ] The original agent-filed issue is closed by this PR (`Closes #N`)
+
+### If this PR introduces a breaking change
+
+- [ ] Changeset body leads with `**BREAKING:**` + before/after snippet
+- [ ] `MIGRATION.md` section added with consumer-side migration steps
+- [ ] **If the break touches more than two components**: codemod shipped in [`@devalok/shilp-sutra-codemods`](https://github.com/devalok-design/shilp-sutra-codemods) per [Codemod policy](../blob/main/CONTRIBUTING.md#codemod-policy). Link the codemod path:
+- [ ] Deprecation cycle observed (≥1 minor as `@deprecated` before removal), OR explicit justification for skipping below
+
+### If this PR adds a new component
+
+- [ ] `React.forwardRef` + `displayName`
+- [ ] `className` merged via `cn()` + remaining props spread
+- [ ] CVA used if `variant`/`size`/`color` props exist
+- [ ] Exported prop types interface
+- [ ] Unit test with at least one `vitest-axe` assertion
+- [ ] Storybook story with `tags: ['autodocs']`
+- [ ] Entry added to `llms.txt` Quick Reference + `llms-full.txt` per-component block
+
+## Notes for the reviewer
+
+<!-- Anything non-obvious about the approach, alternatives considered, or follow-ups intentionally deferred. -->

--- a/.github/workflows/agent-feedback-ack.yml
+++ b/.github/workflows/agent-feedback-ack.yml
@@ -1,0 +1,43 @@
+name: Auto-acknowledge agent feedback
+
+# Posts an automatic acknowledgement comment on any issue opened with the
+# `ai-agent-feedback` label. Removes the "did anyone see this?" silence that
+# kills agent (and human) trust during beta. Bot ack < 1 minute is the
+# scoped commitment in CONTRIBUTING.md#beta-sla; the human SLA scopes
+# triage, not fix.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  ack:
+    if: contains(github.event.issue.labels.*.name, 'ai-agent-feedback')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '**Received** — beta feedback queue.',
+              '',
+              'Triage timing per [Beta SLA](../blob/main/CONTRIBUTING.md#beta-sla):',
+              '- **Urgent** (install-break / runtime crash on supported setup): human response ≤48h',
+              '- **Normal** (API / docs / agent-trap): weekly Monday triage',
+              '- **Nice-to-have** (polish / preference): batched, no calendar',
+              '',
+              'Wrong category? Add label `urgent` or comment to reclassify.',
+              '',
+              'Beta exit criteria + plan: [docs/plans/2026-05-24-beta-release-plan.md](../blob/main/docs/plans/2026-05-24-beta-release-plan.md#7-exit-criteria).',
+              '',
+              '_This is an automated acknowledgement. A human will read this issue on the next triage cycle._',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,55 @@ For the per-component RSC-safety matrix and import patterns, see **`packages/cor
 
 ## Reporting feedback
 
-If you find that a recipe is wrong, a constraint above is no longer accurate, or a component behavior contradicts the docs:
+If a recipe is wrong, a constraint above is no longer accurate, a component behavior contradicts the docs, or `llms.txt` / `AGENTS.md` is missing context you needed — file a GitHub issue. We read every one. The package is in public beta (v0.40.0); your report literally shapes 1.0.
 
-1. Open a GitHub issue at `https://github.com/devalok-design/shilp-sutra/issues` with label `ai-agent-feedback`.
-2. Include the package version (`pnpm view @devalok/shilp-sutra version` or read from the consumer's lockfile), the recipe path, the exact command/file/error, and what you expected.
+### How to file (auth-tier order, use the first one that works)
+
+1. **GitHub MCP available in your environment** → call `mcp__github__create_issue` with the user's auth. Owner `devalok-design`, repo `shilp-sutra`, title `[ai-agent] <one-line summary>`, labels include `ai-agent-feedback`. Cleanest path.
+2. **`gh` CLI configured on the user's machine** → `gh issue create --repo devalok-design/shilp-sutra --template ai-agent-feedback.yml --title "[ai-agent] ..."` with field bodies via `--body-file` or interactive editor.
+3. **Fallback: prefilled URL.** Build `https://github.com/devalok-design/shilp-sutra/issues/new?template=ai-agent-feedback.yml&agent=<...>&human-prompt=<...>&package-version=<...>&framework-os=<...>&urgency=<...>&recipe-path=<...>&what-agent-tried=<...>&what-broke=<...>&doc-gap=<...>` with every field URL-encoded. Output the URL to the user and ask them to click + submit. Zero auth required. Truncate each long field to ~2KB to stay under GitHub's ~8KB issue-URL ceiling.
+
+### Required content in the issue body
+
+The `ai-agent-feedback.yml` template enforces these. Fill all required slots:
+
+- Agent name + model + version (e.g. "Claude Code 2.5 / Opus 4.7")
+- Human's original prompt (one line)
+- shilp-sutra version (`pnpm view @devalok/shilp-sutra version` or from lockfile)
+- Framework + version + OS (from lockfile + `node -v` + OS detection)
+- Urgency (self-classify per the definition below; default Normal)
+- Recipe followed, if any
+- What the agent tried (the plan, the edits, the prompt)
+- Where it broke (verbatim error / stack / surprising behavior)
+- What the docs should have said (rough sentence is fine)
+
+### Urgency self-classification (objective)
+
+**Urgent = ALL of:**
+- Reproduces on documented setup (recipe-followed install)
+- Breaks install OR initial render OR build OR security
+- Not solvable by re-reading existing docs
+
+**NOT urgent:**
+- Visual preference / "looks wrong"
+- Missing feature request
+- Confusion about docs (= normal, doc-gap)
+- Breaks only on undocumented framework or post-modification
+- Already-known issue with existing workaround
+
+Default to Normal. Maintainer reserves the right to reclassify; that is the norm, not a slight.
+
+### Rules (these stop you from drowning the queue)
+
+- **One issue per task.** Multiple problems hit during the same task → file ONE issue listing all. Do NOT file separately per broken file or per missing doc.
+- **Search before filing.** `gh issue list --repo devalok-design/shilp-sutra -l ai-agent-feedback -s open` or web-search `https://github.com/devalok-design/shilp-sutra/issues?q=is%3Aopen+label%3Aai-agent-feedback`. Near-duplicate → comment on existing instead of opening new.
+- **Acknowledge with the human.** Show the human the issue link (or the prefilled URL) before/after submission. Don't file in the background — the human is the source of truth on whether the issue should be filed.
+
+### What happens after you file
+
+- **Bot ack < 1 minute** via `.github/workflows/agent-feedback-ack.yml`.
+- **Triage cadence per [CONTRIBUTING.md#beta-sla](./CONTRIBUTING.md#beta-sla):** urgent ≤48h, normal weekly Mon, nice-to-have batched.
+- **Fix loop:** when an agent-filed issue is fixed, the PR template requires updating `llms.txt` / `docs/recipes/` / `AGENTS.md` if relevant. The next agent that reads these files gets the updated content. The loop closes structurally.
 
 <!-- END:shilp-sutra-agent-rules -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to `@devalok/shilp-sutra` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.40.0] - unreleased (core) — **Public Beta**
+
+The package enters public beta. Install path is stable across Next.js (App + Pages), Vite, Astro, Remix, and TanStack Start per the shipped recipes. API surface is pre-1.0 — minors may break, and any break touching more than two components ships with a codemod in [`@devalok/shilp-sutra-codemods`](https://github.com/devalok-design/shilp-sutra-codemods). Full beta plan: [docs/plans/2026-05-24-beta-release-plan.md](./docs/plans/2026-05-24-beta-release-plan.md).
+
+### Added
+
+- **Beta SLA in `CONTRIBUTING.md#beta-sla`** — bot-ack immediate, urgent human-ack ≤48h, normal triage weekly Mondays. Maintainer commitment scopes to triage, not fix.
+- **Codemod policy in `CONTRIBUTING.md#codemod-policy`** — any break touching >2 components must ship a codemod. Adopted from Mantine v7 lessons.
+- **Auto-acknowledge GitHub Action (`.github/workflows/agent-feedback-ack.yml`)** — every issue labeled `ai-agent-feedback` gets an automated comment <1 minute after opening with the SLA pointer and triage timing.
+- **Pull-request template (`.github/pull_request_template.md`)** — required checkboxes for changeset, recipe/llms.txt/AGENTS.md updates on agent-feedback fixes, and codemod for >2-component breaks.
+- **Extended `ai-agent-feedback.yml` issue template** — new required slots: human's original prompt, framework + version + OS, self-classified urgency dropdown (Urgent / Normal / Nice-to-have) with definitions inline.
+- **Agent feedback rules in `AGENTS.md`** (inside managed BEGIN/END markers) — auth-tier order (GitHub MCP → `gh` CLI → prefilled URL fallback), one-issue-per-task rule, dedup-search rule, identity-declaration requirement.
+- **Storybook MCP server documented in `llms.txt`** — dev-only at `localhost:6006/mcp`, exposes per-story prop dumps and live story URLs to agents.
+
+### Changed
+
+- **README banner** marks the package as public beta with feedback channels and SLA pointer.
+- **`llms.txt` opens with a beta banner** so agents reading `node_modules/@devalok/shilp-sutra/llms.txt` know the API stability posture and feedback path.
+
+### Known
+
+- Marketing site at `https://shilp-sutra.devalok.in` is in active development on `feat/site-v1-and-skill`. Some links from beta announcements may 404 until v1 lands.
+- Only the Next.js App Router starter repo is targeted for beta. Vite, Astro, Remix, and TanStack starters are post-beta.
+- Per-component bundle-size badges, public Chromatic link, ESLint plugin, and visual builder are deferred to post-beta.
+
 ## [0.37.0] - unreleased (core)
 
 **Tailwind 4 CSS-first migration.** This is a setup-only breaking release — component APIs are unchanged. See [MIGRATION.md](./MIGRATION.md#v0370--tailwind-4-css-first-migration) for the full guide and the required consumer changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,18 @@ Before removing a public API:
 
 The v0.38 deprecation sweep is the canonical example — see commits `dff85b37`...`ec5112be` and `MIGRATION.md#v0380--deprecation-sweep`.
 
+### Codemod policy
+
+**Any breaking change that touches more than two components MUST ship with a codemod.** Adopted from Mantine v7's `mantine6to7` lessons — small breaks can be hand-migrated, but cross-component sweeps without automation create migration walls that stall consumer upgrades.
+
+Rules:
+
+1. **Threshold: >2 components touched.** Count the number of consumer-facing component exports impacted. Renames, prop signature changes, default-value flips, removed variants all count. A token-only break (no component code change) does not count toward the threshold.
+2. **Codemod lives in [`@devalok/shilp-sutra-codemods`](https://github.com/devalok-design/shilp-sutra-codemods).** One repo, one codemod per minor that requires one. Built on `jscodeshift`. Each codemod is named for the version that introduced the break: `0.40-to-0.41.js`.
+3. **Codemod ships in the same PR as the breaking change.** The break is not mergeable without it. Reviewer checks: `pnpm changeset` body links to the codemod path, `MIGRATION.md` references it, the codemod has unit tests.
+4. **Consumer migration is one command:** `npx @devalok/shilp-sutra-codemods <version-pair> <path>`. Document in `MIGRATION.md` next to the manual instructions — codemod first, manual as fallback.
+5. **Backfill on demand, not retroactively.** We do not owe codemods for breaks shipped before this policy (e.g. 0.38 deprecation sweep). Backfill only if a consumer explicitly asks during their upgrade.
+
 ### Public API surface
 
 The "public API" includes:
@@ -134,3 +146,41 @@ Internal-only:
 - Test fixtures, Storybook stories, the Vite playground app
 
 If a change touches public-API surface, it's a real semver event. Err toward the higher bump.
+
+## Beta SLA
+
+> Active for the `0.40.0` public beta window. See [docs/plans/2026-05-24-beta-release-plan.md](./docs/plans/2026-05-24-beta-release-plan.md) for the full beta plan.
+
+The beta SLA scopes maintainer commitment honestly — bot ack is automated, human commitment is to **triage**, not fix.
+
+| Category | Definition | Bot ack | Human triage | Fix posture |
+|---|---|---|---|---|
+| **Urgent** | Install-break, runtime crash on supported framework, or security. Reproduces on documented setup. Not solvable by re-reading docs. | Immediate (auto-comment) | ≤48h best-effort | Top of queue; ETA posted in issue |
+| **Normal** | API ambiguity, agent-trap, doc gap, behavior contradicting docs. | Immediate | Weekly Monday | Batched into next minor |
+| **Nice-to-have** | Polish, preference, feature request. | Immediate | Weekly Monday | "If it fits" — no commitment |
+
+**Bot ack** = auto-comment via [`agent-feedback-ack`](./.github/workflows/agent-feedback-ack.yml) GitHub Action. Means "we received this." Not "a human has read it."
+
+**Human SLA scopes triage, not fix.** Fix ETAs are issue-specific and posted in the issue after triage. We do not promise calendar fix times — one maintainer, real life.
+
+**Urgent definition (objective, baked into [`ai-agent-feedback.yml`](./.github/ISSUE_TEMPLATE/ai-agent-feedback.yml)):**
+
+Urgent = ALL of:
+- Reproduces on documented setup (recipe-followed install)
+- Breaks: install OR initial render OR build OR security
+- Not solvable by re-reading existing docs
+
+NOT urgent:
+- Visual preference / "looks wrong"
+- Missing feature request
+- Confusion about docs (= normal, doc-gap)
+- Breaks only on undocumented framework or post-modification
+- Already-known issue with existing workaround
+
+Maintainer reserves the right to reclassify during triage; reclassification is the norm, not a slight.
+
+**Travel/sick weeks:** SLA pauses. Pinned Discussion notice. No silent drift — public acknowledgment that the clock paused.
+
+**Weekly digest:** Mondays AM, posted to GitHub Discussions. "Heard / Shipped / Open / Beta scoreboard" format. Miss two weeks → beta credibility tanks. Discipline > tooling.
+
+**Post-beta:** This SLA section is rewritten or removed when [exit criteria](./docs/plans/2026-05-24-beta-release-plan.md#7-exit-criteria) are met.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Devalok Design System -- tokens, components, and patterns for React & Next.js applications.
 
+> 🚧 **Public Beta — `@devalok/shilp-sutra@0.40.0`.** Install path stable. APIs pre-1.0; breaks touching >2 components ship codemods.
+> **Feedback:** [AI-agent template](./.github/ISSUE_TEMPLATE/ai-agent-feedback.yml) · [Bug report](./.github/ISSUE_TEMPLATE/bug-report.yml) · [Discussions](https://github.com/devalok-design/shilp-sutra/discussions)
+> **SLA:** bot-ack immediate, urgent human-ack ≤48h, normal triage weekly Mon. [Full SLA →](./CONTRIBUTING.md#beta-sla)
+
 [![npm version](https://img.shields.io/npm/v/@devalok/shilp-sutra?logo=npm&color=cb3837)](https://www.npmjs.com/package/@devalok/shilp-sutra)
 [![npm downloads](https://img.shields.io/npm/dm/@devalok/shilp-sutra?logo=npm&color=cb3837)](https://www.npmjs.com/package/@devalok/shilp-sutra)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@devalok/shilp-sutra?label=minzip)](https://bundlephobia.com/package/@devalok/shilp-sutra)

--- a/docs/plans/2026-05-08-public-release-roadmap.md
+++ b/docs/plans/2026-05-08-public-release-roadmap.md
@@ -330,6 +330,9 @@ These need answers BEFORE Phase 4 (public launch):
 | 2026-05-08 | Skip VS Code extension; ship snippets package only | Tailwind IntelliSense covers ~80% of value for free |
 | 2026-05-08 | Skip MUI X-style commercial Pro tier | OSS-only product. Not building a business around this |
 | 2026-05-08 | Discussions before Discord | Lower friction; only escalate if volume demands it |
+| 2026-05-25 | Name locked: `@devalok/shilp-sutra` (scoped) | Soft-promo to outsiders during beta makes the npm name the contract. Scope signals provenance, aligns with brand-first thesis, avoids unscoped-namespace squat. Closes § 7 Q1. |
+| 2026-05-25 | Beta release as `0.40.0` on `latest` (no separate `beta` dist-tag) | Karm is the only existing consumer and is pinned exact (`"0.38.0"`), so dual-tag complexity isn't earned. README banner + announce posts carry the beta signal. See `docs/plans/2026-05-24-beta-release-plan.md` § 2.2. |
+| 2026-05-25 | No custom MCP feedback inbox for beta | GitHub MCP / `gh` CLI / prefilled-URL fallback covers agent-friction. Custom MCP-as-inbox = days of work, fragments triage, solves a problem we don't have at beta volume. Revisit at GA+1. |
 
 ---
 

--- a/docs/plans/2026-05-24-beta-release-plan.md
+++ b/docs/plans/2026-05-24-beta-release-plan.md
@@ -1,0 +1,457 @@
+# Beta Release Plan
+
+> **Status:** Plan. Awaiting execution sign-off.
+> **Date:** 2026-05-24
+> **Author:** Mudit Lal (with Claude Opus 4.7)
+> **Relationship:** Slots between Sprint 5 (marketing site) and Sprint 6 (measurement window) of [2026-05-08-public-release-roadmap.md](./2026-05-08-public-release-roadmap.md). Beta IS the signal source the measurement window was vague about.
+> **Target version:** `@devalok/shilp-sutra@0.40.0` — published to `latest`, marked beta in README + announce posts. No separate dist-tag.
+
+---
+
+## 1. Why a beta exists
+
+The public release roadmap jumps from "Karm-only rapid iteration" → Phase 4 (Show HN, awesome-lists, social). That's too aggressive for a single-maintainer DS with zero external consumers. We need a middle step:
+
+- **Real signal on whether doc-driven setup actually works for non-Karm installs.** Until someone outside the team installs and reports back, the "AI agent can configure it from package name alone" hypothesis is untested.
+- **Pressure-test the brand thesis ("be yourself, beautifully") with people who aren't already inside Devalok.** Site v2 lands flat or sharp — better to know before Show HN.
+- **Surface the bugs we'd otherwise eat in public launch.** First 5–10 honest external installs always find something the maintainer never hit.
+- **Gather the data § 7 Q4 and § 7 Q7 of the public roadmap need.** CLI go/no-go and registry-distribution decisions are both unanswered because we have no consumer evidence. Beta produces that evidence.
+
+A beta is not a smaller launch. It is the **measurement window made concrete** with a real artifact (a version), a real audience (Indian dev community + design-system orbit), and a real exit criterion (3 external consumers, 0 P0s).
+
+---
+
+## 2. Definition
+
+### 2.1 What "beta" means for shilp-sutra
+
+| Dimension | Beta posture |
+|---|---|
+| **Stability claim** | "Install path is stable. APIs may still shift on minor bumps." Same SemVer rules as 0.x, plus a stronger public commitment to ship codemods for any break touching >2 components (per [Phase 1.5.2 policy](./2026-05-08-public-release-roadmap.md#phase-15--developer-tooling-ecosystem-new-track)). |
+| **Distribution** | npm `latest` tag (no separate `beta` tag — see § 2.2 below). Repo public-readable on GitHub. Site v2 live at `https://shilp-sutra.devalok.in` (or chosen domain) and crawlable. |
+| **Promotion** | Soft promo to Indian dev community (r/IndiaDev, ELSP slack, dev.to writeup) + 2–3 design-system orbit folks for honest critique. No Show HN, no awesome-list submissions, no Twitter launch thread. |
+| **Support SLA** | Best-effort, no commitment. Triage weekly during beta. AI-agent-feedback issue template is the primary inbox. |
+| **Exit** | Open-ended. Beta ends when [§ 7 exit criteria](#7-exit-criteria) are met, not on a date. |
+
+### 2.2 Why no separate `beta` dist-tag
+
+Per user decision 2026-05-24: nobody except Devalok consumes the package today, so the dual-tag complexity isn't earned.
+
+- **Karm already pins exact versions in `package.json`** (verify before publish — see § 6.1 gate). It won't drift to 0.40.0 accidentally.
+- **A separate `@beta` tag is a footgun for outsiders.** They'd have to know to type `@beta` to find the version we're announcing. Friction we don't need at this scale.
+- **If/when adoption justifies it, a `next` tag can be introduced post-beta** for pre-release tracking of 0.41/1.0. Until then: single track.
+
+The cost we accept: a third-party who installs `@devalok/shilp-sutra` without reading the README sees beta-quality bits. README banner + announce posts must carry the beta signal loudly enough that this is acceptable.
+
+### 2.3 Version
+
+**`0.40.0`**, not `0.40.0-beta.1` and not `1.0.0-beta.1`.
+
+- Continues 0.x rapid-iteration spirit per [§ 2.2 of public roadmap](./2026-05-08-public-release-roadmap.md#22-strategic-decisions-made).
+- Aligns with the "0.40+ stable" criterion already named in the public roadmap.
+- `1.0.0-beta.1` would imply API freeze for the beta window. We're not ready to commit to that — the whole point of beta is to find the things that still need to move.
+
+CHANGELOG entry frames it: *"0.40.0 — Public Beta. Installation path is stable. API surface still pre-1.0; expect minors to ship codemod when they break >2 components."*
+
+---
+
+## 3. Audience
+
+Three concentric circles, opened in order:
+
+### 3.1 Inner (week 1)
+
+- ~10–20 hand-picked contacts: ex-colleagues, devs/designers Mudit trusts to give blunt feedback. Not a fixed list — share-kit (§ 3.5) is the distribution unit, not a named roster.
+- Goal: catch the most obvious "install instructions don't work on my machine" issues before the public site is indexed.
+- Distribution channel: 1:1 DM (closer contacts) + broadcast list (wider circle). NOT a group chat — feedback should land back to Mudit, not become a side-conversation.
+
+### 3.2 Indian dev community (week 2 onward)
+
+- r/IndiaDev post — short, links to site + repo. Frame as "made by Indian designers for a problem we kept hitting, would love brutal feedback."
+- ELSP / Indian product Slack groups (Reading Group, ProductHunt India, etc. — whichever you're in).
+- dev.to writeup — long-form: *"Why we built a design system that disappears into your brand."* Links to site v2 thesis.
+- Optional: LinkedIn post in your voice, not Devalok-corporate.
+
+### 3.3 Design-system orbit (week 2–3, parallel)
+
+- 2–3 named outreach targets — people who do honest critique on Twitter/Bluesky (e.g. shadcn-orbit, Vercel DRE, Mantine maintainer). Direct message with a single ask: "spend 10 min, tell me what you'd cut."
+- Not a megaphone — a critique panel.
+- This is the highest-leverage feedback channel in beta. Treat it as such.
+
+### 3.5 Share kit (the distribution unit for § 3.1)
+
+Inner-circle isn't a hand-picked roster — it's a copy-pasteable kit Mudit sends to whoever he wants. Lives at [share-kit.md](./beta-share-kit.md) (separate doc so it can be edited without touching this plan).
+
+Kit contents:
+- 1-line pitch
+- Short DM (3-line, for fast sends)
+- Long DM (paragraph, for closer contacts who'll actually try it)
+- r/IndiaDev post draft
+- LinkedIn post draft
+- dev.to longform skeleton
+- Link bundle (site, repo, install one-liner, feedback links)
+- "What we're asking" — explicit + scoped
+- "How to give feedback" — link to issue template, SLA pointer
+
+Each variant tells the recipient: (a) what shilp-sutra is, (b) why beta now, (c) what we want from them, (d) where to send feedback, (e) explicit no-pressure-if-busy out.
+
+### 3.4 Off-limits during beta
+
+- Show HN. Save for GA.
+- Product Hunt. Save for GA.
+- awesome-react, awesome-design-systems PRs. Save for GA.
+- Generic Twitter launch thread. Save for GA.
+- Newsletter sponsorships. Save for GA (if ever).
+
+Rationale: beta exists to find bugs cheaply. Megaphone channels invert the cost ratio — every bug found there is louder.
+
+---
+
+## 4. Entry gates (must-do before tagging 0.40.0)
+
+Each gate has a single "done" criterion. No gate is skippable.
+
+| # | Gate | Done when | Owner |
+|---|---|---|---|
+| G1 | **Name lock** | ✅ LOCKED 2026-05-25: keep `@devalok/shilp-sutra` (scoped). Log into public-release-roadmap § 9 on next edit. | Mudit |
+| G2 | **Site v2 launched** | [2026-05-24-site-v2-be-yourself.md](./2026-05-24-site-v2-be-yourself.md) Phases 1–3 shipped. Landing reads as beta-ready. Theming page works. /blocks has ≥3 entries. | Site work in progress on this branch |
+| G3 | **One starter repo working end-to-end** | `shilp-sutra-starter-next` public repo. `pnpm create next-app && pnpm add @devalok/shilp-sutra && pnpm dev` produces a styled homepage on a fresh machine. Tested on Windows + macOS. Skip Vite/Astro starters for beta — Next is highest-leverage. ([Phase 2.2](./2026-05-08-public-release-roadmap.md#phase-2--starter-templates--docs-site) partial) | New |
+| G4 | **AI-agent-feedback issue template tested** | At least one non-Karm install attempt completed by an AI agent (Claude or Cursor) using only the package name. Issue filed via template. Findings folded back into recipes. ([Phase 1.9 + 1.13 dogfood](./2026-05-08-public-release-roadmap.md#phase-1--ai-agent-install-loop)) | New |
+| G5 | **`pre-publish-audit.mjs` clean on `main`** | 45 gates green. Includes the consumer-smoke-test on Next 15 + Next 16. | Existing infra |
+| G6 | **Codemod policy in CONTRIBUTING.md** | [Phase 1.5.2](./2026-05-08-public-release-roadmap.md#phase-15--developer-tooling-ecosystem-new-track) committed. One-paragraph rule + link to (placeholder) `@devalok/shilp-sutra-codemods` repo. Backfill 0.38 deprecation codemod can wait until first post-beta break. | New, ~30 min |
+| G7 | **Storybook MCP documented in `llms.txt`** | [Phase 1.11](./2026-05-08-public-release-roadmap.md#phase-1--ai-agent-install-loop). Currently only in CLAUDE.md — agents reading `llms.txt` miss it. | New, ~30 min |
+| G8 | **Public Chromatic project link in README** | [Phase 3.3](./2026-05-08-public-release-roadmap.md#phase-3--quality--discovery-hardening). Read-only project URL so external folks can browse visual baselines. | New, ~1 hour |
+| G9 | **README beta banner** | First 3 lines of README announce beta + link to feedback issue template. Bold + visible. | New, ~15 min |
+| G10 | **Karm version pin verified** | `karm-v2/package.json` references exact `@devalok/shilp-sutra` version (e.g. `"0.39.x"`), not `^` or `~`. If using caret, change before publishing 0.40.0. | Mudit (verify in karm-v2 repo) |
+| G11 | **GitHub Discussions enabled + seeded** | Discussions tab on. Pinned "Feedback for 0.40.0 beta" thread. Discord deferred per [public roadmap § 7 Q9](./2026-05-08-public-release-roadmap.md#7-open-questions). | New, ~15 min |
+| G12 | **CHANGELOG 0.40.0 section drafted** | Marks as public beta. Lists what's changed from 0.39. Restates codemod commitment. | New, ~30 min |
+| G13 | **Agent feedback auto-ack Action wired** | `.github/workflows/agent-feedback-ack.yml` posts bot comment on issue-open with `ai-agent-feedback` label. Idempotent. Smoke-test with one dummy issue before publish. (See § 8.5 for spec.) | New, ~30 min |
+| G14 | **PR template shipped** | `.github/pull_request_template.md` with checkboxes: closes-issue, llms.txt/recipes/AGENTS.md updated for agent-feedback fixes, codemod-if-break, changeset added. ([Public roadmap Phase 0.12](./2026-05-08-public-release-roadmap.md#phase-0--foundation-hygiene) — promoted to beta gate.) | New, ~30 min |
+| G15 | **Triage label set pre-created** | All labels from § 8.4 exist in repo. Issue template `labels:` field references them. Avoids triage-stall on day 1. | New, ~30 min |
+| G16 | **CONTRIBUTING.md beta-SLA section** | New `## Beta SLA` section in CONTRIBUTING.md mirroring § 8.2 table verbatim. README banner links to it. | New, ~30 min |
+| G17 | **AGENTS.md updated with feedback rules** | Inside the managed BEGIN/END markers: SLA pointer, auth-tier order (MCP → gh CLI → prefilled URL), urgency definition, one-issue-per-task rule, dedup-search rule. Bumps managed-block version. | New, ~1 hr |
+| G18 | **ai-agent-feedback.yml extended** | Adds required slots: human-prompt (1-line), framework + version + OS, self-classified urgency dropdown (with definitions inline). | New, ~30 min |
+
+Gates G6–G18 are each ≤1 hour. G2 (site) and G3 (starter) are the gating-path work — multi-day each. Plan ~2–3 weeks from this doc's sign-off to tag-eligible.
+
+---
+
+## 5. Out of scope for beta
+
+Explicitly deferred to GA (or later) — do not let scope creep:
+
+- **CLI** ([Phase 1.1–1.7](./2026-05-08-public-release-roadmap.md#phase-1--ai-agent-install-loop)). Sprint 6 decision still gates. Beta IS Sprint 6.
+- **Registry distribution** ([Phase 2.5](./2026-05-08-public-release-roadmap.md#phase-25--distribution--presets-exploration-new-track)). Same evidence-bar.
+- **Vite + Astro starters** ([Phase 2.2](./2026-05-08-public-release-roadmap.md#phase-2--starter-templates--docs-site) remainder). Next-only for beta.
+- **ESLint plugin** ([Phase 1.5.1](./2026-05-08-public-release-roadmap.md#phase-15--developer-tooling-ecosystem-new-track)). Polish, not gate.
+- **Examples gallery / "Used by" / "Compare to" page** ([Phase 2.4, 2.6, 4.6](./2026-05-08-public-release-roadmap.md#phase-2--starter-templates--docs-site)). GA assets.
+- **Per-component size budgets, performance benchmarks** ([Phase 3.1, 3.8](./2026-05-08-public-release-roadmap.md#phase-3--quality--discovery-hardening)). Polish.
+- **Public roadmap mirror on GitHub Projects** ([Phase 3.9](./2026-05-08-public-release-roadmap.md#phase-3--quality--discovery-hardening)). Adds maintainer burden; the doc is enough for beta.
+- **Demo video** ([Phase 4.3](./2026-05-08-public-release-roadmap.md#phase-4--pre-public-promo-polish)). GA asset.
+
+If any of these turn out to be beta-blockers based on early feedback, fold them in explicitly — but the default is defer.
+
+---
+
+## 6. Distribution mechanics
+
+### 6.1 Pre-publish sequence
+
+1. Verify G10 (Karm version pin). If Karm is on caret/tilde, change to exact and merge that PR into Karm before publishing.
+2. Run `pnpm changeset version` + commit. Confirm CHANGELOG matches G12 draft.
+3. Run `pnpm pre-publish-audit` locally. Must be clean.
+4. Tag-and-publish via existing OIDC workflow.
+5. `npm dist-tags ls @devalok/shilp-sutra` — confirm `latest = 0.40.0`. No `beta` tag created.
+6. Smoke install in fresh Vite + Next sandboxes (use `tests/smoke-consumer-next15/` + `tests/smoke-consumer-next16/` as templates). Manual run, not CI.
+
+### 6.2 Announcement sequence
+
+Day 0 (publish day): publish, update site beta banner, file the pinned Discussions thread.
+
+Day 0 + 24h: inner-circle DMs (§ 3.1).
+
+Day 0 + 5–7d: dev.to longform + r/IndiaDev post. Wait for inner circle to surface the first wave of bugs before broadening.
+
+Day 0 + 10–14d: design-system orbit outreach DMs (§ 3.3).
+
+Don't compress this. If inner circle finds bugs, fix-publish-recheck before broadening. The schedule yields to bugs.
+
+### 6.3 README banner copy (draft)
+
+```md
+> 🚧 **Public Beta — `@devalok/shilp-sutra@0.40.0`.** Install path stable. APIs pre-1.0; breaks touching >2 components ship codemods.
+> **Feedback:** [AI-agent template](./.github/ISSUE_TEMPLATE/ai-agent-feedback.yml) · [Bug report](./.github/ISSUE_TEMPLATE/bug-report.yml) · [Discussions](https://github.com/devalok-design/shilp-sutra/discussions)
+> **SLA:** bot-ack immediate, urgent human-ack ≤48h, normal triage weekly Mon. [Full SLA →](./CONTRIBUTING.md#beta-sla)
+```
+
+### 6.4 dev.to / blog post angle
+
+Not a "we shipped a beta" announcement. A thesis post: *"Why we built a design system that disappears into your brand."* The beta is the call-to-action at the end. The pillars from site v2 (be yourself, thought-through, real-scale) become the post outline. ~1500 words.
+
+---
+
+## 7. Exit criteria
+
+Beta ends and GA Phase 4 begins when **all five** hold:
+
+1. **3 external consumers with non-trivial usage.** "Non-trivial" = ≥10 components in use, ≥1 month in their repo, public proof (open-source repo, public site, or written testimonial). Matches [public roadmap § 7 Q2](./2026-05-08-public-release-roadmap.md#7-open-questions).
+2. **0 unresolved P0 issues from beta feedback.** P0 = install breaks, runtime crash in mainstream framework, accessibility regression, API ambiguity that traps agents.
+3. **At least one minor cycle without unplanned breakage.** Means: ship 0.41 (or 0.42, etc.) and the next minor lands without rolling back. Tests the codemod-policy commitment.
+4. **CLI go/no-go decided** ([public roadmap § 7 Q4](./2026-05-08-public-release-roadmap.md#7-open-questions)). Decision logged in roadmap § 9. Trigger conditions: >50% manual triage rate OR <80% agent-success rate → build CLI before GA. Otherwise → skip indefinitely.
+5. **Beta window minimum: 4 weeks.** Even if 1–3 hit faster, leaves time for surprises and the orbit-feedback critique to land.
+
+If any criterion stalls beyond 8 weeks from publish, do a written reassessment — possibly extend beta, possibly retract and rework. Don't drift silently.
+
+---
+
+## 8. Feedback loop
+
+### 8.1 Inbound channels (priority order)
+
+1. **AI-agent-feedback issue template** — primary signal. Auto-labeled `ai-agent-feedback` + `needs-triage`. Auto-acked by bot (§ 8.5).
+2. **Bug-report issue template** — for humans reporting non-agent issues.
+3. **GitHub Discussions pinned thread** — "how do I…" + general feedback.
+4. **DMs from orbit outreach** — highest-quality. Capture into issues/Discussions to keep public trail.
+5. **r/IndiaDev + dev.to comments** — lowest signal-to-noise, free.
+
+### 8.2 Beta SLA (mirrored verbatim in CONTRIBUTING.md per G16)
+
+| Category | Definition | Bot ack | Human triage | Fix posture |
+|---|---|---|---|---|
+| **Urgent** | Install-break, runtime crash on supported framework, or security. Reproduces on documented setup. Not solvable by re-reading docs. | Immediate (auto-comment) | ≤48h best-effort | Top of queue; ETA posted in issue |
+| **Normal** | API ambiguity, agent-trap, doc gap, behavior contradicting docs. | Immediate | Weekly Monday | Batched into next minor |
+| **Nice-to-have** | Polish, preference, feature request. | Immediate | Weekly Monday | "If it fits" — no commitment |
+
+**Bot ack** = automated comment via GH Action. Means "we received this." Not "a human has read it."
+
+**Human SLA scopes triage, not fix.** Fix ETAs are issue-specific and posted in the issue after triage. We don't promise calendar-fix-times — one maintainer, real life.
+
+**Travel/sick weeks:** SLA pauses. Pinned Discussion notice. No silent drift — public acknowledgment that the clock paused.
+
+### 8.3 Urgency definition (for agents and humans, baked into template)
+
+**Urgent = ALL of:**
+- Reproduces on documented setup (recipe-followed install)
+- Breaks: install OR initial render OR build OR security
+- Not solvable by re-reading existing docs
+
+**NOT urgent:**
+- Visual preference / "looks wrong"
+- Missing feature request
+- Confusion about docs (= normal, doc-gap)
+- Breaks only on undocumented framework or post-modification
+- Already-known issue with existing workaround
+
+Agents self-classify via dropdown in the template. Maintainer reserves the right to reclassify during triage; reclassification is the norm, not a slight.
+
+### 8.4 Label set (pre-created per G15)
+
+| Axis | Labels |
+|---|---|
+| Source | `agent-filed`, `human-filed` |
+| Category | `install-break`, `runtime`, `api`, `docs`, `polish` |
+| Framework | `framework:next-app`, `framework:next-pages`, `framework:vite`, `framework:astro`, `framework:remix`, `framework:tanstack`, `framework:other` |
+| Urgency | `urgent`, `normal`, `nice-to-have` |
+| Lifecycle | `needs-triage`, `accepted`, `in-progress`, `blocked`, `wontfix`, `duplicate` |
+| Beta | `beta-feedback` |
+
+Default issue-template labels: `ai-agent-feedback`, `needs-triage`, `beta-feedback`. Triage adds the rest.
+
+### 8.5 Agent-filed feedback — how it actually works
+
+**Auth path (in order of preference):**
+
+1. **GitHub MCP available in agent's environment** → agent calls `mcp__github__create_issue` with user's auth. Cleanest.
+2. **`gh` CLI configured on user's machine** → agent runs `gh issue create --template ai-agent-feedback.yml --title "..." --body "..."`. Works for Claude Code / Cursor users with terminal.
+3. **Fallback: prefilled URL** → agent generates `https://github.com/devalok-design/shilp-sutra/issues/new?template=ai-agent-feedback.yml&agent=Claude+Code+2.5&package-version=0.40.0&...` with all required fields URL-encoded. Outputs URL to user, asks them to click + submit. Zero auth needed.
+
+The prefilled-URL fallback is the unlock — GitHub Issue Forms accept `?<field-id>=value` querystrings per field. Means every agent regardless of tooling can produce a one-click issue.
+
+**Rules baked into AGENTS.md (G17):**
+
+- **One issue per task.** Multiple problems in one task → ONE issue listing all. Do NOT file separately per broken file.
+- **Search before filing.** `gh issue list -l ai-agent-feedback -s open` or web search of `/issues?q=is:open+label:ai-agent-feedback`. Comment on near-dup instead of opening new.
+- **Identity declaration.** Issue body must state: model name + version, human's original prompt (1 line), what was attempted, what failed verbatim, framework + version + OS.
+- **Self-classify urgency** per § 8.3 definition. Default Normal. Don't escalate to Urgent unless ALL criteria met.
+- **Solo agent action.** Agent files on behalf of human, with human's knowledge. Don't file in background — the human sees the issue link before/after submission.
+
+**Auto-ack Action (G13 spec):**
+
+```yaml
+# .github/workflows/agent-feedback-ack.yml
+name: Auto-acknowledge agent feedback
+on:
+  issues:
+    types: [opened]
+jobs:
+  ack:
+    if: contains(github.event.issue.labels.*.name, 'ai-agent-feedback')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `**Received** — beta feedback queue.
+
+            Triage timing per [Beta SLA](../blob/main/CONTRIBUTING.md#beta-sla):
+            - **Urgent** (install-break / runtime crash on supported setup): human response ≤48h
+            - **Normal** (API / docs / agent-trap): weekly Mon triage
+            - **Nice-to-have**: batched, no calendar
+
+            Wrong category? Add label \`urgent\` or comment to reclassify.
+
+            Beta exit criteria: [docs/plans/2026-05-24-beta-release-plan.md](../blob/main/docs/plans/2026-05-24-beta-release-plan.md#7-exit-criteria).`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+```
+
+Idempotent (only on `opened`, not `labeled`). Smoke-test with one dummy issue before publish.
+
+**Close-the-loop on fix:**
+
+PR template (G14) requires:
+- [ ] Closes #N
+- [ ] If fixing agent-filed feedback: `llms.txt` / `docs/recipes/` / `AGENTS.md` updated?
+- [ ] Codemod added if break touches >2 components?
+- [ ] Changeset added?
+
+Means: every agent-reported fix updates the docs the next agent will read. Loop closes structurally, not by memory.
+
+**Agent files, human disagrees:**
+
+Close-with-link template comment:
+
+> Closing — intended behavior per [doc link]. To discuss whether intended behavior *should* change, open a Discussion.
+
+Don't relitigate per-issue. Discussion is the right venue for taste/scope debates.
+
+### 8.6 Weekly digest (mandatory ritual)
+
+Mondays AM. Discussions post. Template:
+
+```md
+# Beta Week N — ending YYYY-MM-DD
+
+## Heard
+- #123: [summary] (urgent / normal / nice-to-have)
+- ...
+
+## Shipped
+- v0.40.X: fix for #N
+- Recipe update: install-vite.md clarified peer-dep step
+- ...
+
+## Open
+- #N triaged urgent, fix WIP
+- ...
+
+## Beta scoreboard
+- External consumers: X / 3 target
+- P0 open: X
+- Days since publish: X
+```
+
+Miss 2 weeks → beta credibility tanks. Discipline > tooling.
+
+### 8.7 What we do NOT build for beta
+
+- No analytics, no telemetry, no install-success postinstall hook. Per [public roadmap C.4](./2026-05-08-public-release-roadmap.md#cross-cutting-continuous), telemetry decision is pending CLI.
+- No CAPTCHA / honeypot / agent-rate-limiting infra. Beta volume too low. GH built-in spam controls + manual lock if abuse emerges.
+- No custom feedback MCP server. The prefilled-URL fallback covers the agent-friction case. MCP-as-inbox revisited at GA+1 if issue volume + agent friction justifies it.
+- No SLA-pause auto-detection. Manual pinned-Discussion notice when traveling/sick.
+
+Issue-volume + Discussions activity is the data source. If insufficient signal, answer is more outreach (§ 3.3), not telemetry.
+
+---
+
+## 9. Risks (beta-specific)
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Beta visibility without polish damages brand | Medium | High | Inner-circle gate before broadening (§ 6.2). README banner sets expectation. Site v2 thesis is the strong-signal asset — if it's not ready, delay beta, don't ship half. |
+| Karm accidentally pulls 0.40 via caret | Medium | High | G10 gate. Pin to exact before publishing. If caret is used elsewhere in the org, audit. |
+| Orbit critique is harsh and demoralizing | High | Medium | Expected. The point of beta is to absorb critique cheaply. Decide upfront: what counts as actionable, what's taste-disagreement, what's "they're wrong about our thesis." Don't pivot the thesis on a single voice. |
+| r/IndiaDev post gets zero engagement | Medium | Low | Acceptable outcome. dev.to longform is the higher-leverage post; subreddit is bonus. If both flop, fall back to orbit DMs only. |
+| First external install reveals a Windows-specific install break we never saw | High | Medium | G3 gate (starter tested on Windows + macOS). Inner-circle includes ≥1 Windows dev. Recovery: patch, ship 0.40.1, narrow blast radius. |
+| Naming feedback during beta forces a rename | Low | High | G1 gate forces this NOW. Decision-logged means we don't relitigate mid-beta. |
+| Beta drifts past 8 weeks with no exit | Medium | High | Hard reassessment trigger written into § 7. Doc must be updated weekly during beta — drift is visible. |
+| The "be yourself" thesis doesn't resonate outside the founders | Medium | High | This is real-world data we can only get post-beta. If signal is "people don't care about customization at this depth," GA changes — possibly toward a sharper niche or a different headline. Better to learn in beta than after Show HN. |
+| Agent spam (someone instructs their agent to flood issues) | Low | Medium | Beta volume too low to engineer against. GH per-account rate limit + spam detection + manual lock if abuse emerges. `[ai-agent]` title prefix makes filtering trivial. Don't build CAPTCHA / honeypot speculatively. |
+| SLA commitment becomes a trap (travel / sick week) | High | Medium | Bot ack covers "did anyone see this." Human SLA scopes to *triage* not *fix*. Pinned Discussion notice when paused. Public acknowledgment > silent drift. |
+| Agent files low-quality / wrong-category issues at high volume | Medium | Medium | Self-classification dropdown + maintainer reclassification-as-norm. Dedup-search rule in AGENTS.md. One-issue-per-task rule. If signal degrades, narrow urgency definition + add `wontfix-out-of-scope` triage label. |
+| Prefilled-URL fallback URL length exceeds GitHub limits | Low | Low | GH issue forms accept ~8KB URL. Long `what broke` / `what tried` body fields could blow it. Mitigation: AGENTS.md instructs agents to truncate body fields to ~2KB each in URL mode; full content goes in via paste if needed. |
+
+---
+
+## 10. What this beta does NOT promise
+
+To set expectations cleanly, both internally and in the README:
+
+- Not promising API stability across 0.40 → 0.41.
+- Not promising any specific component is feature-complete.
+- Not promising support response time.
+- Not promising the marketing site (`apps/site`) won't change shape.
+- Not promising registry distribution, a CLI, or starters in non-Next frameworks. All deferred.
+
+Promised:
+- Install path will work on Next 15 + Next 16 + Vite. Bugs get fixed.
+- Codemods will ship for any break touching >2 components.
+- Public CHANGELOG, public Discussions, public issue tracker.
+- Honest engagement with feedback during beta.
+
+---
+
+## 11. Living status (update inline)
+
+| Gate / Phase | Status | Notes |
+|---|---|---|
+| G1 Name lock | ✅ LOCKED 2026-05-25 | `@devalok/shilp-sutra` (scoped) |
+| G2 Site v2 | ⏳ In progress | Branch `feat/site-v1-and-skill`, plan at `2026-05-24-site-v2-be-yourself.md` |
+| G3 Next starter | ❌ Not started | |
+| G4 Agent-feedback dogfood | ❌ Not started | |
+| G5 Pre-publish audit | ⏳ Ongoing | Last known clean: tag-of-record |
+| G6 Codemod policy | ❌ Not started | ~30min |
+| G7 Storybook MCP in llms.txt | ❌ Not started | ~30min |
+| G8 Chromatic public link | ❌ Not started | ~1hr |
+| G9 README beta banner | ❌ Draft in § 6.3 | Apply when publish-ready |
+| G10 Karm version pin | ❌ Verify in karm-v2 | |
+| G11 Discussions enabled | ❌ Not done | |
+| G12 CHANGELOG 0.40.0 | ❌ Not drafted | |
+| G13 Agent feedback auto-ack Action | ❌ Not wired | Spec in § 8.5 |
+| G14 PR template | ❌ Not shipped | Phase 0.12 promoted to beta gate |
+| G15 Triage label set | ❌ Not pre-created | List in § 8.4 |
+| G16 CONTRIBUTING beta-SLA section | ❌ Not added | Mirrors § 8.2 |
+| G17 AGENTS.md feedback rules | ❌ Not updated | Inside managed BEGIN/END markers |
+| G18 ai-agent-feedback.yml slots | ❌ Not extended | 3 new required slots: human-prompt, framework+version+OS, urgency dropdown |
+| Share kit (§ 3.5) | ❌ Not drafted | Lives at `docs/plans/beta-share-kit.md` |
+| Orbit outreach list | ❌ Not picked | 2–3 names; decide week 2 of beta |
+| Longform post venue | ⏸️ Deferred | Decide day-5–7 of beta |
+| dev.to post draft | ❌ Not started | |
+
+Update this table inline as items move. Don't let the doc drift behind reality.
+
+---
+
+## 12. How this doc relates to others
+
+- **Public release roadmap** ([2026-05-08-public-release-roadmap.md](./2026-05-08-public-release-roadmap.md)) — beta is Sprint 6 (measurement window). Update its § 6 sprint list to point here when this is approved.
+- **Site v2 plan** ([2026-05-24-site-v2-be-yourself.md](./2026-05-24-site-v2-be-yourself.md)) — site v2 is gate G2 of this beta plan. Both target `0.40.0`.
+- **CHANGELOG.md** — final 0.40.0 entry lives there. This doc holds the meta-decisions.
+- **CONTRIBUTING.md** — codemod policy (G6) lives there. This doc references it.
+
+---
+
+## 13. Open questions (status 2026-05-25)
+
+1. ✅ **Name lock** — `@devalok/shilp-sutra` (scoped). LOCKED.
+2. ✅ **Inner-circle "list"** — no fixed roster; share-kit (§ 3.5) is the distribution unit. Mudit sends to whoever, kit handles framing.
+3. ⏳ **Orbit-outreach list (2–3 names).** Still TBD. Decide before § 3.3 DMs go out (~week 2 of beta).
+4. ✅ **Site v2 domain** — `shilp-sutra.devalok.in`. LOCKED.
+5. ⏸️ **Longform post venue** — dev.to vs personal blog vs Devalok Substack. **Deferred — decide before § 6.2 day-5–7.** Bias: dev.to for beta, all three for GA.
+6. ⏸️ **Beta retrospective format** — public retro post-exit? **Deferred — decide near exit-imminent.** Bias: yes, credibility asset.

--- a/docs/plans/beta-share-kit.md
+++ b/docs/plans/beta-share-kit.md
@@ -1,0 +1,237 @@
+# Beta Share Kit
+
+> **For:** Mudit, sending shilp-sutra beta to friends, ex-colleagues, devs/designers.
+> **Companion to:** [2026-05-24-beta-release-plan.md § 3.5](./2026-05-24-beta-release-plan.md#35-share-kit-the-distribution-unit-for--31)
+> **Date:** 2026-05-25
+> **Status:** Draft. Edit as voice settles.
+
+---
+
+## How to use this
+
+Pick the variant that fits the contact. Personalize the first line ("hey [name], saw you've been doing X lately…") — never send the template raw. The kit is the skeleton; the muscle is your voice.
+
+**Distribution channels:**
+
+| Channel | When |
+|---|---|
+| 1:1 DM (WhatsApp / iMessage / Telegram / Signal) | Closer contacts — ex-colleagues, dev friends, people you'd grab coffee with |
+| Broadcast list (WhatsApp / Telegram broadcast — NOT a group) | Wider circle, ~10–30 people. Each recipient sees it as a 1:1 message. Replies come back to you only. **Do not use a group chat** — feedback turns into side-conversation. |
+| LinkedIn DM | Designers/devs you only know professionally |
+| Twitter/X DM | Folks active there |
+| Public LinkedIn post | Once you've sent ~20 DMs and have ~2-3 friendly testers using it |
+| r/IndiaDev post | Week 2 of beta — after inner-circle bugs flushed |
+| dev.to longform | Week 2–3 of beta |
+
+Order matters: DMs first → bugs surface → fix → broader posts. Don't compress.
+
+---
+
+## Variant 1 — Short DM (3 lines, fast send)
+
+> Hey [name] — wanted to share something I've been working on. Shilp Sutra is a React design system we've been using inside Devalok; just put out a public beta and want honest feedback from people who'd actually install it. Site: https://shilp-sutra.devalok.in · Repo: https://github.com/devalok-design/shilp-sutra
+>
+> No pressure if you're slammed. If you do try it and something breaks, here's where to file: [link to ai-agent-feedback template]. Bot will ack in <1 min, I'll get back in <48h for anything install-breaking.
+
+**When to send:** wide broadcast list, ~10–30 people. Each gets it as a 1:1.
+
+---
+
+## Variant 2 — Long DM (paragraph, for people who'll actually try it)
+
+> Hey [name] —
+>
+> Quick context: at Devalok we've been building a React design system called Shilp Sutra. It's been powering Karm (our internal product) for ~8 months. We've just put out a public beta — version 0.40.0 — and I'm sharing it with people whose opinion I'd actually trust.
+>
+> The thesis is the opposite of shadcn/ui's homogenization play: shilp-sutra is built to **disappear into your brand**. Theming sits in the chrome, every component is built so token overrides actually work end-to-end, and we obsess over the "thought through" details (forced-colors, RSC-safety, composability) that most DSes treat as edge cases.
+>
+> What I want from you:
+> 1. **Install it** in a fresh Next or Vite project. Should take 5 min. Recipe: https://shilp-sutra.devalok.in/docs/install
+> 2. **Tell me what broke.** Anything that didn't match the docs, anything your AI agent (Claude / Cursor / Copilot) tripped on, anything that felt clunky.
+> 3. **Or tell me it's not for you** — I'd rather know why than not know.
+>
+> Feedback link: [ai-agent template] for agent-filed issues, [bug-report] for human-filed. Discussions: https://github.com/devalok-design/shilp-sutra/discussions
+>
+> Bot acks in <1 min. I personally respond inside 48h for anything install-breaking, weekly Mondays for everything else. Travel/sick weeks pause — I'll post a notice if I drop off.
+>
+> Beta runs open-ended until 3 outside teams use it for real. No Show HN until then. No pressure to share publicly — keep this between us if you prefer.
+>
+> Thanks for taking a look.
+
+**When to send:** closer contacts who actually code, who'd give blunt feedback, who you trust to spend 30 min.
+
+---
+
+## Variant 3 — r/IndiaDev post (week 2 of beta)
+
+**Title:** Built a React design system that disappears into your brand — public beta, would love feedback
+
+> Hey r/IndiaDev — I'm Mudit, design + product lead at Devalok (Bengaluru). Sharing a project we've been building for ~10 months: **Shilp Sutra** (@devalok/shilp-sutra), a React design system in public beta as of v0.40.0.
+>
+> The honest pitch: shadcn/ui solved discoverability + copy-paste, but it also accidentally homogenized the web. Every YC-stage SaaS now looks identical. Shilp Sutra is built for the opposite — **be yourself, beautifully**. Theming is the headline, not a docs page. Token overrides actually cascade through every component. We obsess over the "thought through" details (forced-colors mode, RSC-safety, composability) that most DSes treat as edge cases.
+>
+> **Tech:** React 19, Tailwind 4 (CSS-first), CVA, Radix primitives vendored, framer-motion peer.
+>
+> **Public beta** because:
+> - We've been the only consumer for 8 months. Need outside eyes.
+> - No Show HN until 3 external teams use it for real. This is the soft-launch.
+> - Honest feedback > polished launch. If the thesis doesn't resonate, I want to know now, not after a big post.
+>
+> **Links:**
+> - Site: https://shilp-sutra.devalok.in
+> - Repo: https://github.com/devalok-design/shilp-sutra
+> - Install: `pnpm add @devalok/shilp-sutra` + 2 lines of CSS
+> - Feedback: [issue template]
+>
+> **What I'd love from you:**
+> - Try installing it. Tell me what broke.
+> - Push back on the thesis. Is "disappears into your brand" a real differentiator or marketing fluff?
+> - If you're using Claude Code / Cursor — try having your agent install it cold. Tell me where the agent tripped.
+>
+> Happy to answer anything in comments. Roast freely — beta is for finding things to fix.
+
+**Tone notes:** Indian-context cue ("Bengaluru," r/IndiaDev) builds trust. Acknowledge shadcn directly — refusing to mention it reads evasive. The "Roast freely" line invites real engagement.
+
+---
+
+## Variant 4 — LinkedIn post (after first 2-3 friendly testers report back)
+
+**Format:** medium-length post, 1 image (site v2 screenshot).
+
+> 10 months ago, we started building Shilp Sutra — a React design system for Devalok's internal products.
+>
+> Today, it's in public beta.
+>
+> Why now? Because we've been the only consumer for 8 months, and the friction we hit was teaching us things only outside eyes can teach.
+>
+> The thesis is contrarian: in a world where every SaaS uses the same DS and looks identical, **Shilp Sutra is built to disappear into your brand.** Theming is the headline, not a footnote. Every token override cascades through every component end-to-end.
+>
+> We obsess over the details most DSes treat as edge cases:
+> – Forced-colors mode (Windows high-contrast)
+> – RSC-safety per component
+> – Composability that doesn't break when you add a wrapper
+> – AI-agent install paths that actually work cold
+>
+> If you build with React + Tailwind, I'd love your honest feedback:
+> - Site: shilp-sutra.devalok.in
+> - Repo: github.com/devalok-design/shilp-sutra
+> - Install: pnpm add @devalok/shilp-sutra
+>
+> Beta is open-ended. No Show HN until 3 outside teams use it for real. This is the soft-launch — bugs welcome, opinions welcome, roasts welcome.
+>
+> Tag a designer or engineer who'd care. Or DM me — I respond to every install-breaking issue inside 48h.
+
+**Tone notes:** Less Reddit-irreverent than r/IndiaDev variant. More "founder builds in public." Don't pad with hashtags.
+
+---
+
+## Variant 5 — dev.to longform skeleton
+
+**Working title:** *Why we built a design system that disappears into your brand*
+
+**Outline (target ~1500 words):**
+
+1. **Hook** — the problem with current DS landscape (homogenization, every SaaS looks identical, shadcn solved discoverability but at this cost).
+2. **What "disappear into your brand" actually means** — concrete: theming as headline, not footnote. Show before/after of the same Card in 4 industry brands.
+3. **What we obsess over that others skip** — forced-colors, RSC-safety per component, composability invariants, AI-agent install paths.
+4. **The AI angle** — agents can install shilp-sutra cold from the package name. Recipes, llms.txt, AGENTS.md. Demo: paste prompt → agent installs + theming → working dashboard.
+5. **Why beta, why now** — 8 months single-consumer (Karm). Need outside eyes. No Show HN until 3 outside teams use it for real.
+6. **What we want from you** — install, break it, file. Honest pushback on the thesis.
+7. **What we promise** — bot ack instant, urgent human ack <48h, codemods for breaks touching >2 components, weekly digest of what we heard + shipped.
+8. **CTA** — install + site + repo + feedback link.
+
+**Voice notes:** First-person, single-author voice (Mudit). Don't hide behind "we built." Frame it as a designer's perspective ("I've spent 10 years watching brands flatten themselves into the same shadcn shape — that's the thing this fixes").
+
+Drop this on dev.to first (best dev discovery). Cross-post to personal site or Devalok Substack after week 1.
+
+---
+
+## Variant 6 — Twitter/X / Bluesky / Mastodon (single post + thread)
+
+**Lead post:**
+
+> Public beta — Shilp Sutra, the React design system that disappears into your brand.
+>
+> No Show HN. No Product Hunt. Just want honest install feedback.
+>
+> 🔗 https://shilp-sutra.devalok.in
+
+**Thread (optional, 4-5 posts):**
+
+1. (lead above)
+2. The thesis: shadcn solved discoverability. It also accidentally homogenized the web. Shilp Sutra is the opposite — theming is the headline, every token override cascades end-to-end.
+3. What we obsess over: forced-colors mode, RSC-safety per component, composability, AI-agent install paths that work cold.
+4. AI angle: agents can install cold from the package name. `curl install.sh | bash` for Claude Code skill; `pnpm add @devalok/shilp-sutra` for everyone else. Recipes + llms.txt + AGENTS.md ship with the package.
+5. Beta exit: 3 outside teams using it for real. Until then, soft-launch. Roast freely.
+
+**When:** after r/IndiaDev + LinkedIn have flushed obvious bugs. Twitter is broader but noisier.
+
+---
+
+## Link bundle (paste-ready)
+
+```
+Site:        https://shilp-sutra.devalok.in
+Repo:        https://github.com/devalok-design/shilp-sutra
+Install:     pnpm add @devalok/shilp-sutra
+Recipe:      https://shilp-sutra.devalok.in/docs/install
+Feedback:    https://github.com/devalok-design/shilp-sutra/issues/new/choose
+Discussions: https://github.com/devalok-design/shilp-sutra/discussions
+Claude Code skill: curl -fsSL https://raw.githubusercontent.com/devalok-design/shilp-sutra/main/skills/shilp-sutra/install.sh | bash
+```
+
+---
+
+## What we're explicitly asking
+
+Single sentence to copy into every variant:
+
+> Install it cold. Tell me what broke — install failure, runtime crash, doc gap, surprise behavior, or "I just don't get the value prop." All of it useful.
+
+---
+
+## What we're explicitly NOT asking
+
+To set expectations cleanly:
+
+- Not asking for stars / shares / public endorsement during beta.
+- Not asking them to migrate their existing project.
+- Not asking them to evangelize. If they love it, that comes later organically.
+- Not asking for unpaid labor. If they spend >30 min, that's their generosity — say thanks publicly + privately.
+
+---
+
+## Feedback channel cheat-card (paste at end of every long DM)
+
+```
+🐛 Found a bug?           → https://github.com/devalok-design/shilp-sutra/issues/new/choose
+🤖 AI agent tripped?      → Use the "AI agent feedback" template above. Bot acks <1 min.
+💬 Question / "how do I"  → https://github.com/devalok-design/shilp-sutra/discussions
+📨 Prefer DM?              → Reply here. I read every one.
+
+SLA:
+- Urgent (install-break / runtime crash):  human response ≤48h
+- Normal (API / docs / agent-trap):         weekly Monday triage
+- Nice-to-have (polish / preference):       batched, no calendar
+```
+
+---
+
+## After-send hygiene
+
+- Track who you sent to in a spreadsheet (name, channel, date, replied yes/no, filed issue yes/no). Doesn't have to be fancy — Google Sheet, Notion, whatever.
+- Wait ~5–7 days before nudging non-responders. Don't double-tap sooner.
+- Thank everyone who replied, even if their feedback was "not for me."
+- People who install + report back = potential first 3 external consumers for the exit criterion. Treat them well.
+
+---
+
+## What to do if nobody replies
+
+Realistic possibility. Mitigations in order:
+
+1. **Wait full week.** First 48h response rate ≠ overall rate.
+2. **Personalize the next send better.** Generic DM gets generic ignore.
+3. **Drop r/IndiaDev post earlier than week 2** to widen funnel.
+4. **Lower the ask** — instead of "install it," try "just open the site and tell me what you think in one sentence."
+5. **Reassess after 2 weeks.** Zero engagement = signal about the thesis or the framing. Update plan accordingly.

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -4,6 +4,26 @@
 > Built on the same primitives as shadcn/ui but with key API differences.
 > Read this file BEFORE writing any UI code. Do NOT guess from shadcn/ui knowledge.
 
+> **🚧 Public Beta (v0.40.0).** Install path stable. APIs pre-1.0; breaks touching >2 components ship codemods. Feedback shapes 1.0 — file via the AI-agent template at `https://github.com/devalok-design/shilp-sutra/issues/new?template=ai-agent-feedback.yml`. Auth-tier order: GitHub MCP → `gh` CLI → prefilled URL (you generate, human clicks). Full rules in `AGENTS.md` § Reporting feedback. Beta SLA in `CONTRIBUTING.md#beta-sla`.
+
+## STORYBOOK MCP (live component reference for AI agents)
+
+When running this repo's dev server (`pnpm dev`), a Storybook MCP server is exposed at `http://localhost:6006/mcp`. It provides:
+
+- Per-story prop dumps (variants, sizes, default args) — authoritative against `llms-full.txt` if they ever diverge.
+- Live story URLs for visual inspection during agent runs.
+- Component → story-id mapping for `gh issue` repro links.
+
+**Connect from your agent:**
+
+| Agent | Config |
+|---|---|
+| Claude Code | `claude mcp add --transport http shilp-sutra http://localhost:6006/mcp` (only while `pnpm dev` is running locally) |
+| Cursor | Settings → MCP Servers → add HTTP server `http://localhost:6006/mcp` |
+| Other MCP-compatible | Standard HTTP MCP endpoint |
+
+**Scope:** dev-only. The MCP server is exposed by Storybook's local server only; it is not deployed alongside Storybook on GitHub Pages. Consumer projects do not need to run this — read `llms.txt` / `llms-full.txt` / `docs/recipes/` from `node_modules` instead.
+
 ## QUICK SETUP (AI agents — start here)
 
 If you are setting up shilp-sutra in a consumer project for the first time, **do not improvise**. Use a recipe.


### PR DESCRIPTION
## Summary

Foundation for the **0.40.0 public beta**. No code changes — docs, policies, issue/PR templates, feedback infra. See [`docs/plans/2026-05-24-beta-release-plan.md`](../blob/chore/beta-foundations/docs/plans/2026-05-24-beta-release-plan.md) for the full beta plan.

## What ships in this PR

**Policy + docs**
- `CONTRIBUTING.md` — new **Codemod policy** (any break touching >2 components must ship a codemod) + new **Beta SLA** section (bot ack <1min, urgent human ack ≤48h, normal triage weekly Mon).
- `README.md` — beta banner with feedback links + SLA pointer.
- `CHANGELOG.md` — `0.40.0` Public Beta section drafted.
- `packages/core/llms.txt` — beta banner + Storybook MCP server documentation (was only in CLAUDE.md).
- `AGENTS.md` — feedback rules inside managed BEGIN/END markers: auth-tier order (GitHub MCP → `gh` CLI → prefilled URL fallback), urgency definition, one-issue-per-task, dedup-search.

**Issue + PR templates**
- `.github/ISSUE_TEMPLATE/ai-agent-feedback.yml` — extended with required slots: human's original prompt, framework + version + OS, self-classified urgency dropdown. Default labels now include `beta-feedback` + `agent-filed`.
- `.github/pull_request_template.md` — NEW. Required checkboxes: changeset, docs-on-agent-fix (llms.txt / recipes / AGENTS.md), codemod for >2-component break, new-component checklist.

**Automation**
- `.github/workflows/agent-feedback-ack.yml` — NEW. Auto-acks every `ai-agent-feedback` issue with the SLA pointer and triage timing, <1min after open.

**Plan + share kit**
- `docs/plans/2026-05-24-beta-release-plan.md` — NEW. Full beta plan: definition, gates, audience tiers, SLA, feedback loop, exit criteria, risks.
- `docs/plans/beta-share-kit.md` — NEW. Copy-paste kit: short DM, long DM, r/IndiaDev post, LinkedIn post, dev.to longform skeleton, Twitter/Bluesky thread, link bundle, distribution-channel guide.

**Strategic decisions logged**
- `docs/plans/2026-05-08-public-release-roadmap.md` § 9 — name locked (`@devalok/shilp-sutra`, scoped), 0.40 ships on `latest` (no separate beta dist-tag), no custom MCP feedback inbox for beta.

## Done out-of-band against the repo (not in this diff)

- ✅ GitHub Discussions enabled.
- ✅ 23 triage labels pre-created: `agent-filed`, `human-filed`, `install-break`, `runtime`, `api`, `docs`, `polish`, `framework:next-app`/`next-pages`/`vite`/`astro`/`remix`/`tanstack`/`other`, `urgent`, `normal`, `nice-to-have`, `accepted`, `in-progress`, `blocked`, `beta-feedback`, plus `ai-agent-feedback` (was missing; template references it).
- ✅ Karm version pin verified exact (`"0.38.0"`) — no drift risk on 0.40 publish.

## Beta gates this closes

Per the beta plan's gate table (§ 4):

- G6 Codemod policy in CONTRIBUTING.md
- G7 Storybook MCP doc in `llms.txt`
- G9 README beta banner
- G10 Karm version pin verified (read-only)
- G11 GH Discussions enabled (out-of-band)
- G12 CHANGELOG 0.40.0 section
- G13 Agent-feedback auto-ack Action
- G14 PR template
- G15 Triage label set pre-created (out-of-band)
- G16 CONTRIBUTING beta-SLA section
- G17 AGENTS.md feedback rules
- G18 ai-agent-feedback.yml extended

## Still gating publish (separate work streams)

- G1 Name lock — ✅ LOCKED in this PR's roadmap update
- G2 Site v2 — WIP on `feat/site-v1-and-skill`
- G3 Next.js starter repo — needs new public repo
- G4 Agent dogfood test — needs a non-Karm install run
- G8 Chromatic public link — needs Chromatic admin action

## Test plan

- [ ] CI green (typecheck / lint / test / pre-publish-audit)
- [ ] Open one dummy `ai-agent-feedback` issue → verify auto-ack bot comments <1min, comment links resolve
- [ ] Click prefilled-URL fallback (template field) → verify GitHub Issue Form renders all prefilled slots
- [ ] Verify `gh label list` shows all 23 new labels
- [ ] Verify Discussions tab visible at repo root, pin a "Beta 0.40.0 feedback" thread post-merge
- [ ] Review CHANGELOG 0.40.0 wording; confirm matches the actual scope at publish time

🤖 Generated with [Claude Code](https://claude.com/claude-code)