### PR TITLE
fix(site): route version mentions through SHILP_SUTRA_MINOR + drop brand transpile

### DIFF
--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata, Viewport } from 'next'
 import { BrandInit } from '@/components/brand-init'
 import { ThemeInit } from '@/components/theme-init'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 import './globals.css'
 
 const SITE_URL = 'https://shilp-sutra.devalok.in'
 const SITE_TITLE = 'shilp-sutra · Devalok Design System'
 const SITE_DESCRIPTION =
-  'Your brand. Every component. Out of the box. A React design system from Devalok. Tailwind 4, OKLCH tokens, 119 components. Public beta v0.40.'
+  `Your brand. Every component. Out of the box. A React design system from Devalok. Tailwind 4, OKLCH tokens, 119 components. Public beta v${SHILP_SUTRA_MINOR}.`
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/apps/site/app/opengraph-image.tsx
+++ b/apps/site/app/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 
 /**
  * Dynamic Open Graph image for the homepage.
@@ -71,7 +72,7 @@ export default async function OpengraphImage() {
               color: 'oklch(0.4 0.12 360)',
             }}
           >
-            From Devalok · Public beta v0.40
+            From Devalok · Public beta v{SHILP_SUTRA_MINOR}
           </div>
         </div>
 

--- a/apps/site/components/landing-surface.tsx
+++ b/apps/site/components/landing-surface.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tabler/icons-react'
 import { Avatar, AvatarFallback } from '@devalok/shilp-sutra/ui/avatar'
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
@@ -29,7 +30,7 @@ type Activity = {
 }
 
 const initialActivity: Activity[] = [
-  { who: 'Mudit', initials: 'ML', what: 'shipped v0.39 · Agent Skill + site v1', when: '14 min ago', tag: 'release' },
+  { who: 'Mudit', initials: 'ML', what: `shipped v${SHILP_SUTRA_MINOR} · BREAKING.json manifest + recipe polish`, when: '14 min ago', tag: 'release' },
   { who: 'Goutham', initials: 'GP', what: 'pushed Button accessibility audit fixes', when: '38 min ago', tag: 'fix' },
   { who: 'Yogin', initials: 'YS', what: 'reviewed the Atlas showcase composition', when: '1 hr ago', tag: 'review' },
   { who: 'Amal', initials: 'AM', what: 'opened a PR for Skeleton variants', when: '3 hr ago', tag: 'design' },
@@ -120,7 +121,7 @@ export function LandingSurface() {
             </header>
 
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-ds-03">
-              <Stat label="Components" value="119" hint="3 added in v0.39" />
+              <Stat label="Components" value="119" hint={`current: v${SHILP_SUTRA_MINOR}`} />
               <Stat label="Showcases live" value="6" hint="industries covered" />
               <Stat label="Tests passing" value="2,107" hint="100% on main" />
             </div>

--- a/apps/site/content/blocks/dashboard/block.tsx
+++ b/apps/site/content/blocks/dashboard/block.tsx
@@ -13,6 +13,7 @@ import {
 import { Avatar, AvatarFallback } from '@devalok/shilp-sutra/ui/avatar'
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
 import { Button } from '@devalok/shilp-sutra/ui/button'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
 
@@ -29,7 +30,7 @@ const activity: Activity[] = [
   { who: 'Goutham', initials: 'GP', what: 'pushed 4 component fixes to Padmavarna v2 audit', when: '12 min ago', tag: 'fix' },
   { who: 'Yogin', initials: 'YS', what: 'opened a PR adding Skeleton variants for charts', when: '38 min ago', tag: 'feat' },
   { who: 'Amal', initials: 'AM', what: 'reviewed Karm onboarding flow, left 6 comments', when: '1 hr ago', tag: 'review' },
-  { who: 'Mudit', initials: 'ML', what: 'cut v0.39 with the Agent Skill bundle and site v1', when: '3 hr ago', tag: 'release' },
+  { who: 'Mudit', initials: 'ML', what: `cut v${SHILP_SUTRA_MINOR} with the BREAKING.json manifest and recipe polish`, when: '3 hr ago', tag: 'release' },
 ]
 
 type NavItem = { icon: typeof IconHome; label: string; active?: boolean }

--- a/apps/site/content/components/alert.preview.tsx
+++ b/apps/site/content/components/alert.preview.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { Alert } from '@devalok/shilp-sutra/ui/alert'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 
 export function AlertHero() {
   return (
     <div className="max-w-xl">
-      <Alert color="info" title="shilp-sutra v0.39 is live">
-        Agent Skill bundle and the marketing site shipped together. The skill installs in one curl.
+      <Alert color="info" title={`shilp-sutra v${SHILP_SUTRA_MINOR} is live`}>
+        Machine-readable BREAKING.json manifest, Next.js recipe polish, and the
+        usual Devalok improvements. Patch path stays one command.
       </Alert>
     </div>
   )

--- a/apps/site/content/components/card.preview.tsx
+++ b/apps/site/content/components/card.preview.tsx
@@ -4,14 +4,15 @@ import { Badge } from '@devalok/shilp-sutra/ui/badge'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
+import { SHILP_SUTRA_VERSION } from '@/lib/version'
 
 export function CardHero() {
   return (
     <div className="max-w-md">
       <Card>
         <CardHeader>
-          <CardTitle>Daily release</CardTitle>
-          <CardDescription>v0.40.0 ships Sunday. Skill bundle + site v1 already live.</CardDescription>
+          <CardTitle>Latest release</CardTitle>
+          <CardDescription>v{SHILP_SUTRA_VERSION} is live. BREAKING.json manifest, recipe polish, and the usual Devalok improvements.</CardDescription>
         </CardHeader>
         <CardContent>
           <Text variant="body-sm" className="text-surface-fg-muted">

--- a/apps/site/content/components/tabs.preview.tsx
+++ b/apps/site/content/components/tabs.preview.tsx
@@ -2,6 +2,7 @@
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@devalok/shilp-sutra/ui/tabs'
 import { Text } from '@devalok/shilp-sutra/ui/text'
+import { SHILP_SUTRA_MINOR } from '@/lib/version'
 
 export function TabsHero() {
   return (
@@ -21,7 +22,7 @@ export function TabsHero() {
         </TabsContent>
         <TabsContent value="changelog" className="pt-ds-04">
           <Text variant="body-sm" className="text-surface-fg-muted">
-            v0.39 · Agent Skill bundle, marketing site v1, /theming editor (this site).
+            v{SHILP_SUTRA_MINOR} · BREAKING.json manifest, Next.js recipe polish, release skill-regen automation.
           </Text>
         </TabsContent>
         <TabsContent value="discussion" className="pt-ds-04">

--- a/apps/site/next.config.ts
+++ b/apps/site/next.config.ts
@@ -36,7 +36,7 @@ const config: NextConfig = {
         outputFileTracingRoot: repoRoot,
       }
     : {}),
-  transpilePackages: ['@devalok/shilp-sutra', '@devalok/shilp-sutra-brand'],
+  transpilePackages: ['@devalok/shilp-sutra'],
   images: {
     remotePatterns: [
       { protocol: 'https', hostname: 'images.unsplash.com' },


### PR DESCRIPTION
Site was stuck showing v0.39/v0.40 mentions weeks after 0.41.0 shipped because seven surfaces hardcoded the version. `lib/version.ts` already sources from `packages/core/package.json` at build time via `NEXT_PUBLIC_SHILP_SUTRA_VERSION` (Next env replacement) — the infra was right, the surfaces weren't using it.

## What now auto-syncs
- `app/layout.tsx` metadata description (the `<head>` blurb)
- `app/opengraph-image.tsx` social-card text (link previews on Twitter/LinkedIn/Slack)
- `components/landing-surface.tsx` (mock activity feed + components stat)
- `content/blocks/dashboard/block.tsx` (mock activity)
- `content/components/alert.preview.tsx` (Alert hero example)
- `content/components/card.preview.tsx` (Card hero — uses full `SHILP_SUTRA_VERSION`)
- `content/components/tabs.preview.tsx` (Tabs hero changelog)

Railway redeploys on every main push, so the next deploy picks up 0.41.0 automatically. Every future bump propagates without site edits.

## Also
Dropped `@devalok/shilp-sutra-brand` from `next.config.ts` `transpilePackages` — internal brand package isn't used in the site, leftover from before the 0.40 brand de-emphasis.

Site typechecks + builds clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)