### PR TITLE
feat(release): ship machine-readable BREAKING.json manifest (closes #62 item 4)

### DIFF
--- a/.changeset/breaking-manifest.md
+++ b/.changeset/breaking-manifest.md
@@ -1,0 +1,47 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+feat(release): ship a machine-readable `BREAKING.json` manifest
+
+Closes the structured-data half of devalok-design/shilp-sutra#62. AI agents and migration tooling can now answer "what breaks between X and Y?" programmatically instead of parsing CHANGELOG prose.
+
+### What ships
+
+- **`packages/core/BREAKING.json`** — manifest of every breaking change per version, categorised: `moved` (import-path change), `narrowed` (prop type accepts less), `removed`, `renamed`, `notes`. Populated with the full 0.40.0 data: all 27 barrel→subpath moves + the 17-component Icon API narrowing (`React.ReactNode` → `IconInput`), with peer-dep and eslint-rule cross-refs on each move.
+- **`packages/core/BREAKING.schema.json`** — canonical JSON Schema for the manifest. Editors auto-validate via `$schema`.
+- **Two new subpath exports** — `@devalok/shilp-sutra/BREAKING.json` and `@devalok/shilp-sutra/BREAKING.schema.json`. Consumers can `import manifest from '@devalok/shilp-sutra/BREAKING.json'`.
+- **Tarball ships both files** (added to `files[]`).
+
+### What the publish mechanism enforces
+
+- **New pre-publish-audit gate** (`scripts/validate-breaking-manifest.mjs`) — runs as part of every release:
+  - manifest structurally valid (required fields, allowed fields, array shapes)
+  - every `moved.to` path resolves against the current `package.json#exports` (catches stale manifest entries pointing at non-existent subpaths)
+  - **discipline check:** if the current version's CHANGELOG section contains a breaking signal (`feat!` / `**Breaking.`) AND the manifest has no entry for that version → audit fails. Mirrors the `/publish-release` narrowing-is-breaking checklist with tooling teeth.
+
+### Consumer usage
+
+```js
+import manifest from '@devalok/shilp-sutra/BREAKING.json'
+
+const fromV = '0.39.0'
+const toV = '0.40.0'
+// Versions between fromV+1 and toV
+const breaksInRange = Object.entries(manifest.versions).filter(([v]) =>
+  v > fromV && v <= toV,
+)
+// breaksInRange.flatMap(([_, e]) => e.moved) → every import-path change to apply
+// breaksInRange.flatMap(([_, e]) => e.narrowed) → every type narrowing to inspect
+```
+
+Recipes (`docs/recipes/upgrading.md`), `AGENTS.md`, `llms.txt`, and `llms-quick.txt` now route agents at the manifest first, prose second.
+
+### Why minor, not patch
+
+New tarball-shipped file + two new subpath exports = new public API surface. Per `CONTRIBUTING.md → Versioning`, any new public surface is a real semver event → minor under 0.x.
+
+### What this does NOT cover
+
+- The `migrate` CLI from #62 item #5 — deferred. The eslint plugin's `migration` preset already does the mechanical autofixes; a CLI wrapper that reads `BREAKING.json` is a future build.
+- Backfill of pre-0.40.0 breaking changes — added on demand, not retroactively (per the existing codemod policy).

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ build-storybook.log
 
 # Figma sync-script build artifacts (generated from tokens/CVA sources)
 packages/*/scripts/.figma/
+playgrounds-review-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ If you are a human, read [README.md](./README.md) instead.
 3. **`packages/core/docs/recipes/<framework>.md`** — copy-paste install + setup for the user's framework.
 4. **`packages/core/llms-full.txt`** — exhaustive per-component reference (~140K tokens, props/variants/examples). Read only when `llms.txt` is insufficient.
 5. **`packages/core/docs/recipes/upgrading.md`** + **`MIGRATION.md`** — read BOTH before any version bump. See the hard constraint below.
+6. **`node_modules/@devalok/shilp-sutra/BREAKING.json`** — machine-readable manifest of every breaking change per version (moves, type narrowings, removals, renames). Read this programmatically when planning an upgrade — schema in `BREAKING.schema.json`. Lets you answer "does my code import any of these moved symbols?" without parsing CHANGELOG prose.
 
 When the package is installed in a consumer project, the same files live at:
 
@@ -60,7 +61,7 @@ If the framework is not in the table, fall back to **`install-vite.md`** (closes
 
 ## Hard constraints (these break things if violated)
 
-- **On any version bump, do not report it safe before reading the COMPLETE changelog + `MIGRATION.md` for the target version.** Breaking entries are often ordered last (changesets sorts by file, not severity), and breaks are frequently type-level — a prop type narrowed (`React.ReactNode` → a tighter type fails `tsc` for values that compiled before) or a symbol moved from a barrel to a per-component subpath. Grep your codebase for the moved/narrowed symbols, run `typecheck` + `build`, and use the `@devalok/eslint-plugin-shilp-sutra` migration preset for the mechanical edits. Full procedure: `packages/core/docs/recipes/upgrading.md`.
+- **On any version bump, do not report it safe before reading the COMPLETE changelog + `MIGRATION.md` for the target version.** Breaking entries are often ordered last (changesets sorts by file, not severity), and breaks are frequently type-level — a prop type narrowed (`React.ReactNode` → a tighter type fails `tsc` for values that compiled before) or a symbol moved from a barrel to a per-component subpath. **Fastest path: parse `node_modules/@devalok/shilp-sutra/BREAKING.json` for the version range** — it has the structured break data so you can grep your codebase for affected symbols deterministically. Then run `typecheck` + `build` and use the `@devalok/eslint-plugin-shilp-sutra` `migration` preset for the mechanical edits. Full procedure: `packages/core/docs/recipes/upgrading.md`.
 - **Tailwind 4 only.** Do NOT create `tailwind.config.ts` with `presets: [shilpSutra]`. The JS preset was removed in 0.38. Setup uses CSS imports:
   ```css
   @import "tailwindcss";

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,7 @@ Rules:
 3. **The migration ships in the same PR as the breaking change.** The break is not mergeable without it. Reviewer checks: `pnpm changeset` body names the rule, `MIGRATION.md` references it, the rule has test cases.
 4. **Consumer migration is one command:** `pnpm eslint --fix --config node_modules/@devalok/eslint-plugin-shilp-sutra/migration src/`. Document in `MIGRATION.md` next to the manual instructions — codemod first, manual as fallback.
 5. **Backfill on demand, not retroactively.** No obligation for breaks shipped before this policy. Backfill only if a consumer explicitly asks during their upgrade.
+6. **Every break also gets a machine-readable entry in [`packages/core/BREAKING.json`](./packages/core/BREAKING.json).** Same PR. Categorise: `moved` (import-path change), `narrowed` (type accepts less), `renamed`, `removed`, or `notes` (anything else). Schema is `BREAKING.schema.json`. AI agents and migration tooling read this manifest instead of parsing CHANGELOG prose. The `pre-publish-audit` gate fails if a release has a `feat!` / `**Breaking.` CHANGELOG signal without a corresponding manifest entry.
 
 ### Public API surface
 

--- a/packages/core/BREAKING.json
+++ b/packages/core/BREAKING.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "./BREAKING.schema.json",
+  "package": "@devalok/shilp-sutra",
+  "versions": {
+    "0.40.0": {
+      "summary": "Barrel peer-cliff cleanup — 12 symbol families removed from /ui, /composed, /ai barrels (per-component subpath only). Icon API unification narrows the `icon` prop on 14 components from React.ReactNode to IconInput.",
+      "migrationDoc": "MIGRATION.md#v0400--barrel-peer-cliff-cleanup--icon-api-unification",
+      "moved": [
+        { "symbol": "Toaster", "from": "@devalok/shilp-sutra/ui", "to": "@devalok/shilp-sutra/ui/toaster", "peer": "sonner", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "toast", "from": "@devalok/shilp-sutra/ui", "to": "@devalok/shilp-sutra/ui/toast", "peer": "sonner", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "InputOTP", "from": "@devalok/shilp-sutra/ui", "to": "@devalok/shilp-sutra/ui/input-otp", "peer": "input-otp", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "DatePicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "DateRangePicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "DateTimePicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "TimePicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "CalendarGrid", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "MonthPicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "YearPicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "Presets", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "useCalendar", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/date-picker", "peer": "date-fns", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "EmojiPicker", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/emoji-picker", "peer": "@emoji-mart/data", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "EmojiPickerPopover", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/emoji-picker", "peer": "@emoji-mart/data", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "EmojiNode", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/extensions/emoji-node", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "createEmojiSuggestion", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/extensions/emoji-suggestion", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "FilePreview", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/file-preview", "peer": "react-pdf", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "MarkdownViewer", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/markdown-viewer", "peer": "react-markdown", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "RichTextEditor", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-text-editor", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "RichTextViewer", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-text-editor", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "RichChatInput", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-chat-input", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "AudioPlayer", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-chat-input", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "AudioWaveform", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-chat-input", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "useVoiceRecorder", "from": "@devalok/shilp-sutra/composed", "to": "@devalok/shilp-sutra/composed/rich-chat-input", "peer": "@tiptap/react", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "BlockRenderer", "from": "@devalok/shilp-sutra/ai", "to": "@devalok/shilp-sutra/ai/block-renderer", "peer": "react-markdown", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "ErrorBlock", "from": "@devalok/shilp-sutra/ai/blocks", "to": "@devalok/shilp-sutra/ai/blocks/error", "peer": "react-markdown", "eslintRule": "prefer-per-component-import" },
+        { "symbol": "TextBlock", "from": "@devalok/shilp-sutra/ai/blocks", "to": "@devalok/shilp-sutra/ai/blocks/text", "peer": "react-markdown", "eslintRule": "prefer-per-component-import" }
+      ],
+      "narrowed": [
+        {
+          "prop": "icon",
+          "components": [
+            "Combobox option",
+            "Stepper step",
+            "TreeItem",
+            "OAuthButton",
+            "AppCommandPalette",
+            "CommandRegistry",
+            "BottomNavbar",
+            "Sidebar NavItem",
+            "Sidebar NavSubItem",
+            "Sidebar footer.promo",
+            "TopBar UserMenuItem",
+            "Chat.Message.Avatar",
+            "Chat.SystemMessage",
+            "AIConversation agent",
+            "ActivityFeed item",
+            "CommandPalette item",
+            "CommandBar item"
+          ],
+          "from": "React.ReactNode",
+          "to": "IconInput",
+          "fix": "Retype the icon source from React.ReactNode to React.ReactElement (or import the IconInput type). Build-time only; runtime JSX is unaffected."
+        }
+      ]
+    }
+  }
+}

--- a/packages/core/BREAKING.schema.json
+++ b/packages/core/BREAKING.schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shilp-sutra.devalok.in/breaking-manifest.schema.json",
+  "title": "shilp-sutra BREAKING manifest",
+  "description": "Machine-readable record of breaking changes per published version. Lets AI agents and migration tools answer 'what breaks between X and Y?' programmatically instead of parsing CHANGELOG prose. Cumulative — every prior version's breaks remain so a consumer jumping 0.37 → 0.41 can see every break in range.",
+  "type": "object",
+  "required": ["package", "versions"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": { "type": "string" },
+    "package": {
+      "type": "string",
+      "description": "npm package name this manifest covers.",
+      "examples": ["@devalok/shilp-sutra"]
+    },
+    "versions": {
+      "type": "object",
+      "description": "Map of semver version → breaking-change record. A version only appears if it had at least one breaking change. Non-breaking releases are absent (an empty object would falsely signal 'this version had breaks I forgot to document').",
+      "patternProperties": {
+        "^\\d+\\.\\d+\\.\\d+$": { "$ref": "#/$defs/versionEntry" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "versionEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "All breaks shipped in this version. Every present field is an array; omit empty fields entirely. A consumer planning an upgrade reads the union of all entries between current and target version.",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "One-line human summary of the version's breaks. Mirrors the `> ⚠️ Breaking in X.Y.Z` callout in CHANGELOG."
+        },
+        "migrationDoc": {
+          "type": "string",
+          "description": "Relative path inside the package tarball to the human migration guide for this version.",
+          "examples": ["MIGRATION.md#v0400--barrel-peer-cliff-cleanup--icon-api-unification"]
+        },
+        "moved": {
+          "type": "array",
+          "description": "Symbols whose import path changed. Old path no longer exports the symbol; new path does. Consumer fix is a search-and-replace of the import path; prop/type signatures are unchanged.",
+          "items": { "$ref": "#/$defs/move" }
+        },
+        "narrowed": {
+          "type": "array",
+          "description": "Prop types that accept LESS than before. A consumer value valid under the old type may now fail tsc. Not a runtime break. The fix is typically retyping the value's source.",
+          "items": { "$ref": "#/$defs/narrowing" }
+        },
+        "removed": {
+          "type": "array",
+          "description": "Symbols (components, props, variants, exports) deleted with no replacement on the same path. If a renamed-with-deprecation, list under `renamed` instead.",
+          "items": { "$ref": "#/$defs/removal" }
+        },
+        "renamed": {
+          "type": "array",
+          "description": "Symbols whose name changed in place (same import path, new export name) or whose prop name changed (same component, new prop name).",
+          "items": { "$ref": "#/$defs/rename" }
+        },
+        "notes": {
+          "type": "array",
+          "description": "Free-form breaking changes that don't fit the structured categories above (e.g. visual-only changes, DOM structure shifts, default-value flips). Reader must check these manually — the migration is NOT one-shot autofixable.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "move": {
+      "type": "object",
+      "required": ["symbol", "from", "to"],
+      "additionalProperties": false,
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "description": "Exported name as it appears in an import statement.",
+          "examples": ["Toaster", "DatePicker"]
+        },
+        "from": {
+          "type": "string",
+          "description": "Old import path (no longer exports this symbol after this version).",
+          "examples": ["@devalok/shilp-sutra/ui"]
+        },
+        "to": {
+          "type": "string",
+          "description": "New import path (exports this symbol going forward).",
+          "examples": ["@devalok/shilp-sutra/ui/toaster"]
+        },
+        "peer": {
+          "type": "string",
+          "description": "Optional. If this move was driven by a peer-cliff cleanup, the peer dependency the new subpath pulls.",
+          "examples": ["sonner", "input-otp", "date-fns"]
+        },
+        "eslintRule": {
+          "type": "string",
+          "description": "Optional. The `@devalok/eslint-plugin-shilp-sutra` rule that autofixes this move.",
+          "examples": ["prefer-per-component-import"]
+        }
+      }
+    },
+    "narrowing": {
+      "type": "object",
+      "required": ["prop", "components", "from", "to", "fix"],
+      "additionalProperties": false,
+      "properties": {
+        "prop": {
+          "type": "string",
+          "description": "Prop name whose type narrowed.",
+          "examples": ["icon", "startIcon"]
+        },
+        "components": {
+          "type": "array",
+          "description": "Components whose this-prop narrowed. List each affected component explicitly — the same prop name on a component whose type was already narrower than the new type is NOT affected.",
+          "items": { "type": "string" },
+          "examples": [["CommandItem", "ActivityItem", "Chat.Message.Avatar"]]
+        },
+        "from": {
+          "type": "string",
+          "description": "Previous TypeScript type, as a string. Use the exact source form.",
+          "examples": ["React.ReactNode"]
+        },
+        "to": {
+          "type": "string",
+          "description": "New TypeScript type, as a string. Must be a subset of `from` (otherwise it's a widening, not a narrowing).",
+          "examples": ["IconInput"]
+        },
+        "fix": {
+          "type": "string",
+          "description": "One-line consumer fix. Should be actionable from the type alone.",
+          "examples": ["Retype the icon source from React.ReactNode to React.ReactElement."]
+        }
+      }
+    },
+    "removal": {
+      "type": "object",
+      "required": ["symbol", "where"],
+      "additionalProperties": false,
+      "properties": {
+        "symbol": {
+          "type": "string",
+          "examples": ["variant=\"filled\""]
+        },
+        "where": {
+          "type": "string",
+          "description": "What the symbol was on — a component, an import path, or a token namespace.",
+          "examples": ["Alert", "@devalok/shilp-sutra/tailwind"]
+        },
+        "replacement": {
+          "type": "string",
+          "description": "Optional. If a replacement exists at the same site, name it. If there is none, omit.",
+          "examples": ["variant=\"solid\""]
+        },
+        "deprecatedSince": {
+          "type": "string",
+          "description": "Optional. The version that first emitted a deprecation warning, if a cycle was observed.",
+          "examples": ["0.32.0"]
+        }
+      }
+    },
+    "rename": {
+      "type": "object",
+      "required": ["from", "to", "where"],
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "examples": ["isLoadingMore"]
+        },
+        "to": {
+          "type": "string",
+          "examples": ["loadingMore"]
+        },
+        "where": {
+          "type": "string",
+          "description": "Component or import path the rename applies to.",
+          "examples": ["MessageList"]
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["prop", "export", "variant"],
+          "default": "prop"
+        }
+      }
+    }
+  }
+}

--- a/packages/core/docs/recipes/upgrading.md
+++ b/packages/core/docs/recipes/upgrading.md
@@ -16,6 +16,25 @@ A version bump is **not** safe-by-default. Breaking changes in this design syste
 
 ## Step 2 — find affected call sites in your code
 
+**Fastest path — read the machine-readable manifest:**
+
+```bash
+# Lists every break per version as structured data (moves, narrowings, removals)
+cat node_modules/@devalok/shilp-sutra/BREAKING.json
+```
+
+Or programmatically:
+
+```js
+import manifest from '@devalok/shilp-sutra/BREAKING.json'
+// manifest.versions["0.40.0"].moved        → [{ symbol, from, to, peer, eslintRule }, …]
+// manifest.versions["0.40.0"].narrowed     → [{ prop, components, from, to, fix }, …]
+```
+
+Schema: `@devalok/shilp-sutra/BREAKING.schema.json`. AI agents should prefer this over prose-parsing CHANGELOG.
+
+**Or grep manually:**
+
 ```bash
 # Symbols moved out of barrels (0.40.0 peer-cliff cleanup example):
 grep -rn "from '@devalok/shilp-sutra/ui'" src/ | grep -E "Toaster|toast|InputOTP"

--- a/packages/core/llms-quick.txt
+++ b/packages/core/llms-quick.txt
@@ -47,6 +47,8 @@ Per-framework recipes: `node_modules/@devalok/shilp-sutra/docs/recipes/install-<
 
 **Lint + migrate:** `pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`. Catches deprecated APIs, peer-cliff barrel imports, TW3 classes — most autofixable. Use the `migration` preset (`pnpm eslint --fix`) when upgrading across breaking versions.
 
+**Machine-readable breaks:** `node_modules/@devalok/shilp-sutra/BREAKING.json` lists every breaking change per version as structured data (moves, narrowings, removals). Read this for programmatic upgrade planning instead of parsing CHANGELOG prose. Schema: `BREAKING.schema.json`.
+
 ## OPTIONAL PEER DEPENDENCIES (install BEFORE first import)
 
 | When you import…                                          | Install                                                                                                |

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -49,6 +49,7 @@ The repo URL for these files is `https://github.com/devalok-design/shilp-sutra/t
 - **Agent-friendly install experience.** `AGENTS.md` now ships in the tarball (`node_modules/@devalok/shilp-sutra/AGENTS.md`), discoverable by 25+ agent tools. `package.json` declares an `agents` field (npm-agentskills convention) so `pnpm dlx @codemcp/agentskills export` auto-installs the bundled skill. New postinstall welcome banner (silent in CI / non-TTY / `SHILP_SUTRA_NO_WELCOME=1`). `troubleshoot.md` gained peer-cliff symptom entries.
 - **`llms-quick.txt`.** New ≤15K-token fast-path summary in the tarball — fits in one Read on any agent. Read order is now `llms-quick.txt` → `llms.txt` → `llms-full.txt`.
 - **Companion package `@devalok/eslint-plugin-shilp-sutra`** (first release). 12 rules — deprecated-API catches, peer-cliff barrel-import detection, TW3→TW4 classname autofixes. `pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`. Three presets: `recommended`, `strict`, `migration` (one-shot codemod).
+- **Machine-readable `BREAKING.json` manifest** (v0.40.2+). Structured record of every breaking change per version (moves, narrowings, removals, renames). At `node_modules/@devalok/shilp-sutra/BREAKING.json` after install; subpath export `@devalok/shilp-sutra/BREAKING.json`. AI agents and migration tooling read this instead of parsing CHANGELOG prose. Schema at `BREAKING.schema.json`. Pre-publish-audit gate enforces a manifest entry for every release with a breaking CHANGELOG signal.
 
 ## BREAKING CHANGES (v0.40.0)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,8 @@
     },
     "./css": "./dist/tokens/shilp-sutra.css",
     "./tokens": "./dist/tokens/index.css",
+    "./BREAKING.json": "./BREAKING.json",
+    "./BREAKING.schema.json": "./BREAKING.schema.json",
     "./ui": {
       "types": "./dist/ui/index.d.ts",
       "import": "./dist/ui/index.js",
@@ -802,6 +804,8 @@
     "skill",
     "scripts/welcome.mjs",
     "AGENTS.md",
+    "BREAKING.json",
+    "BREAKING.schema.json",
     "MIGRATION.md",
     "README.md",
     "llms.txt",

--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -16,6 +16,7 @@ import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join, resolve } from 'path'
 import { globSync } from 'node:fs'
+import { validate as validateBreakingManifest } from './validate-breaking-manifest.mjs'
 
 const ROOT = resolve(import.meta.dirname, '..')
 const PASS = '\x1b[32m✓\x1b[0m'
@@ -783,6 +784,17 @@ gate('llms-quick.txt ≤ 15K tokens (≈60KB)', () => {
     return `llms-quick.txt is ~${approxTokens} tokens (${content.length} chars). Cap is 15K — trim before publishing. The quick file's value is fitting in one Read; let llms.txt absorb the overflow.`
   }
   return true
+})
+
+// Gate: BREAKING.json manifest validates + a current-version with a breaking
+// CHANGELOG signal has a corresponding manifest entry. Mirrors the
+// /publish-release narrowing-is-breaking checklist with tooling teeth — if a
+// `feat!` lands without structured manifest data, AI agents and migration
+// tooling can't answer "what breaks" programmatically.
+gate('BREAKING.json manifest valid + complete for current version', () => {
+  const r = validateBreakingManifest()
+  if (r.ok) return true
+  return r.errors.map((e) => `       ${e}`).join('\n').replace(/^ +/, '')
 })
 
 // --- New Gates (added by ecosystem audit 2026-04-06) ---

--- a/scripts/validate-breaking-manifest.mjs
+++ b/scripts/validate-breaking-manifest.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * validate-breaking-manifest.mjs
+ *
+ * Validates `packages/core/BREAKING.json` against `BREAKING.schema.json` and
+ * cross-checks against repo state:
+ *
+ *   1. Structural — required fields, allowed fields, array shapes.
+ *   2. `moved.to` paths exist in `packages/core/package.json#exports`.
+ *   3. Discipline gate — current version's CHANGELOG with a breaking signal
+ *      (`feat!` / `**Breaking.`) MUST have a manifest entry. Catches the
+ *      class of mistake that produced the F-10 mislabel.
+ *
+ * Exposes `validate()` for the pre-publish-audit gate AND runs as a CLI.
+ */
+
+import { readFileSync, existsSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CORE = join(ROOT, 'packages/core')
+const MANIFEST_PATH = join(CORE, 'BREAKING.json')
+const SCHEMA_PATH = join(CORE, 'BREAKING.schema.json')
+const PKG_PATH = join(CORE, 'package.json')
+const CHANGELOG_PATH = join(CORE, 'CHANGELOG.md')
+
+/**
+ * Validate BREAKING.json. Returns { ok: boolean, errors: string[], versions: string[] }.
+ * No process.exit — leaves that to callers.
+ */
+export function validate() {
+  const errors = []
+  const fail = (m) => errors.push(m)
+
+  if (!existsSync(MANIFEST_PATH)) {
+    return { ok: false, errors: ['BREAKING.json missing at packages/core/'], versions: [] }
+  }
+  if (!existsSync(SCHEMA_PATH)) {
+    return { ok: false, errors: ['BREAKING.schema.json missing at packages/core/'], versions: [] }
+  }
+
+  let manifest, pkg
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8'))
+  } catch (e) {
+    return { ok: false, errors: [`BREAKING.json is not valid JSON: ${e.message}`], versions: [] }
+  }
+  try {
+    pkg = JSON.parse(readFileSync(PKG_PATH, 'utf-8'))
+  } catch (e) {
+    return { ok: false, errors: [`packages/core/package.json is not valid JSON: ${e.message}`], versions: [] }
+  }
+
+  const currentVersion = pkg.version
+
+  if (manifest.package !== pkg.name) {
+    fail(`manifest.package ("${manifest.package}") must equal packages/core/package.json#name ("${pkg.name}")`)
+  }
+  if (!manifest.versions || typeof manifest.versions !== 'object') {
+    fail('manifest.versions must be an object')
+  }
+
+  const semverRe = /^\d+\.\d+\.\d+$/
+  const allowedFields = new Set(['summary', 'migrationDoc', 'moved', 'narrowed', 'removed', 'renamed', 'notes'])
+  for (const v of Object.keys(manifest.versions || {})) {
+    if (!semverRe.test(v)) fail(`version key "${v}" is not a valid X.Y.Z semver`)
+    const entry = manifest.versions[v]
+    for (const k of Object.keys(entry)) {
+      if (!allowedFields.has(k)) fail(`${v}: unknown field "${k}" — allowed: ${[...allowedFields].join(', ')}`)
+    }
+    for (const arrKey of ['moved', 'narrowed', 'removed', 'renamed', 'notes']) {
+      if (entry[arrKey] != null && !Array.isArray(entry[arrKey])) {
+        fail(`${v}.${arrKey} must be an array`)
+      }
+    }
+    for (const m of entry.moved || []) {
+      for (const r of ['symbol', 'from', 'to']) {
+        if (!m[r] || typeof m[r] !== 'string') fail(`${v}.moved entry missing/empty required string "${r}": ${JSON.stringify(m)}`)
+      }
+    }
+    for (const n of entry.narrowed || []) {
+      for (const r of ['prop', 'components', 'from', 'to', 'fix']) {
+        if (n[r] == null) fail(`${v}.narrowed entry missing required field "${r}": ${JSON.stringify(n)}`)
+      }
+      if (!Array.isArray(n.components) || n.components.length === 0) {
+        fail(`${v}.narrowed entry must have non-empty components array: ${JSON.stringify(n)}`)
+      }
+    }
+  }
+
+  // moved.to paths must exist in package.json exports
+  const exportPaths = new Set(Object.keys(pkg.exports || {}))
+  const prefix = pkg.name + '/'
+  for (const v of Object.keys(manifest.versions || {})) {
+    for (const m of (manifest.versions[v].moved || [])) {
+      if (!m.to.startsWith(prefix)) {
+        fail(`${v} moved: \`to\` ("${m.to}") must start with "${prefix}"`)
+        continue
+      }
+      const rel = './' + m.to.slice(prefix.length)
+      if (!exportPaths.has(rel)) {
+        fail(`${v} moved: \`to\` path "${m.to}" → "${rel}" is not in packages/core/package.json#exports. Either add the subpath export or fix the manifest entry.`)
+      }
+    }
+  }
+
+  // Discipline gate: current version with breaking CHANGELOG signal MUST have a manifest entry.
+  if (existsSync(CHANGELOG_PATH)) {
+    const changelog = readFileSync(CHANGELOG_PATH, 'utf-8').replace(/\r\n/g, '\n')
+    const head = changelog.search(/^## /m)
+    if (head !== -1) {
+      const after = changelog.slice(head + 3)
+      const nextRel = after.search(/^## /m)
+      const section = changelog.slice(head, nextRel === -1 ? changelog.length : head + 3 + nextRel)
+      const versionMatch = section.match(/^## (\S+)/)
+      if (versionMatch && versionMatch[1] === currentVersion) {
+        const BREAKING_RE = /\b(?:feat|fix|perf|refactor|build|chore)!|!:|(?<!non[- ])\*\*Breaking[.:]/i
+        if (BREAKING_RE.test(section) && !manifest.versions[currentVersion]) {
+          fail(
+            `CHANGELOG.md ${currentVersion} contains a breaking signal (feat! / **Breaking.) but BREAKING.json has no entry for ${currentVersion}. Add the structured break data so AI agents and migration tooling can read it programmatically (see packages/core/BREAKING.schema.json).`,
+          )
+        }
+      }
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    versions: Object.keys(manifest.versions || {}),
+  }
+}
+
+// CLI entry — only when invoked directly.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+if (invokedDirectly) {
+  const r = validate()
+  if (r.ok) {
+    console.log(`✓ BREAKING.json validates — ${r.versions.length} version(s): ${r.versions.join(', ') || '(none)'}`)
+    process.exit(0)
+  }
+  console.error(`✗ BREAKING.json validation FAILED — ${r.errors.length} issue(s):`)
+  for (const e of r.errors) console.error(`  • ${e}`)
+  process.exit(1)
+}


### PR DESCRIPTION
Closes the structured-data half of #62. AI agents and migration tooling can now answer "what breaks between X and Y?" programmatically instead of parsing CHANGELOG prose.

## What ships
- `packages/core/BREAKING.json` — populated with the full 0.40.0 data (27 barrel→subpath moves + the 17-component Icon API narrowing). Categorised: `moved` / `narrowed` / `removed` / `renamed` / `notes`. Each `moved` entry carries `peer` + `eslintRule` cross-refs.
- `packages/core/BREAKING.schema.json` — canonical JSON Schema. Editors auto-validate via `$schema`.
- Two new subpath exports — `@devalok/shilp-sutra/BREAKING.json` + `@devalok/shilp-sutra/BREAKING.schema.json` so consumers can `import manifest from '@devalok/shilp-sutra/BREAKING.json'`. Both ship in the tarball (`files[]`).

## Publish-mechanism enforcement
- `scripts/validate-breaking-manifest.mjs` — exports `validate()` (audit calls it) + runs as CLI. Three checks:
  - structural: required/allowed fields, array shapes
  - every `moved.to` path resolves against current `package.json#exports` (no stale subpath references)
  - **discipline gate:** if the current version's CHANGELOG has a breaking signal (`feat!` / `**Breaking.`) AND no manifest entry exists for that version → audit fails
- New gate added to `pre-publish-audit.mjs`. Mirrors the `/publish-release` narrowing-is-breaking checklist with tooling teeth.

## Docs routed at the manifest
- `CONTRIBUTING` § Codemod policy — rule 6 (manifest entry required for any break)
- `llms.txt` + `llms-quick.txt` + `AGENTS.md` — tell agents to read the manifest first
- `docs/recipes/upgrading.md` — leads with the manifest, grep as fallback

## Why minor, not patch
New tarball-shipped file + two new subpath exports = new public surface → minor under 0.x per `CONTRIBUTING § Versioning`.

## Not in this PR
- `migrate` CLI (#62 item 5) — deferred. The eslint plugin's `migration` preset already does the mechanical autofixes; a CLI wrapper reading BREAKING.json is a future build.
- Backfill of pre-0.40.0 entries — on demand, not retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)