### PR TITLE
chore(docs, skill): regen llms-full + skill for 0.39.0 version stamp

### DIFF
--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -5,7 +5,7 @@
 > All variant values and props verified from source CVA definitions.
 >
 > Package: @devalok/shilp-sutra
-> Version: 0.38.0
+> Version: 0.39.0
 >
 > **If you are an AI agent reading this file top-to-bottom:** the Setup
 > section below is authoritative. If any later per-component doc or a

--- a/skills/shilp-sutra/references/components-full.md
+++ b/skills/shilp-sutra/references/components-full.md
@@ -7,7 +7,7 @@
 > All variant values and props verified from source CVA definitions.
 >
 > Package: @devalok/shilp-sutra
-> Version: 0.38.0
+> Version: 0.39.0
 >
 > **If you are an AI agent reading this file top-to-bottom:** the Setup
 > section below is authoritative. If any later per-component doc or a


### PR DESCRIPTION
Unblocks v0.39.0 publish. PR #50's version bump didn't regenerate llms-full.txt header — skill drift gate caught it. Pure regen, 2 lines changed (version stamp 0.38.0 → 0.39.0).