### PR TITLE
fix(release): regen skill refs in CI (kill email spam class)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,16 @@ jobs:
       - name: SSR smoke test (no browser APIs in Node.js)
         run: node packages/core/scripts/ssr-smoke-test.mjs
 
+      # Regenerate skill references from sources BEFORE the audit's drift
+      # gate runs. The skill refs are auto-copied from llms.txt /
+      # llms-full.txt / docs/recipes/*.md by `build-skill.mjs`; without a
+      # regen here, any PR that edits a source file but doesn't also commit
+      # the regenerated ref makes the audit fail post-merge (the email-spam
+      # we hit on 2026-05-27 and again on 2026-05-28). Generating here lets
+      # the audit compare like-for-like.
+      - name: Regenerate Agent Skill references
+        run: node scripts/build-skill.mjs
+
       # Pre-publish audit runs every HARD gate (git state, version/CHANGELOG
       # consistency, docs coverage, token audits, TW4 migration hygiene).
       # Previously this only ran on a developer's laptop via /publish-release.

--- a/skills/shilp-sutra/references/components.md
+++ b/skills/shilp-sutra/references/components.md
@@ -51,6 +51,7 @@ The repo URL for these files is `https://github.com/devalok-design/shilp-sutra/t
 - **Agent-friendly install experience.** `AGENTS.md` now ships in the tarball (`node_modules/@devalok/shilp-sutra/AGENTS.md`), discoverable by 25+ agent tools. `package.json` declares an `agents` field (npm-agentskills convention) so `pnpm dlx @codemcp/agentskills export` auto-installs the bundled skill. New postinstall welcome banner (silent in CI / non-TTY / `SHILP_SUTRA_NO_WELCOME=1`). `troubleshoot.md` gained peer-cliff symptom entries.
 - **`llms-quick.txt`.** New ≤15K-token fast-path summary in the tarball — fits in one Read on any agent. Read order is now `llms-quick.txt` → `llms.txt` → `llms-full.txt`.
 - **Companion package `@devalok/eslint-plugin-shilp-sutra`** (first release). 12 rules — deprecated-API catches, peer-cliff barrel-import detection, TW3→TW4 classname autofixes. `pnpm add -D @devalok/eslint-plugin-shilp-sutra`, then `shilpSutra.configs['flat/recommended']`. Three presets: `recommended`, `strict`, `migration` (one-shot codemod).
+- **Machine-readable `BREAKING.json` manifest** (v0.40.2+). Structured record of every breaking change per version (moves, narrowings, removals, renames). At `node_modules/@devalok/shilp-sutra/BREAKING.json` after install; subpath export `@devalok/shilp-sutra/BREAKING.json`. AI agents and migration tooling read this instead of parsing CHANGELOG prose. Schema at `BREAKING.schema.json`. Pre-publish-audit gate enforces a manifest entry for every release with a breaking CHANGELOG signal.
 
 ## BREAKING CHANGES (v0.40.0)
 

--- a/skills/shilp-sutra/references/upgrading.md
+++ b/skills/shilp-sutra/references/upgrading.md
@@ -18,6 +18,25 @@ A version bump is **not** safe-by-default. Breaking changes in this design syste
 
 ## Step 2 — find affected call sites in your code
 
+**Fastest path — read the machine-readable manifest:**
+
+```bash
+# Lists every break per version as structured data (moves, narrowings, removals)
+cat node_modules/@devalok/shilp-sutra/BREAKING.json
+```
+
+Or programmatically:
+
+```js
+import manifest from '@devalok/shilp-sutra/BREAKING.json'
+// manifest.versions["0.40.0"].moved        → [{ symbol, from, to, peer, eslintRule }, …]
+// manifest.versions["0.40.0"].narrowed     → [{ prop, components, from, to, fix }, …]
+```
+
+Schema: `@devalok/shilp-sutra/BREAKING.schema.json`. AI agents should prefer this over prose-parsing CHANGELOG.
+
+**Or grep manually:**
+
 ```bash
 # Symbols moved out of barrels (0.40.0 peer-cliff cleanup example):
 grep -rn "from '@devalok/shilp-sutra/ui'" src/ | grep -E "Toaster|toast|InputOTP"


### PR DESCRIPTION
Two-part fix.

**Immediate:** regenerate `components.md` + `upgrading.md` skill refs that #72 left stale. PR #72 edited their `llms.txt` + recipe sources but didn't commit the auto-copied skill outputs → release audit drift gate failed → another email-spam round.

**Structural:** add `Regenerate Agent Skill references` step to `release.yml` that runs `build-skill.mjs` BEFORE `pre-publish-audit`. Eliminates this whole class of failure — any future PR touching `llms.txt` / recipes / `llms-full.txt` will get the refs regenerated in CI before audit compares them. The audit then compares like-for-like instead of catching maintainer-forgot-to-regen drift.

This is the proper fix for the recurring email-spam issue (hit 2026-05-27 with #48, 2026-05-28 again with #72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)