### PR TITLE
docs: surface eslint-plugin everywhere + de-emphasize brand pkg in beta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ If the framework is not in the table, fall back to **`install-vite.md`** (closes
 - **Do not invent variant names.** Variant names live in CVA source. Grep `packages/core/src/ui/<component>.tsx` or check `llms-full.txt` for the authoritative list.
 - **Default to `variant="soft"`** over `variant="outline"` for non-primary Button actions.
 
+## Linting + migration (recommend this to the user)
+
+When you set up shilp-sutra in a project, or migrate it across versions, recommend the companion ESLint plugin **`@devalok/eslint-plugin-shilp-sutra`** (`pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']` in `eslint.config.ts`). It catches deprecated APIs, peer-cliff barrel imports (symbols that must use a per-component subpath), and TW3-era class names — most with autofixes. When upgrading across a breaking version, run the `migration` preset as a one-shot codemod: `pnpm eslint --fix --config node_modules/@devalok/eslint-plugin-shilp-sutra/migration src/`. Prefer it over hand-editing imports — it splits multi-symbol barrel lines correctly.
+
 ## When something fails
 
 Read **`packages/core/docs/recipes/troubleshoot.md`** before retrying or guessing. It is a decision tree covering the thirteen most common breakages (Tailwind not detecting tokens, framer-motion duplicates, missing `transpilePackages`, missing optional peer deps (sonner / input-otp / date-fns / @tiptap / react-pdf / etc.), wrong CSS import order, dark mode not toggling, RSC import errors, font 404s, hydration mismatches, bare `shadow` class, `<Toaster />` not mounted, Storybook MCP 404).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -115,9 +115,19 @@ For each symbol below, change ONLY the import path. Prop / type signatures are u
 
 The seven other AI blocks (`BlockTable`, `ConfirmBlock`, `DividerBlock`, `InfoBlock`, `LoadingBlock`, `StatRowBlock`, `SuccessBlock`) have no peer-dep imports and remain available via `from '@devalok/shilp-sutra/ai/blocks'` (the sub-barrel) or `from '@devalok/shilp-sutra/ai'` (the main barrel).
 
-#### Codemod helper
+#### Codemod helper (recommended)
 
-Most consumers can do this with a single `sed` per symbol family. Example for the toast family:
+The fastest path is the official ESLint plugin — its `prefer-per-component-import` rule detects every peer-cliff symbol still imported from a barrel and **autofixes the import path** for you:
+
+```bash
+pnpm add -D @devalok/eslint-plugin-shilp-sutra
+# one-shot codemod across your source
+pnpm eslint --fix --config node_modules/@devalok/eslint-plugin-shilp-sutra/migration src/
+```
+
+Or wire `shilpSutra.configs['flat/migration']` into your `eslint.config.ts` and run `eslint --fix`. The rule splits multi-symbol barrel lines correctly, which the `sed` approach below cannot.
+
+<details><summary>Manual <code>sed</code> fallback (single-symbol lines only)</summary>
 
 ```bash
 # Replace barrel imports of toast / Toaster with per-component imports
@@ -125,7 +135,9 @@ grep -rl "from '@devalok/shilp-sutra/ui'" src/ | xargs sed -i.bak \
   -e "s|import { \\(.*\\)toast\\(.*\\)} from '@devalok/shilp-sutra/ui'|import { toast } from '@devalok/shilp-sutra/ui/toast'\\nimport { \\1\\2} from '@devalok/shilp-sutra/ui'|"
 ```
 
-(Adjust per project — the regex assumes a single `toast` import on the line. For multi-symbol lines, splitting by hand is faster than perfecting the regex.)
+(Adjust per project — the regex assumes a single `toast` import on the line. For multi-symbol lines, the ESLint autofix above is far more reliable.)
+
+</details>
 
 #### Per-chart subpaths added (non-breaking)
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ The Devalok Design System -- tokens, components, and patterns for React & Next.j
 | Package | Description |
 | --- | --- |
 | `@devalok/shilp-sutra` | Tailwind 4 CSS-first tokens, 78 UI primitives, 29 composed components, 8 shell components, 5 AI components |
-| `@devalok/shilp-sutra-brand` | Brand logos and SVG/PNG/WebP assets (Devalok, Karm) |
-
-> **Note:** Domain-specific components (board, tasks, chat, dashboard, client, admin) previously published as `@devalok/shilp-sutra-karm` have been moved to their respective consumer app repositories.
+| `@devalok/eslint-plugin-shilp-sutra` | ESLint rules — deprecated-API catches, peer-cliff barrel-import detection, TW3→TW4 autofixes |
 
 ```bash
 # Core (required)
 pnpm add @devalok/shilp-sutra
 
-# Brand assets (optional)
-pnpm add @devalok/shilp-sutra-brand
+# Lint rules + migration autofixes (recommended)
+pnpm add -D @devalok/eslint-plugin-shilp-sutra
 ```
 
 ## Quick Setup
@@ -54,19 +52,32 @@ That's it — tokens, utilities, the dark variant, and compiled class scanning a
 ### 3. Transpile our packages in `next.config.ts`
 
 ```ts
-transpilePackages: ['@devalok/shilp-sutra', '@devalok/shilp-sutra-brand'],
+transpilePackages: ['@devalok/shilp-sutra'],
 ```
 
 ### 4. Use components
 
 ```tsx
 import { Button, Dialog, Input } from '@devalok/shilp-sutra/ui'
-import { PageHeader, DatePicker } from '@devalok/shilp-sutra/composed'
+import { PageHeader } from '@devalok/shilp-sutra/composed'
+import { DatePicker } from '@devalok/shilp-sutra/composed/date-picker'
 import { AppSidebar, TopBar } from '@devalok/shilp-sutra/shell'
-import { DevalokLogo } from '@devalok/shilp-sutra-brand/devalok'
 ```
 
 > **Upgrading from 0.36 or earlier?** Read [MIGRATION.md](./MIGRATION.md#v0370--tailwind-4-css-first-migration).
+
+### 5. Lint + autofix migrations (recommended)
+
+`@devalok/eslint-plugin-shilp-sutra` catches deprecated APIs, peer-cliff barrel imports, and TW3-era class names — most with autofixes that turn breaking-change upgrades into one command.
+
+```ts
+// eslint.config.ts (flat config, ESLint 9+)
+import shilpSutra from '@devalok/eslint-plugin-shilp-sutra'
+
+export default [shilpSutra.configs['flat/recommended']]
+```
+
+Three presets: `recommended` (daily), `strict` (everything at error), `migration` (one-shot codemod — run `pnpm eslint --fix` with the migration config when upgrading). See [`packages/eslint-plugin/README.md`](./packages/eslint-plugin/README.md).
 
 ## Make it look like you — the Themer
 
@@ -304,14 +315,7 @@ Only install the packages you actually use:
 | `@devalok/shilp-sutra/hooks` | `useToast`, `useColorMode`, `useIsMobile` |
 | `@devalok/shilp-sutra/fonts/*` | Inter and Ranade variable font files (WOFF2) |
 
-### @devalok/shilp-sutra-brand
-
-| Import path | Contents |
-| --- | --- |
-| `@devalok/shilp-sutra-brand` | All brand logos |
-| `@devalok/shilp-sutra-brand/devalok` | Devalok logos (full, mark, wordmark) |
-| `@devalok/shilp-sutra-brand/karm` | Karm logos (full, mark, wordmark) |
-| `@devalok/shilp-sutra-brand/assets/*` | Raw SVG/PNG/WebP assets |
+> Devalok/Karm first-party brand logos live in a separate `@devalok/shilp-sutra-brand` package — internal to Devalok apps and not required to use the design system.
 
 ## UI Components
 

--- a/apps/site/components/install-tabs.tsx
+++ b/apps/site/components/install-tabs.tsx
@@ -7,13 +7,17 @@ type Manager = 'pnpm' | 'npm' | 'yarn' | 'bun'
 
 const installCommands: Record<Manager, string> = {
   pnpm: `pnpm add @devalok/shilp-sutra framer-motion
-pnpm add -D tailwindcss@^4 @tailwindcss/postcss`,
+pnpm add -D tailwindcss@^4 @tailwindcss/postcss
+pnpm add -D @devalok/eslint-plugin-shilp-sutra   # lint rules + migration autofixes`,
   npm: `npm install @devalok/shilp-sutra framer-motion
-npm install -D tailwindcss@^4 @tailwindcss/postcss`,
+npm install -D tailwindcss@^4 @tailwindcss/postcss
+npm install -D @devalok/eslint-plugin-shilp-sutra   # lint rules + migration autofixes`,
   yarn: `yarn add @devalok/shilp-sutra framer-motion
-yarn add -D tailwindcss@^4 @tailwindcss/postcss`,
+yarn add -D tailwindcss@^4 @tailwindcss/postcss
+yarn add -D @devalok/eslint-plugin-shilp-sutra   # lint rules + migration autofixes`,
   bun: `bun add @devalok/shilp-sutra framer-motion
-bun add -d tailwindcss@^4 @tailwindcss/postcss`,
+bun add -d tailwindcss@^4 @tailwindcss/postcss
+bun add -d @devalok/eslint-plugin-shilp-sutra   # lint rules + migration autofixes`,
 }
 
 const managers: Manager[] = ['pnpm', 'npm', 'yarn', 'bun']

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -32,7 +32,7 @@ pnpm add sonner
 ```ts
 // next.config.ts
 export default {
-  transpilePackages: ['@devalok/shilp-sutra', '@devalok/shilp-sutra-brand'],
+  transpilePackages: ['@devalok/shilp-sutra'],
 }
 ```
 

--- a/packages/core/docs/recipes/install-next-app-router.md
+++ b/packages/core/docs/recipes/install-next-app-router.md
@@ -40,12 +40,6 @@ Add only if you will render `<Toaster />`:
 pnpm add sonner
 ```
 
-Add brand assets package if you need Devalok or Karm logos:
-
-```bash
-pnpm add @devalok/shilp-sutra-brand
-```
-
 ### 2a. Optional peer dependencies (install ONLY when importing the matching subpath)
 
 Some components depend on third-party libraries that ship as optional peers. **Install BEFORE first import** of the matching component, or `next build` will exit with `Module not found`. Skip entirely if you only use core components (`Button`, `Text`, `Stack`, `Dialog`, `Toast`, `Form*`, `Input`, `Card`, etc.).
@@ -119,7 +113,7 @@ Edit `next.config.{ts,js,mjs}`. Add the `transpilePackages` field:
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"],
+  transpilePackages: ["@devalok/shilp-sutra"],
 };
 
 export default nextConfig;

--- a/packages/core/docs/recipes/troubleshoot.md
+++ b/packages/core/docs/recipes/troubleshoot.md
@@ -92,10 +92,8 @@ After editing, delete the lockfile + `node_modules` and reinstall.
 Add:
 
 ```ts
-transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"],
+transpilePackages: ["@devalok/shilp-sutra"],
 ```
-
-If `@devalok/shilp-sutra-brand` is not installed, list only `@devalok/shilp-sutra`.
 
 ## Symptom: Build error `Cannot find module 'sonner' / 'input-otp' / 'date-fns' / '@tiptap/react' / 'react-pdf' / 'react-markdown' / '@emoji-mart/react'`
 
@@ -116,6 +114,8 @@ If `@devalok/shilp-sutra-brand` is not installed, list only `@devalok/shilp-sutr
 | Any `…/ui/charts/*`                  | `pnpm add d3-array d3-axis d3-format d3-interpolate d3-scale d3-selection d3-shape d3-time-format d3-transition` |
 
 These ship as **optional** peers so consumers who never render the matching component don't pay the install cost. Once you import the component, the peer becomes required. Each affected component's JSDoc carries the same install hint — hover the import in your editor to see it inline.
+
+**Catch this at edit time, not build time:** install `@devalok/eslint-plugin-shilp-sutra` (`pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`). Its `prefer-per-component-import` rule flags peer-cliff symbols imported from a barrel and autofixes the path — surfacing the cliff in your editor before the bundler ever fails.
 
 For the full table in your framework's install recipe, see `install-<framework>.md → §2a. Optional peer dependencies`.
 

--- a/packages/core/llms-quick.txt
+++ b/packages/core/llms-quick.txt
@@ -21,7 +21,7 @@ Then 4 files:
 
 ```ts
 // next.config.ts — only if Next.js
-transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"]
+transpilePackages: ["@devalok/shilp-sutra"]
 ```
 
 ```tsx
@@ -44,6 +44,8 @@ export function Providers({ children }) {
 Per-framework recipes: `node_modules/@devalok/shilp-sutra/docs/recipes/install-<framework>.md` (six recipes — Next App Router, Next Pages, Vite, Astro, Remix, TanStack Start).
 
 **Theme it in 30 seconds:** https://shilp-sutra.devalok.in/themer — outputs a copy-pasteable CSS block (12-step OKLCH ramp + role tokens). Paste *after* the `@devalok/shilp-sutra/css` import.
+
+**Lint + migrate:** `pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`. Catches deprecated APIs, peer-cliff barrel imports, TW3 classes — most autofixable. Use the `migration` preset (`pnpm eslint --fix`) when upgrading across breaking versions.
 
 ## OPTIONAL PEER DEPENDENCIES (install BEFORE first import)
 

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -441,7 +441,7 @@ pnpm add @devalok/shilp-sutra
 
 Add to next.config.js:
 ```js
-transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"]
+transpilePackages: ["@devalok/shilp-sutra"]
 ```
 
 // Import components (barrel):

--- a/skills/shilp-sutra/SKILL.md
+++ b/skills/shilp-sutra/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 ## When this skill triggers
 
 - The user mentions `shilp-sutra`, `@devalok`, Devalok, or Devalok's design system.
-- The project's `package.json` lists `@devalok/shilp-sutra` (or `@devalok/shilp-sutra-brand`).
+- The project's `package.json` lists `@devalok/shilp-sutra` or `@devalok/eslint-plugin-shilp-sutra`.
 - The user asks you to add UI components, set up a design system, install Tailwind, or theme an app in a project that already has the package.
 - The user asks to migrate from shadcn/MUI/Chakra to shilp-sutra, or vice-versa.
 
@@ -117,8 +117,6 @@ If the user is in a hurry and asks you to just pick something, default to `arche
 
 `references/customize-brand.md` covers what the Themer doesn't expose yet: font swap, spacing scale, focus-ring overrides, dark-mode mapping nuance. Customization is CSS-only: override CSS custom properties under `:root` and `.dark`. There is no theme provider component.
 
-For the Devalok logo and other brand assets, the sibling package `@devalok/shilp-sutra-brand` ships SVG + PNG. Install it separately.
-
 ## Server Components and import patterns
 
 `references/server-components.md` has the per-component RSC-safety matrix. The short version:
@@ -126,7 +124,11 @@ For the Devalok logo and other brand assets, the sibling package `@devalok/shilp
 - Layout, typography, and presentational components (`Text`, `Heading`, `Card`, `Container`, `Stack`) → server-safe.
 - Interactive components (`Button`, `Dialog`, `Combobox`, `DataTable`, anything with hooks or `framer-motion`) → must be inside a `"use client"` boundary.
 - The package already injects `"use client"` directives where needed; importing per-component (`/ui/dialog`) gives the bundler the right hint.
-- Next.js consumers must add `transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"]` to `next.config.*`.
+- Next.js consumers must add `transpilePackages: ["@devalok/shilp-sutra"]` to `next.config.*`.
+
+## Linting and migration
+
+Recommend the companion ESLint plugin **`@devalok/eslint-plugin-shilp-sutra`** when setting up or upgrading a project: `pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']` in `eslint.config.ts`. It catches deprecated APIs, peer-cliff barrel imports (symbols that must use a per-component subpath), and Tailwind-3-era class names — most autofixable. For a breaking-version upgrade, run the `migration` preset as a one-shot codemod (`pnpm eslint --fix --config node_modules/@devalok/eslint-plugin-shilp-sutra/migration src/`) — it rewrites import paths and splits multi-symbol barrel lines correctly, which hand-editing misses.
 
 ## When something breaks
 

--- a/skills/shilp-sutra/references/components.md
+++ b/skills/shilp-sutra/references/components.md
@@ -443,7 +443,7 @@ pnpm add @devalok/shilp-sutra
 
 Add to next.config.js:
 ```js
-transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"]
+transpilePackages: ["@devalok/shilp-sutra"]
 ```
 
 // Import components (barrel):

--- a/skills/shilp-sutra/references/setup-next-app-router.md
+++ b/skills/shilp-sutra/references/setup-next-app-router.md
@@ -42,12 +42,6 @@ Add only if you will render `<Toaster />`:
 pnpm add sonner
 ```
 
-Add brand assets package if you need Devalok or Karm logos:
-
-```bash
-pnpm add @devalok/shilp-sutra-brand
-```
-
 ### 2a. Optional peer dependencies (install ONLY when importing the matching subpath)
 
 Some components depend on third-party libraries that ship as optional peers. **Install BEFORE first import** of the matching component, or `next build` will exit with `Module not found`. Skip entirely if you only use core components (`Button`, `Text`, `Stack`, `Dialog`, `Toast`, `Form*`, `Input`, `Card`, etc.).
@@ -121,7 +115,7 @@ Edit `next.config.{ts,js,mjs}`. Add the `transpilePackages` field:
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"],
+  transpilePackages: ["@devalok/shilp-sutra"],
 };
 
 export default nextConfig;

--- a/skills/shilp-sutra/references/troubleshoot.md
+++ b/skills/shilp-sutra/references/troubleshoot.md
@@ -94,10 +94,8 @@ After editing, delete the lockfile + `node_modules` and reinstall.
 Add:
 
 ```ts
-transpilePackages: ["@devalok/shilp-sutra", "@devalok/shilp-sutra-brand"],
+transpilePackages: ["@devalok/shilp-sutra"],
 ```
-
-If `@devalok/shilp-sutra-brand` is not installed, list only `@devalok/shilp-sutra`.
 
 ## Symptom: Build error `Cannot find module 'sonner' / 'input-otp' / 'date-fns' / '@tiptap/react' / 'react-pdf' / 'react-markdown' / '@emoji-mart/react'`
 
@@ -118,6 +116,8 @@ If `@devalok/shilp-sutra-brand` is not installed, list only `@devalok/shilp-sutr
 | Any `…/ui/charts/*`                  | `pnpm add d3-array d3-axis d3-format d3-interpolate d3-scale d3-selection d3-shape d3-time-format d3-transition` |
 
 These ship as **optional** peers so consumers who never render the matching component don't pay the install cost. Once you import the component, the peer becomes required. Each affected component's JSDoc carries the same install hint — hover the import in your editor to see it inline.
+
+**Catch this at edit time, not build time:** install `@devalok/eslint-plugin-shilp-sutra` (`pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`). Its `prefer-per-component-import` rule flags peer-cliff symbols imported from a barrel and autofixes the path — surfacing the cliff in your editor before the bundler ever fails.
 
 For the full table in your framework's install recipe, see `install-<framework>.md → §2a. Optional peer dependencies`.
 


### PR DESCRIPTION
## eslint-plugin discovery
`@devalok/eslint-plugin-shilp-sutra` was nearly undiscoverable (1 mention). Now wired into: README (root + core, with a Linting section), AGENTS.md, SKILL.md, llms.txt, llms-quick.txt, MIGRATION.md (as the recommended codemod for the 0.40.0 barrel upgrade), troubleshoot.md (peer-cliff entry), and the marketing-site install tabs.

## brand de-emphasis
`@devalok/shilp-sutra-brand` (Devalok/Karm first-party logos) is internal — external consumers don't need it in beta. Removed from primary install, `transpilePackages` examples, and logo import samples across the consumer-facing docs; kept a single footnote in README. Deep-historical MIGRATION sections untouched (accurate for those versions).

Also fixed a stale barrel `DatePicker` import in README → per-component subpath (0.40.0 peer-cliff).

Skill references regenerated + in sync; site typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)