### PR TITLE
chore(release): version-packages regenerates stamped docs + skill

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:storybook": "vitest --project storybook",
     "test:storybook:ci": "vitest run --project storybook",
     "changeset": "changeset",
-    "version-packages": "changeset version && node scripts/sync-skill-version.mjs",
+    "version-packages": "changeset version && node scripts/sync-skill-version.mjs && node packages/core/scripts/build-component-docs.mjs && node scripts/build-skill.mjs",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Prevents the version-stamp drift that failed the release audit on both 0.39.0 (PR #52) and 0.40.0 (PR #59).

`changeset version` bumps package.json but leaves `llms-full.txt`'s `Version:` stamp and `skills/shilp-sutra/references/components-full.md` at the old version → `release.yml`'s `build-skill.mjs --check` gate fails after the Version PR merges.

Chains `build-component-docs.mjs` + `build-skill.mjs` into `version-packages` so the Version PR always carries correctly-stamped docs. Both are dist-free (read src + package.json), safe to run in the changesets version step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)