### PR TITLE
fix(docs): stamp llms-full + skill at 0.40.0 (unblock release)

### DIFF
--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -5,7 +5,7 @@
 > All variant values and props verified from source CVA definitions.
 >
 > Package: @devalok/shilp-sutra
-> Version: 0.39.0
+> Version: 0.40.0
 >
 > **If you are an AI agent reading this file top-to-bottom:** the Setup
 > section below is authoritative. If any later per-component doc or a

--- a/skills/shilp-sutra/references/components-full.md
+++ b/skills/shilp-sutra/references/components-full.md
@@ -7,7 +7,7 @@
 > All variant values and props verified from source CVA definitions.
 >
 > Package: @devalok/shilp-sutra
-> Version: 0.39.0
+> Version: 0.40.0
 >
 > **If you are an AI agent reading this file top-to-bottom:** the Setup
 > section below is authoritative. If any later per-component doc or a


### PR DESCRIPTION
Release #58 merged but `release.yml` audit failed at `build-skill.mjs --check`: committed `llms-full.txt` + `references/components-full.md` still stamp `Version: 0.39.0` because changesets' version-packages bumped package.json without regenerating the version-stamped docs. Nothing published yet (npm still 0.39.0).

Regenerated both from a fresh build → now stamp 0.40.0. Merging re-triggers release.yml → publishes 0.40.0 + eslint-plugin 0.2.0.

Follow-up: `version-packages` should rebuild docs+skill, not just `sync-skill-version.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)