### PR TITLE
docs(recipes): fix Next.js App Router cold-install friction (dogfood)

### DIFF
--- a/.changeset/next-app-router-recipe-cold-install-fixes.md
+++ b/.changeset/next-app-router-recipe-cold-install-fixes.md
@@ -1,0 +1,25 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+docs(recipes): fix Next.js App Router cold-install friction surfaced by dogfood test
+
+A cold-install dogfood test against `pnpm create next-app@latest` on Next 16.2.6 + Turbopack + React 19.2 + pnpm 10.30 (2026-05-25) surfaced seven friction points in `install-next-app-router.md`. Recipe still worked end-to-end, but every friction point was a place an AI agent could trip naively. This release updates the recipe.
+
+### What changed
+
+- **Added "Tested on" matrix** at the top of the recipe so agents know the exact stack we last verified against.
+- **`src/app/globals.css` is now listed as the priority-1 location** for the global CSS file (Next 14+ default; was priority-2 in the old recipe).
+- **§ 4b now explicitly tells agents to replace the entire scaffold `globals.css`**, not just append. The scaffold writes `:root` color vars, an `@theme inline` block linked to Geist font vars, a `prefers-color-scheme` block, and a `body { font-family: Arial }` block — any of which can silently override shilp-sutra tokens.
+- **§ 5 calls out Turbopack** as the Next 16 default and confirms `transpilePackages` is respected.
+- **§ 3 PostCSS step rewritten** to say "verify or create" — Next 14+ scaffolds the correct file. Agents were burning cycles re-creating it.
+- **§ 6 layout.tsx replacement now explicitly lists the scaffold lines to remove** — `next/font/google` Geist imports, the `${geistSans.variable}` className on `<html>`, and the `min-h-full flex flex-col` className on `<body>`. Naive agents kept the Geist imports running alongside shilp-sutra's fonts.
+- **§ 7 page.tsx replacement notes the scaffold's existing Vercel marketing layout** so agents know they're replacing real content.
+- **§ 8 gotchas adds three new entries**:
+  - Scaffold's `body { font-family: Arial }` wins the cascade over shilp-sutra fonts if kept (most common silent break).
+  - Auto-generated `pnpm-workspace.yaml` from pnpm 10+ — harmless standalone, broken inside a monorepo.
+  - Auto-generated `AGENTS.md` from `create-next-app` uses `<!-- BEGIN:nextjs-agent-rules -->` markers; shilp-sutra's use `<!-- BEGIN:shilp-sutra-agent-rules -->` — they coexist, but worth knowing.
+
+### Why patch, not minor
+
+Recipe content updates that clarify existing setup do not widen public API surface. They make the same recipe land successfully on more environments. No new exports, no behavior change, no new dependency.

--- a/packages/core/docs/recipes/install-next-app-router.md
+++ b/packages/core/docs/recipes/install-next-app-router.md
@@ -2,6 +2,8 @@
 
 > Setup recipe for adding `@devalok/shilp-sutra` to a Next.js 13+ App Router project.
 
+> **Tested cold-install on:** Next 16.2.6 + React 19.2 + Turbopack + pnpm 10.30 + Node 22 + Windows 11 (2026-05-25). Earlier versions of Next 13/14/15 are still supported on this recipe; deltas called out inline.
+
 ## 1. Detect the framework
 
 You are in this recipe if **all** of these are true:
@@ -59,27 +61,35 @@ Some components depend on third-party libraries that ship as optional peers. **I
 
 ## 3. Configure PostCSS
 
-Create or update `postcss.config.mjs` at the project root:
+**Next 14+ scaffolds this for you.** Verify `postcss.config.mjs` (or `.js` / `.cjs` / `.json`) at the project root contains:
 
 ```js
-export default {
+const config = {
   plugins: {
     "@tailwindcss/postcss": {},
   },
 };
+
+export default config;
 ```
 
-If a `postcss.config.{js,cjs,json}` already exists, merge the plugin in. Do not delete the existing file.
+If the file is missing, create it with the contents above. If another PostCSS file exists with different plugins, merge `@tailwindcss/postcss` in — do not delete the existing file.
 
 ## 4. Wire Tailwind 4 + design tokens
 
-Locate the global CSS file. Common paths in priority order:
+### 4a. Locate the global CSS file
 
-- `app/globals.css`
-- `src/app/globals.css`
-- `app/global.css`
+Next 13+ default location depends on the `--src-dir` choice at scaffold time:
 
-If none exists, create `app/globals.css`. Set the file contents to (or merge into):
+- `src/app/globals.css` — default since Next 14 when scaffolded without `--src-dir false`. **Most common in Next 16+ defaults.**
+- `app/globals.css` — when scaffolded with `--src-dir false` (no `src/`).
+- `app/global.css` — older Next 13 scaffolds.
+
+If none exists, create at whichever path matches the project's existing `app/` location.
+
+### 4b. Replace the scaffold's CSS with the shilp-sutra setup
+
+A fresh `create-next-app` scaffold writes a `globals.css` with `:root` color vars, an `@theme inline` block linked to Geist font vars, a `prefers-color-scheme` dark override, and a `body { font-family: Arial }` block. **Replace the entire file** with the shilp-sutra setup unless you have a specific reason to keep scaffold styles:
 
 ```css
 @import "tailwindcss";
@@ -88,7 +98,11 @@ If none exists, create `app/globals.css`. Set the file contents to (or merge int
 
 **Order matters.** `tailwindcss` MUST come first. The shilp-sutra `/css` entry registers `@theme` blocks that the Tailwind import must process.
 
-If the project has its own theme overrides, place them AFTER both imports:
+If you want to keep the scaffold's color/font vars alongside shilp-sutra tokens (rare — usually you want one or the other), put scaffold's `@theme inline` / `:root` / `body` blocks AFTER the shilp-sutra import. Otherwise the scaffold's `body { font-family: Arial }` will compete with shilp-sutra's font setup.
+
+### 4c. Optional: add your own theme overrides
+
+Place after both imports:
 
 ```css
 @import "tailwindcss";
@@ -99,11 +113,15 @@ If the project has its own theme overrides, place them AFTER both imports:
 }
 ```
 
-Import the CSS file once from `app/layout.tsx` (it should already be imported in a fresh `create-next-app` project):
+### 4d. Ensure CSS is imported from the layout
+
+The CSS import in `app/layout.tsx` (or `src/app/layout.tsx`) should already exist in a fresh scaffold:
 
 ```tsx
 import "./globals.css";
 ```
+
+If you removed the Geist-font import from layout.tsx (see § 6), keep this CSS import line.
 
 ## 5. Configure `transpilePackages`
 
@@ -122,6 +140,8 @@ export default nextConfig;
 If a `transpilePackages` array already exists, append to it. Do not replace.
 
 Without `transpilePackages`, Next will refuse to load our pre-built `dist/*.js` because it ships native ESM that does not match Next's CJS-leaning loader for `node_modules`.
+
+**Turbopack:** as of Next 16, Turbopack is the default bundler (`next dev` and `next build`). `transpilePackages` is respected by both Turbopack and the Webpack backend. Tested on Turbopack 16.2 cold-install (2026-05-25); no extra config needed.
 
 ## 6. Scaffold the Providers wrapper
 
@@ -149,13 +169,21 @@ export function Providers({ children }: { children: ReactNode }) {
 - Drop the `Toaster` import and its JSX usage
 - Skip installing `sonner`
 
-Mount `<Providers>` from `app/layout.tsx`:
+Mount `<Providers>` from `app/layout.tsx` (or `src/app/layout.tsx`). **Replace the scaffold's layout** with the version below — the scaffold imports `next/font/google` (Geist) and applies font-variable classes to `<html>`, which you don't need when shilp-sutra ships its own fonts:
 
 ```tsx
+import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export const metadata: Metadata = {
+  title: "Your app",
+  description: "Built with shilp-sutra",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body>
@@ -166,11 +194,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 }
 ```
 
+Specifically, **remove these scaffold lines**:
+
+- `import { Geist, Geist_Mono } from "next/font/google";`
+- The `const geistSans = Geist({...})` and `const geistMono = Geist_Mono({...})` blocks
+- The `className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}` on `<html>`
+- The `className="min-h-full flex flex-col"` on `<body>`
+
+If you want to keep Geist alongside shilp-sutra's fonts, leave the `Geist` imports — but know that shilp-sutra's `font-sans` token resolves to Inter (body) and Ranade (display), not to the scaffold's `--font-geist-sans`. Loading both is wasted bytes.
+
 `suppressHydrationWarning` on `<html>` is required because `next-themes` writes the `class` attribute before React hydrates. Without it, every page logs a hydration warning.
 
 ## 7. Verify the install
 
-Replace the contents of `app/page.tsx`:
+Replace the contents of `app/page.tsx` (or `src/app/page.tsx`). The scaffold's `page.tsx` imports `next/image` and renders the Vercel marketing layout — replace the whole file:
 
 ```tsx
 import { Button } from "@devalok/shilp-sutra/ui/button";
@@ -209,6 +246,7 @@ If anything is off, see [troubleshoot.md](./troubleshoot.md).
 ## 8. Common gotchas
 
 - **CSS import order.** `tailwindcss` BEFORE `@devalok/shilp-sutra/css`. Reversing the order silently produces a build with no design-system utilities.
+- **Scaffold's `body { font-family: Arial }` overrides shilp-sutra fonts.** The `create-next-app` `globals.css` template sets `font-family: Arial, Helvetica, sans-serif` on `<body>`. If you kept the scaffold's body styles, they win the cascade over shilp-sutra's `font-sans`. § 4b says to replace the whole file — follow it.
 - **Multiple `framer-motion` copies.** Run `pnpm why framer-motion`. If it shows more than one resolved version, contexts (`MotionConfig`, `LayoutGroup`, `AnimatePresence`) silently break. Fix:
   ```jsonc
   // package.json
@@ -222,7 +260,9 @@ If anything is off, see [troubleshoot.md](./troubleshoot.md).
   ```
   For npm/yarn/bun equivalents, see [troubleshoot.md](./troubleshoot.md).
 - **Per-component imports keep RSC fast AND avoid peer-dep cliffs.** Inside Server Components, prefer `@devalok/shilp-sutra/ui/text`, `…/composed/page-header`, etc. The barrel `@devalok/shilp-sutra/ui` re-exports many client components — including some with hard peer-dep imports (e.g. `input-otp`) — so it both inflates the client bundle and forces those peers to be installed even when you never render those components. See [server-components.md](./server-components.md) for the full RSC-safety matrix.
-- **`p-3` vs `p-ds-03` — both are valid.** DS spacing uses the `--spacing-ds-*` namespace (`p-ds-04`, `gap-ds-03`); Tailwind 4's default numeric scale (`p-4`, `gap-2`) coexists by design. Pick `p-ds-*` for values that should track DS theme changes (card padding, form gaps); pick `p-N` for one-off layout values (section breathing room). Do NOT mass-codemod `p-4` → `p-ds-04` — that is not what the package intends.
+- **`p-3` vs `p-ds-03` — both are valid.** DS spacing uses the `--spacing-ds-*` namespace (`p-ds-04`, `gap-ds-03`); Tailwind 4's default numeric scale (`p-4`, `gap-2`) coexists by design. Pick `p-ds-*` for values that should track DS theme changes (card padding, form gaps); pick `p-N` for one-off layout values (section breathing room). Do NOT mass-codemod `p-4` → `p-ds-04` — that is not what the package intends. For layout rhythm, pick a 3-tier cadence (`ds-03` related / `ds-05` grouped / `ds-07` section), not every adjacent token.
+- **Auto-generated `pnpm-workspace.yaml`.** `pnpm 10+` writes a `pnpm-workspace.yaml` at the project root on first install with `ignoredBuiltDependencies` entries. This is harmless for a standalone app, but if you're nesting this project inside a larger monorepo, delete this file and use the parent monorepo's workspace config instead.
+- **Auto-generated `AGENTS.md`.** `create-next-app` writes an `AGENTS.md` with managed `<!-- BEGIN:nextjs-agent-rules -->` / `<!-- END:nextjs-agent-rules -->` markers. Shilp Sutra's agent rules use `<!-- BEGIN:shilp-sutra-agent-rules -->` markers — they coexist cleanly. If you install the shilp-sutra Agent Skill (see the repo root `AGENTS.md` for the one-liner), it adds its block alongside Next's, not over it.
 - **Bare `shadow` is dead.** Tailwind 4 has no `--shadow-DEFAULT`. Use `shadow-raised`, `shadow-overlay`, or `shadow-floating`.
 
 ## 9. What you should NOT do


### PR DESCRIPTION
## Summary

Cold-install dogfood test of `install-next-app-router.md` against fresh `pnpm create next-app@latest` on Next 16.2.6 + Turbopack + React 19.2 + pnpm 10.30 + Node 22 + Windows 11 (2026-05-25). Recipe landed end-to-end — production build clean, dev SSR rendered correct class stacks, framer-motion deduped, no hydration warnings — but **7 friction points surfaced**. Each was a place an AI agent could trip naively (and a confused agent fills `ai-agent-feedback` issues). This PR addresses all 7.

This closes one of the beta entry gates from [`docs/plans/2026-05-24-beta-release-plan.md`](../blob/main/docs/plans/2026-05-24-beta-release-plan.md): G4 (agent-dogfood test on the recipe before publishing 0.40.0 beta).

## What changed

| # | Friction | Fix |
|---|---|---|
| 1 | Recipe didn't say what stack we last verified against | Added "Tested on" matrix at the top |
| 2 | `src/app/globals.css` listed as priority-2; Next 14+ default is `src/app/` | Reordered: `src/app/globals.css` is priority-1 |
| 3 | Recipe said "set file contents to" without addressing scaffold's pre-existing globals.css content (`:root` color vars, `@theme inline` block, Geist font vars, `body { font-family: Arial }`) | § 4b now explicitly says REPLACE entire file; calls out each scaffold block that needs to go |
| 4 | Turbopack (Next 16 default) not addressed | § 5 confirms Turbopack respects `transpilePackages`; no extra config |
| 5 | § 3 PostCSS said "create or update"; Next 14+ scaffolds it | Rewritten to "verify or create" — saves agent the diff-check |
| 6 | § 6 layout.tsx replacement didn't tell agents to remove scaffold's `next/font/google` Geist imports or the className-on-html | Now explicitly lists scaffold lines to remove |
| 7 | § 8 missing gotchas | Added 3: body-font-Arial cascade, pnpm-workspace.yaml monorepo, AGENTS.md marker coexistence |

## Verification

Cold-install path that produced this PR (reproducible):

```bash
mkdir dogfood && cd dogfood
pnpm create next-app@latest dogfood-app --typescript --tailwind --eslint --app --use-pnpm --skip-install
cd dogfood-app
pnpm add @devalok/shilp-sutra framer-motion next-themes
# follow the (NEW) recipe steps 3–7
pnpm build  # ✓ Compiled successfully (Turbopack)
pnpm dev    # SSR renders all 3 button variants with correct class stacks
pnpm why framer-motion  # ✓ Found 1 version
```

## Why patch, not minor

Recipe clarification widens no public-API surface. Same recipe lands successfully on more environments. No new exports, no behavior change, no new dependency. Per [CONTRIBUTING § Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes): patch.

## Test plan

- [ ] CI green
- [ ] Re-run the cold-install (above) in a fresh sandbox after this PR lands
- [ ] Skim the diff for any wording that contradicts other recipes (Vite, Astro, Remix) — they'll get the same dogfood treatment in follow-up PRs

## Notes for reviewer

A second branch (`chore/beta-foundations`, PR #47) already added the codemod policy and Beta SLA referenced indirectly by this PR — they don't need to land first.

Companion test artifact: `C:\Users\mudit\Documents\GitHub\shilp-sutra-dogfood/dogfood-app/` (local, not committed). Discard after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)