### PR TITLE
docs(plans): mark codemods repo superseded by eslint-plugin

### DIFF
--- a/docs/plans/2026-05-08-public-release-roadmap.md
+++ b/docs/plans/2026-05-08-public-release-roadmap.md
@@ -121,9 +121,9 @@ Tools that wrap shilp-sutra and make consumer DX better. Each is a separate, opt
 
 | # | Item | Tag | Effort | Status |
 |---|---|---|---|---|
-| 1.5.1 | `@devalok/eslint-plugin-shilp-sutra` — rules: no bare `shadow`, prefer `Stack` over `flex` divs, prefer `variant="soft"` over `variant="outline"` for non-primary, no `p-N` (use `p-ds-N`), no removed APIs (e.g. `variant="filled"` on Alert), per-component-import preference | P1 | M (3-5 days) | ❌ |
-| 1.5.2 | Codemod policy in `CONTRIBUTING.md` — any breaking change touching >2 components SHIPS a codemod (`@devalok/shilp-sutra-codemods`) using jscodeshift | P0 | S | ❌ |
-| 1.5.3 | `@devalok/shilp-sutra-codemods` package — repo for past + future codemods. Backfill v0.38 deprecation-sweep codemod retroactively | P1 | M (3-4 days) | ❌ |
+| 1.5.1 | `@devalok/eslint-plugin-shilp-sutra` — **DONE 2026-05-27 (`@0.2.0`)**: 12 rules incl. `no-bare-shadow`, deprecated-API catches, TW3→TW4 class autofixes, `prefer-per-component-import`. (Dropped the `no-p-N` rule — `p-N` and `p-ds-N` coexist by design; see CONTRIBUTING cadence guidance instead.) | P1 | M | ✅ |
+| 1.5.2 | Codemod policy in `CONTRIBUTING.md`. **DONE 2026-05-27** — shipped, but the vehicle is the `@devalok/eslint-plugin-shilp-sutra` `migration` preset, NOT a standalone jscodeshift repo (superseded; see 1.5.3). | P0 | S | ✅ |
+| 1.5.3 | ~~`@devalok/shilp-sutra-codemods` jscodeshift package~~ **SUPERSEDED 2026-05-27** — replaced by `@devalok/eslint-plugin-shilp-sutra@0.2.0`. Autofix ESLint rules are the migration mechanism (consumers already run ESLint); no separate codemod repo. The standalone repo was never built. | P1 | — | ✅ |
 | 1.5.4 | Storybook MCP server productization — currently dev-only at `localhost:6006/mcp`. Decide: leave as dev-only OR publish standalone | P3 | M | ❌ — strategic Q below |
 | 1.5.5 | VS Code snippets package (`shilp-sutra-snippets`) — `bn` → `<Button variant="…">…</Button>` etc. Skip full extension; snippets give 80% value | P2 | S | ❌ |
 

--- a/docs/plans/2026-05-09-multi-phase-implementation-plan.md
+++ b/docs/plans/2026-05-09-multi-phase-implementation-plan.md
@@ -108,8 +108,8 @@ The biggest single piece of pre-1.0 work. Touches every CVA component.
 - Migrate Switch (currently 3), Toggle (currently 4 different), Slider (currently 4 no-neutral), ConfirmDialog (currently 2-only)
 - Remove `color="default"` from Card, Select-trigger, Progress, StatCard.accent
 
-**Codemod (`@devalok/shilp-sutra-codemods`):**
-- jscodeshift transforms for each renamed/removed axis
+**Codemod** *(SUPERSEDED 2026-05-27: shipped as `@devalok/eslint-plugin-shilp-sutra` autofix rules, not a standalone jscodeshift repo):*
+- ESLint `migration`-preset rules for each renamed/removed axis (autofix), e.g. `prefer-per-component-import` for the 0.40.0 barrel moves
 - Backward-compat aliases live for one minor (deprecated with dev warning, removed in 0.40.0)
 
 #### 1.4 — Enforcement tooling MVP (2-3 days)
@@ -307,18 +307,15 @@ Expand from Phase-1 MVP to full rule set:
 
 Ship as separate npm package: `@devalok/eslint-plugin-shilp-sutra@1.0.0`
 
-#### 4.2 — `@devalok/shilp-sutra-codemods` v1 (3-4 days)
+#### 4.2 — Migration autofixes (SUPERSEDED — folded into the ESLint plugin)
 
-Consolidated codemod package. Each transform is jscodeshift + dry-run + diff-mode.
+**2026-05-27:** the standalone `@devalok/shilp-sutra-codemods` jscodeshift package was never built and is dropped. Migration automation lives in `@devalok/eslint-plugin-shilp-sutra`'s `migration` preset instead — consumers already run ESLint, so autofix rules beat a separate codemod CLI. Already shipped: `prefer-per-component-import` (0.40.0 barrel moves), `no-bg-gradient-to` / `no-css-var-bracket` / `no-tailwind-config-preset` (TW3→TW4).
 
-Backfill historical codemods retroactively:
-- `v0.38-deprecation-sweep` (variant=filled→solid, action→actions, startIcon→startSection, etc.)
-- `v0.39-variant-normalization` (Card/Alert/Badge/Banner/Toggle migration)
-- `v0.40-i18n-extraction` (auto-prop-extraction skeleton — humans complete)
-- `v0.40-rtl-codemod` (logical properties)
-- `v0.41-state-api-alignment` (boolean error → state enum)
+Future per-version migration rules to add to the preset as those breaks land:
+- variant-normalization (Card/Alert/Badge/Banner/Toggle)
+- state-api-alignment (boolean error → state enum)
 
-Usage: `npx @devalok/shilp-sutra-codemods v0.39-variant-normalization src/`
+Usage: `pnpm eslint --fix --config node_modules/@devalok/eslint-plugin-shilp-sutra/migration src/`
 
 #### 4.3 — `@devalok/shilp-sutra-snippets` (VS Code) (1 day)
 


### PR DESCRIPTION
Roadmap docs (2026-05-08 / 2026-05-09) planned a standalone `@devalok/shilp-sutra-codemods` jscodeshift repo. Never built — migration automation shipped as `@devalok/eslint-plugin-shilp-sutra`'s `migration` preset instead. Annotated the affected rows/sections as superseded; marked the now-shipped eslint-plugin (1.5.1) + codemod-policy (1.5.2) as DONE. Planning docs now match what shipped; no live phantom-repo references remain.

Pure docs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)