### PR TITLE
ci(release): build library before typecheck (release.yml fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,15 @@ jobs:
       # manual audit enforce the same invariants. Ordering mirrors the
       # audit script so a failure here is debuggable by re-running the
       # same step locally.
+      #
+      # Build runs FIRST so workspace consumers (apps/site) can resolve
+      # @devalok/shilp-sutra/ui/* subpath imports during typecheck. The
+      # site's showcase pages import per-component subpaths from the
+      # package's dist/, so typechecking before build produces TS2307
+      # cascades.
+
+      - name: Build
+        run: pnpm build
 
       - name: Typecheck
         run: pnpm typecheck
@@ -121,9 +130,6 @@ jobs:
 
       - name: Test
         run: pnpm test
-
-      - name: Build
-        run: pnpm build
 
       - name: SSR smoke test (no browser APIs in Node.js)
         run: node packages/core/scripts/ssr-smoke-test.mjs


### PR DESCRIPTION
## Summary

Same TS2307 cascade we just fixed in `ci.yml` ([a8ef1062](https://github.com/devalok-design/shilp-sutra/commit/a8ef1062)) — `release.yml` also runs `pnpm typecheck` before `pnpm build`, so `apps/site` can't resolve `@devalok/shilp-sutra/ui/*` subpath imports during the typecheck step.

Surfaced right after merging #46 to main: the post-merge Release workflow ([run 26390218268](https://github.com/devalok-design/shilp-sutra/actions/runs/26390218268)) failed at the typecheck step before Changesets could open the Version Packages PR.

## What changed

Move `Build` to run first, before Typecheck/Lint/Test. Subsequent steps (SSR smoke, pre-publish audit, publish) still run in their original order.

## Test plan

- [ ] Merging this re-runs Release workflow on main
- [ ] Build step succeeds
- [ ] Typecheck step now resolves @devalok/shilp-sutra/ui/* subpath imports
- [ ] Changesets opens Version Packages PR for 0.39.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)