### PR TITLE
fix(site): drop unknown-rule eslint-disable in built-with.tsx Favicon

### DIFF
--- a/apps/site/components/built-with.tsx
+++ b/apps/site/components/built-with.tsx
@@ -199,7 +199,11 @@ function Favicon({
   }
 
   return (
-    // eslint-disable-next-line @next/next/no-img-element
+    // Intentional: <img> with Google favicon service — Next/Image would proxy
+    // through /_next/image for a 32-128px favicon. Not worth the latency.
+    // The @next/next/no-img-element rule is not registered in this flat ESLint
+    // config, so a disable directive errors with "Definition for rule … was
+    // not found".
     <img
       src={`https://www.google.com/s2/favicons?domain=${domain}&sz=128`}
       alt={`${name} favicon`}


### PR DESCRIPTION
Same lint blocker as 91c3de31 — re-introduced by the BuiltWith redesign (5aae1561). Replaces `// eslint-disable-next-line @next/next/no-img-element` with a prose comment. Plugin isn't registered in this flat ESLint config, so the directive errors with 'Definition for rule … was not found'. Blocks v0.39.0 publish at the Lint step.