### PR TITLE
feat(make-kit): ship Figma Make kit guidelines

### DIFF
--- a/.changeset/figma-make-kit.md
+++ b/.changeset/figma-make-kit.md
@@ -1,0 +1,17 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Ship Figma Make kit guidelines. New `make-kit/` directory in the published tarball at `node_modules/@devalok/shilp-sutra/make-kit/` containing:
+
+- `Guidelines.md` — top-level entry, product character + mandatory rules.
+- `setup.md` — install + provider tree + Vite config.
+- `foundations/` — 7 files (color, typography, spacing, surfaces, radius, motion, dark-mode, icons).
+- `components/overview.md` — catalog + decision trees across actions / inputs / overlays / feedback / nav / layout / data display.
+- `components/{button,card,input,dialog,badge,select,tabs,toast,form,table,dropdown-menu,popover,text,stack,icon}.md` — 15 component deep guides.
+
+Authored for Figma Make to consume when registering this package as a Make kit (per https://developers.figma.com/docs/code/bring-your-design-system-package/). Use these files as paste-in content when configuring the kit in Figma Make.
+
+New subpath exports: `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `@devalok/shilp-sutra/make-kit/*` → individual files.
+
+Smoke-tested in a fresh Vite 8 + React 19 + TW4 + framer-motion 12 app — build green, dev server clean, DS utilities emit. shilp-sutra is Figma Make kit eligible as of this release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,16 @@ Before writing "non-breaking" / "type widening only" on any prop-type change, cl
 
 When unsure whether old ⊂ new or new ⊂ old, write a `@ts-expect-error`/`expectTypeOf` probe with a value valid under the old type (a `Record<string, ReactNode>` entry, a `string`) and check it still compiles against the new type. If it doesn't, it's a narrowing → breaking.
 
+## Figma Make Kit
+
+`packages/core/make-kit/` ships in the npm tarball. 26 files: `Guidelines.md` + `setup.md` + 7 `foundations/*.md` + `components/overview.md` + 15 per-component guides. Authored to be pasted into Figma Make when registering shilp-sutra as a Make kit (https://developers.figma.com/docs/code/bring-your-design-system-package/).
+
+Subpath exports: `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `@devalok/shilp-sutra/make-kit/*` → individual files.
+
+**Authoring rules.** Voice is direct + prescriptive, no marketing copy. Sections per component: import → When to use → Variants/Colors/Sizes tables → Props table → Examples (4–6) → Rules. Props/defaults MUST come from `llms-full.txt` or actual CVA source — when those disagree, the source code wins (caught one stale `llms-full.txt` Form section during initial authoring). When updating components in `src/ui/`, also update the matching `make-kit/components/*.md` if the prop surface changed.
+
+Smoke-tested 2026-06-01 in fresh Vite 8 + React 19 + TW4 + framer-motion 12 app. Build/dev/utility emission all green. Make eligibility confirmed pending only the human registration step in Figma UI.
+
 ## Storybook MCP Server
 
 When the Storybook dev server is running (`pnpm dev`), an MCP server at `localhost:6006/mcp` provides AI agents with:

--- a/packages/core/make-kit/Guidelines.md
+++ b/packages/core/make-kit/Guidelines.md
@@ -1,0 +1,71 @@
+# shilp-sutra — Figma Make Kit Guidelines
+
+> **Read order.** This is the entry point. Read `setup.md` next, then `foundations/overview.md`, then `components/overview.md`. Branch into specific token / component files on demand.
+
+## What this is
+
+`@devalok/shilp-sutra` is the Devalok design system: React 18/19 components built on vendored Radix primitives, OKLCH design tokens, CSS-first Tailwind 4. Generated apps must use these components instead of raw HTML elements wherever a matching component exists.
+
+## Product character
+
+| Trait | Value |
+|---|---|
+| Density | Mid. Default `md` size on controls. Reach for `sm` only inside dense toolbars, tables, filter bars. |
+| Color philosophy | ~90% neutral surfaces, accent color used sparingly for primary action + status. Brand accent is OKLCH magenta by default, but the kit is themable — never hardcode hex. |
+| Corner radius | Semantic roles (`--radius-control`, `--radius-surface`, `--radius-overlay`). Default preset = "slightly-rounded" (6/10/16 px). Never hand-pick radii. |
+| Elevation | Five surface tiers (`surface-base`, `raised`, `sunken`, `overlay`, `inverted`). Cards sit on `raised`, dialogs on `overlay`. Never combine an explicit `border-*` with a `shadow-*` token — shadow tokens already contain a hairline ring layer. |
+| Motion | framer-motion is a required peer. Wrap apps in `<MotionProvider reducedMotion="user">` once. Use motion primitives (`MotionFade`, `MotionCollapse`, `MotionSlide`) instead of CSS keyframes. |
+| Dark mode | `.dark` class on `<html>` or `<body>` flips every token. Algorithmically derived from OKLCH curves — surfaces lighten with elevation. |
+
+## Mandatory rules
+
+These are not preferences. Generated code that violates them is wrong.
+
+1. **Use design system components, not raw HTML.** `<Button>` not `<button>`. `<Input>` not `<input>`. `<Text>` not `<span>`/`<p>` (when typographic semantics matter). `<Stack>` not bare flex divs.
+2. **Use semantic tokens, never hex / rgb / hsl.** `bg-surface-raised` not `bg-white`. `text-fg` not `text-zinc-900`. `bg-accent-9` not `bg-pink-500`.
+3. **Spacing uses `ds-*` cadence.** `p-ds-05`, `gap-ds-03`. Never `p-4` / `p-6`. Default cadence is `ds-03 / ds-05 / ds-07` (related items / grouped sections / page sections). Do not reach for every adjacent token (`ds-04`, `ds-06`) — three tiers, not five.
+4. **Prefer `variant="soft"` over `variant="outline"` for non-primary actions.** Soft (tinted bg, no visible border) reads better in data-dense UIs. Outline only when on a colored bg or paired with a primary for explicit hierarchy.
+5. **Surface layering is strict.** Page = `surface-base`. Cards/panels/widgets = `surface-raised`. Dialogs/popovers/dropdowns/inputs = `surface-overlay`. Shell chrome (sidebar, topbar) = `surface-sunken`. Tooltips = `surface-inverted`. If you're unsure, read `foundations/surfaces.md`.
+6. **Never combine `border-*` + `shadow-*` tokens.** Shadow tokens already include a 1px ring layer. Adding an explicit border creates a 2-px edge.
+7. **Icons use `<Icon icon={...} />` from `@tabler/icons-react`.** Do not import lucide, heroicons, mui-icons. The icon system auto-sizes via `IconProvider` context.
+8. **Toasts mount once at app root.** `<Toaster />` (singleton). All triggering is imperative: `toast.success("...")`, `toast.error("...")`.
+9. **Forms wire via `<FormField>`.** It auto-binds `<Label htmlFor>` ↔ `<Input id>` via context. Do not hand-generate ids.
+10. **Dialog is responsive by default.** It auto-fullScreens on mobile (<768px). Sheet auto-bottom-drawer. Popover auto-drawer. Opt out with `responsive={false}` only when explicitly needed.
+
+## Workflow — before generating any screen
+
+1. **Identify the layout shell.** AppSidebar + TopBar for product pages. Container + Stack for marketing. Dialog/Sheet for modal flows.
+2. **Pick the surface for each region.** Read `foundations/surfaces.md`. Default page bg is `surface-base`; everything else stacks up from there.
+3. **Pick components from `components/overview.md`.** That file has decision trees for the common confusions (Button variant, Input vs Combobox vs Autocomplete, Dialog vs Sheet vs Popover).
+4. **Lay things out with `<Stack>` + `<Container>`.** Use `gap-ds-03/05/07`. Don't reach for arbitrary flex divs.
+5. **Apply state via component props, not classnames.** Loading? `loading` prop on Button. Error state on Input? `state="error"`. Disabled? `disabled`. Don't simulate states with className overrides.
+
+## Workflow — before using a component
+
+1. Read its component guideline in `components/`. Each lists variants, props, and at least 3 correct examples.
+2. Check the "Don't" section at the bottom of the file. Most common mistakes are listed there.
+3. If a prop you want isn't documented, it probably doesn't exist — don't invent one.
+
+## Guidelines map
+
+| File | When to read |
+|---|---|
+| `setup.md` | Always. Required imports + provider setup. |
+| `foundations/color.md` | Choosing background / text / border color. Decision tree for status colors. |
+| `foundations/typography.md` | Picking text size / weight. Heading vs body hierarchy. |
+| `foundations/spacing.md` | Picking gap / padding. The three-tier cadence rule. |
+| `foundations/surfaces.md` | Picking which surface tier a region sits on. Includes the surface decision matrix. |
+| `foundations/radius.md` | When to override a radius role. Shape presets (`sharp` / `slightly-rounded` / `rounded`). |
+| `foundations/motion.md` | Adding transitions, list stagger, drawer slides. framer-motion primitives. |
+| `foundations/dark-mode.md` | Wiring the `.dark` toggle. How tokens behave in dark mode. |
+| `foundations/icons.md` | Using Tabler icons, sizing via IconProvider. |
+| `components/overview.md` | Catalog of all major components with decision trees. Read before picking a component. |
+| `components/{name}.md` | Deep guide per component. Variants, props, examples, rules. |
+
+## What this kit excludes
+
+- Raw HTML form elements (use `<Input>`, `<Select>`, `<Combobox>`, `<Textarea>`, etc.)
+- Tailwind utility colors (`text-zinc-*`, `bg-blue-*`) — use semantic tokens
+- Custom icon libraries — Tabler only
+- CSS-in-JS at runtime — utilities + tokens cover styling
+- React Router / Next.js Link primitives — use `<Link>` from the kit; consumers wire their router via `LinkProvider`

--- a/packages/core/make-kit/components/badge.md
+++ b/packages/core/make-kit/components/badge.md
@@ -1,0 +1,162 @@
+# Badge
+
+Small inline status / label / chip. Counts, statuses, tags, filter chips.
+
+```tsx
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+```
+
+## When to use
+
+- Status pill on a row (Active / Pending / Failed).
+- Filter chip with optional dismiss X.
+- Selectable tag (multi-select chips).
+- Count indicator on an Avatar / Icon / Button — use `<Badge.Indicator>`.
+- A horizontal cluster of tags — wrap in `<Badge.Group>` with optional `max`.
+
+Not for in-flow text emphasis — use `<Text variant="label-*">` or `<Code>`.
+
+## Variants
+
+| Variant | When |
+|---|---|
+| `subtle` (default) | Tinted bg, colored border. Most common. |
+| `solid` | Filled background, on-color text. Use for high-emphasis statuses (e.g. red error). |
+| `outline` | Border-only, transparent bg. Use on already-tinted backgrounds. |
+| `soft` | Tinted bg, no border. Lighter than `subtle`. Use in dense lists. |
+
+## Colors
+
+| Color | Use |
+|---|---|
+| `default` (default) | Neutral / generic. |
+| `accent` | Brand-aligned tag. |
+| `error` | Failed / blocked / critical. |
+| `success` | Active / completed / healthy. |
+| `warning` | Caution / overdue. |
+| `info` | Informational / new. |
+| `neutral` | Brand-agnostic muted tag. |
+| `teal`, `amber`, `slate`, `indigo`, `cyan`, `orange`, `emerald` | Categorical (Kanban columns, project labels). Pick distinct hues per category. |
+| `custom` | Drives off `--badge-color` (and `--badge-fg-color` for solid) inline CSS vars. |
+
+## Sizes
+
+| Size | When |
+|---|---|
+| `xs` | Inline next to a 14 px text run. |
+| `sm` | Filter chips, dense tables. |
+| `md` (default) | Standard row pills. |
+| `lg` | Hero / marketing badges. |
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `variant` | `'subtle'\|'solid'\|'outline'\|'soft'` | Default `subtle`. |
+| `color` | See colors table | Default `default`. |
+| `size` | `'xs'\|'sm'\|'md'\|'lg'` | Default `md`. |
+| `startIcon` | `ReactElement` | Use `<Icon icon={IconX} />` — auto-sized. |
+| `endIcon` | `ReactElement` | Same. |
+| `dot` | `boolean` | Animated leading status dot. Use for live-state badges. |
+| `onClick` | `() => void` | Renders as `<button>` — interactive badge. |
+| `selected` | `boolean` | Toggle state — shows a check icon. Pair with `onClick`. |
+| `disabled` | `boolean` | Reduced opacity + pointer-events-none. |
+| `onDismiss` | `() => void` | Inline X button for filter chips. |
+| `maxWidth` | `number` | Triggers truncation with `title` tooltip. |
+| `truncate` | `boolean` | Ellipsis overflow without explicit maxWidth. |
+| `circle` | `boolean` | Square aspect-ratio (icon-only / count badges). |
+| `asChild` | `boolean` | Merge with a child (router Link, etc.). |
+
+## Interactive modes
+
+| Combo | Renders as | Use |
+|---|---|---|
+| `onClick` only | `<button>` | Selectable tag, filter chip. |
+| `onDismiss` only | `<span>` with inner X button | Read-only chip with dismiss. |
+| `onClick` + `onDismiss` | `<div role="button">` | Selectable + dismissible (avoids nested buttons). |
+
+## Examples
+
+**Status pill:**
+```tsx
+<Badge variant="solid" color="success">Active</Badge>
+<Badge color="warning">Overdue</Badge>
+<Badge color="error" dot>Failed</Badge>
+```
+
+**Dismissible filter chip:**
+```tsx
+<Badge color="accent" onDismiss={() => removeFilter('react')}>
+  React
+</Badge>
+```
+
+**Selectable tag (toggle):**
+```tsx
+<Badge
+  onClick={() => toggleTag('design')}
+  selected={selectedTags.has('design')}
+  color="accent"
+>
+  Design
+</Badge>
+```
+
+**Categorical chip with leading icon:**
+```tsx
+<Badge color="teal" startIcon={<Icon icon={IconUsers} />}>
+  Engineering
+</Badge>
+```
+
+**Count indicator on an Avatar:**
+```tsx
+<Badge.Indicator content={3} color="error">
+  <Avatar src={user.avatar} alt={user.name} />
+</Badge.Indicator>
+```
+
+**Tag cluster with overflow:**
+```tsx
+<Badge.Group max={3} size="sm" onOverflowClick={() => setShowAll(true)}>
+  <Badge>React</Badge>
+  <Badge>TypeScript</Badge>
+  <Badge>Tailwind</Badge>
+  <Badge>Vite</Badge>
+  <Badge>Vitest</Badge>
+</Badge.Group>
+{/* Renders: React, TypeScript, Tailwind, +2 */}
+```
+
+**As a router link:**
+```tsx
+<Badge asChild>
+  <Link href="/tags/react">React</Link>
+</Badge>
+```
+
+**Custom color:**
+```tsx
+<Badge color="custom" style={{ '--badge-color': '#8b5cf6' }}>
+  Beta
+</Badge>
+```
+
+## Composability
+
+- **Badge.Group** lays out badges with consistent gap and an optional overflow indicator. Doesn't style children — they keep their own variant / color / size.
+- **Badge.Indicator** overlays a count or dot onto any child (Icon, Avatar, Button). Positioning-only.
+- **IconProvider:** `startIcon` / `endIcon` auto-size to badge size. Don't set explicit size on the nested Icon.
+- **asChild:** Compose with router Link for nav-style badges.
+
+See `foundations/color.md` for the color step system, `foundations/icons.md` for IconProvider.
+
+## Rules
+
+- For destructive / failed states, use `variant="solid" color="error"`. There is no `variant="destructive"`.
+- Use `Badge.Group` for any tag list — manual gap-handling drifts from the spacing cadence.
+- For toggle-style selectable tags, use `onClick` + `selected`. Don't roll your own with `<Toggle>` styled to look like a Badge.
+- Don't nest a Badge inside a Button — it produces invalid nested buttons. Use `Badge.Indicator` over the Button instead.
+- Icons in `startIcon` / `endIcon` go through `<Icon icon={...} />`. Don't pass `size` on the Icon.
+- For truncated badges, set `truncate` AND a `maxWidth` or container width. Both work together.
+- The deprecated `Chip` component was merged into Badge — use `Badge` with `onClick` for interactive tags.

--- a/packages/core/make-kit/components/button.md
+++ b/packages/core/make-kit/components/button.md
@@ -1,0 +1,125 @@
+# Button
+
+Primary action element. Use instead of `<button>` everywhere.
+
+```tsx
+import { Button } from '@devalok/shilp-sutra/ui/button'
+```
+
+## When to use
+
+- Any user-triggered action: submit a form, open a dialog, navigate (with `asChild`), trigger a flow.
+- Icon-only? Use `<IconButton>` instead.
+- Action plus dropdown? Use `<SplitButton>`.
+- Inline text link (no button affordance)? Use `<Link>` or `<Button variant="link">`.
+
+## Variants — and which to pick
+
+| Variant | When |
+|---|---|
+| `solid` (default) | Primary CTA. One per region. Heavy visual weight. |
+| `soft` | Secondary action. **Preferred default for any non-primary action.** Tinted bg, colored text, no visible border — warmer than outline, brand-consistent. |
+| `outline` | Secondary action on a colored / `surface-raised` bg where soft's tint disappears. In toolbars / icon-dense rows. Paired adjacent to a primary that needs explicit hierarchy. |
+| `ghost` | Tertiary / dismissive — close, cancel, skip. Minimal weight. |
+| `link` | Inline action that should read as a link but behave as a button. Use sparingly. |
+
+**Rule:** for non-primary actions, default to `soft`. Reach for `outline` only when the three above conditions hit.
+
+## Colors
+
+| Color | Use |
+|---|---|
+| `accent` (default) | Primary brand action. |
+| `error` | Destructive action. Pair with confirmation. |
+| `success` | Confirmation / completion action. |
+| `warning` | Caution action. |
+| `neutral` | Brand-agnostic action. Filing/utility buttons. |
+
+There is **no** `color="destructive"` — use `variant="solid" color="error"`.
+There is **no** `variant="destructive"` — same.
+
+## Sizes
+
+| Size | Pixel height | When |
+|---|---|---|
+| `xs` | 28 | Filter chips, dense toolbars. |
+| `sm` | 32 | Secondary actions in dense rows. |
+| `md` (default) | 40 | Standard. |
+| `lg` | 48 | Marketing CTAs, primary in spacious layouts. |
+| `compact-xs/sm/md` | inline (height-less) | Inline buttons that flow with text. |
+| `icon`, `icon-xs/sm/md/lg` | square | Use `<IconButton>` instead, with the same sizes. |
+
+## Common props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `variant` | `'solid'\|'soft'\|'outline'\|'ghost'\|'link'` | See above. |
+| `color` | `'accent'\|'error'\|'success'\|'warning'\|'neutral'` | See above. |
+| `size` | `'xs'\|'sm'\|'md'\|'lg'` + compact + icon variants | Default `md`. |
+| `startIcon`, `endIcon` | `IconInput` | Use `<Icon icon={IconX} />` or a Tabler ref. |
+| `loading` | `boolean` | Disables click + shows spinner. |
+| `loadingPosition` | `'start'\|'end'\|'center'` | Default `'start'`. |
+| `fullWidth` | `boolean` | Stretch to parent width. |
+| `shape` | `'default'\|'pill'` | Pill = fully rounded. |
+| `weight` | `'semibold'\|'normal'` | Default `semibold`. Use `normal` for soft/ghost in dense areas. |
+| `onClickAsync` | `(e) => Promise<void>` | Auto-runs idle → loading → success/error → idle state machine. |
+| `asyncFeedbackDuration` | `number` (ms) | Default 1500. |
+| `processing` | `boolean \| 'ambient' \| 'working' \| 'urgent'` | Marching-ants border for long ops. Forces `soft` variant. |
+| `asChild` | `boolean` | Style transfers to child (use with router Links). |
+
+## Examples
+
+**Primary action:**
+```tsx
+<Button>Save</Button>
+```
+
+**Primary + secondary, sensible default:**
+```tsx
+<Stack direction="row" gap="ds-03">
+  <Button>Save</Button>
+  <Button variant="soft">Cancel</Button>
+</Stack>
+```
+
+**Destructive with confirmation pattern:**
+```tsx
+<Button variant="solid" color="error" startIcon={IconTrash}>
+  Delete project
+</Button>
+```
+
+**Async with built-in feedback:**
+```tsx
+<Button onClickAsync={async () => { await api.save(form) }}>
+  Save changes
+</Button>
+```
+
+**Inside a ButtonGroup (toolbar):**
+```tsx
+<ButtonGroup variant="outline" size="sm">
+  <Button startIcon={IconBold} />
+  <Button startIcon={IconItalic} />
+  <Button startIcon={IconUnderline} />
+</ButtonGroup>
+```
+
+**With a router link (Next.js):**
+```tsx
+<Button asChild>
+  <Link href="/dashboard">Dashboard</Link>
+</Button>
+```
+
+## Rules
+
+- **Default to `variant="soft"`** for any non-primary action.
+- **Never** `variant="destructive"` / `variant="secondary"` / `color="danger"` / `color="default"` — these don't exist.
+- **Never** size `default` — use `md`.
+- **Never** color-override via className (`className="bg-red-500"`) — use `color` prop.
+- **Don't pair** explicit `loading` + `onClickAsync` — `onClickAsync` manages loading itself.
+- **`processing` forces `variant="soft"`** so the marching ants are visible. Don't fight it.
+- **Inside `<ButtonGroup>`**, omit `variant`/`color`/`size` on children unless intentionally overriding — they inherit from context.
+- Icons in `startIcon` / `endIcon` auto-size via `IconProvider`. Don't pass `size` on the icon.
+- For multi-line button content, use `<Stack>` inside; default Button is single-line.

--- a/packages/core/make-kit/components/card.md
+++ b/packages/core/make-kit/components/card.md
@@ -1,0 +1,147 @@
+# Card
+
+The default container for any panel-style content that sits **on** the page.
+
+```tsx
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from '@devalok/shilp-sutra/ui/card'
+```
+
+## When to use
+
+- Any rectangular region that reads as a discrete unit on the page: dashboards widgets, list items, marketing feature blocks.
+- Need built-in header / actions / footer slots? Use `<ContentCard>` (composed wrapper).
+- Need just a tinted region with no card affordance? Use a `<div className="bg-surface-raised">` (rare; usually Card is right).
+
+Card renders on `surface-raised` with `shadow-raised`. **Never** override its background or border.
+
+## Variants
+
+| Variant | Use |
+|---|---|
+| `default` (default) | `surface-raised` + `shadow-raised`. Standard card. |
+| `elevated` | Slightly stronger shadow. Use for hero / hovered emphasis. |
+| `outline` | `surface-raised` + border-only (no shadow). Dense lists where 12 cards stacked together would feel too lifted. |
+| `flat` | `surface-raised` + no shadow, no border. For cards inside an already-elevated container. |
+
+## Colors
+
+| Color | What it tints |
+|---|---|
+| `default` (default) | Standard border. |
+| `accent`, `error`, `success`, `warning`, `info`, `neutral` | Border picks up the semantic color at step-7. Use to signal status without filling the whole card. |
+
+## Sizes (padding cascade)
+
+`size` on Card propagates to `CardHeader`, `CardContent`, `CardFooter` via React context:
+
+| Size | Default padding |
+|---|---|
+| `sm` | `ds-04` (12 px) |
+| `md` (default) | `ds-05` (16 px) |
+| `lg` | `ds-07` (32 px) |
+
+Override on a sub-component via `className` only if absolutely necessary — it breaks the cascade.
+
+## Compound shape
+
+```
+Card (root)
+  CardHeader      ← inherits size from Card
+    CardTitle
+    CardDescription
+  CardContent     ← inherits size from Card
+  CardFooter      ← inherits size from Card
+```
+
+## Other props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `interactive` | `boolean` | Adds hover lift + `cursor-pointer`. Make the whole card clickable. Provide `onClick` and `aria-label`. |
+| `accent` | `'left'\|'top'\|'right'\|'bottom'` | Decorative colored bar on the named edge. |
+| `accentColor` | `'default'\|'accent'\|'error'\|'success'\|'warning'\|'info'` | Color of the accent bar. |
+
+## Examples
+
+**Standard:**
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>Q4 revenue</CardTitle>
+    <CardDescription>Last updated 2h ago</CardDescription>
+  </CardHeader>
+  <CardContent>
+    <Text variant="heading-lg">$2.4M</Text>
+    <Text variant="body-sm" className="text-fg-muted">+18% YoY</Text>
+  </CardContent>
+</Card>
+```
+
+**Interactive (whole card clickable):**
+```tsx
+<Card interactive onClick={() => navigate(`/projects/${id}`)} aria-label={`Open ${name}`}>
+  <CardHeader>
+    <CardTitle>{name}</CardTitle>
+    <CardDescription>{owner} · {memberCount} members</CardDescription>
+  </CardHeader>
+</Card>
+```
+
+**Status-tinted border (warning):**
+```tsx
+<Card color="warning">
+  <CardHeader>
+    <CardTitle>Action required</CardTitle>
+    <CardDescription>2 invoices are overdue.</CardDescription>
+  </CardHeader>
+  <CardFooter>
+    <Button variant="soft" color="warning">Review</Button>
+  </CardFooter>
+</Card>
+```
+
+**Accent bar — pipeline state:**
+```tsx
+<Card accent="left" accentColor="success">
+  <CardHeader>
+    <CardTitle>Deploy succeeded</CardTitle>
+    <CardDescription>main · 2 min ago</CardDescription>
+  </CardHeader>
+</Card>
+```
+
+**Dense list — outline variant, no shadow accumulation:**
+```tsx
+<Stack gap="ds-03">
+  {items.map((item) => (
+    <Card key={item.id} variant="outline" size="sm">
+      <CardHeader>
+        <CardTitle>{item.title}</CardTitle>
+      </CardHeader>
+    </Card>
+  ))}
+</Stack>
+```
+
+**Inside a colored region (flat):**
+```tsx
+<div className="bg-surface-sunken p-ds-07">
+  <Card variant="flat">…</Card>  {/* nested-feel, no double shadow */}
+</div>
+```
+
+## Rules
+
+- **Never** `bg-surface-base` on a Card — cards sit on `surface-raised`. The pre-publish audit rejects this.
+- **Never** combine `border-*` + `shadow-*` on a Card. Pick one (Card already does — don't override).
+- **Use `interactive` + `onClick` + `aria-label`** for clickable cards. Don't wrap a Card in a `<button>` — broken nesting.
+- **`size` on Card** drives sub-component padding. Don't set padding on `CardContent` directly.
+- **Don't stack `default` cards inside another `default` card.** The nested one should be `flat` or `outline`.
+- For row-style content (avatar + title + meta + actions), prefer `<ContentCard>` from `/composed/content-card` — it bundles the slots.

--- a/packages/core/make-kit/components/dialog.md
+++ b/packages/core/make-kit/components/dialog.md
@@ -1,0 +1,167 @@
+# Dialog
+
+Centered modal overlay for focused tasks that interrupt the page flow.
+
+```tsx
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from '@devalok/shilp-sutra/ui/dialog'
+```
+
+## When to use
+
+- Confirmations (destructive actions, accept-terms).
+- Short forms that need full attention (rename, share, invite).
+- Critical announcements requiring acknowledgment.
+- Side-anchored drawer (settings panel, mobile nav)? Use `<Sheet>`.
+- Lightweight rich tooltip with no required interaction? Use `<HoverCard>`.
+- Interactive panel anchored to a trigger (filter, picker)? Use `<Popover>`.
+
+On mobile, Dialog auto-promotes to a full-screen sheet — don't rebuild this manually.
+
+## Compound shape
+
+```
+Dialog (root — open, onOpenChange, defaultOpen, modal)
+  DialogTrigger          ← uses asChild around a Button
+  DialogContent          ← portalled, traps focus
+    DialogHeader
+      DialogTitle         ← REQUIRED for a11y
+      DialogDescription
+    [body content]
+    DialogFooter
+      DialogClose         ← uses asChild around a Button
+```
+
+## Root props (passthrough to Radix)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `open` | `boolean` | Controlled mode. |
+| `onOpenChange` | `(open: boolean) => void` | Fires on every state change. |
+| `defaultOpen` | `boolean` | Uncontrolled. |
+| `modal` | `boolean` | Default `true`. Set `false` for non-blocking overlays (rare). |
+
+Styling props live on `DialogContent`. Trigger / Close use `asChild` to merge with your Button.
+
+## Examples
+
+**Confirmation:**
+```tsx
+<Dialog>
+  <DialogTrigger asChild>
+    <Button variant="soft" color="error">Delete project</Button>
+  </DialogTrigger>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Delete this project?</DialogTitle>
+      <DialogDescription>
+        This permanently deletes all tasks, files, and history. Cannot be undone.
+      </DialogDescription>
+    </DialogHeader>
+    <DialogFooter>
+      <DialogClose asChild>
+        <Button variant="soft">Cancel</Button>
+      </DialogClose>
+      <Button variant="solid" color="error" onClick={handleDelete}>
+        Delete
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+**Short form:**
+```tsx
+<Dialog open={open} onOpenChange={setOpen}>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Rename workspace</DialogTitle>
+    </DialogHeader>
+    <Stack gap="ds-04">
+      <FormField>
+        <Label htmlFor="ws-name">Name</Label>
+        <Input id="ws-name" value={name} onChange={(e) => setName(e.target.value)} />
+      </FormField>
+    </Stack>
+    <DialogFooter>
+      <DialogClose asChild>
+        <Button variant="soft">Cancel</Button>
+      </DialogClose>
+      <Button onClickAsync={async () => { await api.rename(name); setOpen(false) }}>
+        Save
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+**Visually-hidden title (a11y compliance without showing the heading):**
+```tsx
+<DialogContent>
+  <VisuallyHidden>
+    <DialogTitle>Image preview</DialogTitle>
+  </VisuallyHidden>
+  <img src={src} alt={alt} />
+</DialogContent>
+```
+
+**Programmatic close from a deep child:**
+```tsx
+<DialogContent>
+  <Stack>
+    <FancyForm onSubmit={handleSubmit} />
+    <DialogClose asChild>
+      <Button variant="ghost">Done</Button>
+    </DialogClose>
+  </Stack>
+</DialogContent>
+```
+
+**Nested Popover inside Dialog:**
+```tsx
+<Dialog>
+  <DialogContent>
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="soft">Pick a date</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Calendar value={date} onChange={setDate} />
+      </PopoverContent>
+    </Popover>
+  </DialogContent>
+</Dialog>
+```
+
+Popover uses `z-popover` (1400) which is above `z-dialog` — nesting stacks correctly without z-index fights.
+
+## Mobile behavior
+
+On viewports below the `md` breakpoint, DialogContent auto-fullscreens with a top-anchored close button. Layouts that work on desktop in centered modal usually work on mobile in fullscreen as-is — but verify long forms scroll inside the dialog body, not the page.
+
+## Composability
+
+- **Portal rendering:** DialogContent portals to `document.body`. CSS `overflow: hidden`, `transform`, or stacking contexts on ancestors don't clip it.
+- **Focus management:** Focus traps inside while open. First focusable element receives focus. Returns to trigger on close.
+- **Imperative close:** Wrap your own button with `<DialogClose asChild>` — no prop drilling.
+- **z-index:** `z-dialog`. Popovers, DropdownMenus, Tooltips inside stack above using `z-popover`.
+
+See `foundations/surfaces.md` for the overlay surface tokens, `foundations/motion.md` for the spring entry animation.
+
+## Rules
+
+- Always render a `<DialogTitle>` — screen readers depend on it. If the design hides it visually, wrap it in `<VisuallyHidden>`.
+- Use `<DialogTrigger asChild>` with a Button — don't use Dialog's default injected trigger.
+- For destructive actions, place the destructive Button on the right with `color="error"`. Cancel (`<DialogClose>`) sits left with `variant="soft"`.
+- Don't manipulate `open` from inside the content tree without going through `onOpenChange` or `<DialogClose>` — focus restoration breaks.
+- Don't nest Dialogs. Use a single Dialog with stepped state, or close the first before opening the second.
+- For side-anchored drawers, switch to `<Sheet>`. Don't recreate Sheet behavior with custom Dialog styling.
+- If your Dialog is mostly read-only content (image preview, log viewer), still provide a `<DialogTitle>` for a11y, hidden if needed.

--- a/packages/core/make-kit/components/dropdown-menu.md
+++ b/packages/core/make-kit/components/dropdown-menu.md
@@ -1,0 +1,205 @@
+# DropdownMenu
+
+Click-triggered menu of actions. Use for overflow menus, row actions, account menus.
+
+```tsx
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuGroup,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+} from '@devalok/shilp-sutra/ui/dropdown-menu'
+```
+
+## When to use
+
+- Row / item actions (kebab menu — Edit, Duplicate, Delete).
+- Account menu (Profile, Settings, Logout).
+- Sort / filter pickers with a fixed list.
+- Toolbar overflow ("More" button).
+- Interactive panel (forms, calendars, complex pickers)? Use `<Popover>`.
+- Single-choice from a fixed list inside a form field? Use `<Select>`.
+- Hover-triggered rich preview? Use `<HoverCard>`.
+- Right-click contextual menu? Use `<ContextMenu>` (separate component).
+
+## Compound shape
+
+```
+DropdownMenu (root — open, onOpenChange, defaultOpen, modal)
+  DropdownMenuTrigger                          ← asChild around your button
+  DropdownMenuContent
+    DropdownMenuLabel                          ← non-interactive section heading
+    DropdownMenuSeparator
+    DropdownMenuItem (+ DropdownMenuShortcut)  ← standard action
+    DropdownMenuCheckboxItem                   ← multi-select toggle
+    DropdownMenuRadioGroup
+      DropdownMenuRadioItem                    ← single-select group
+    DropdownMenuGroup                          ← visual grouping
+    DropdownMenuSub
+      DropdownMenuSubTrigger                   ← visible item that opens submenu
+      DropdownMenuSubContent                   ← the nested submenu panel
+```
+
+## Root state props (Radix passthrough)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `open` | `boolean` | Controlled. |
+| `onOpenChange` | `(open: boolean) => void` | |
+| `defaultOpen` | `boolean` | Uncontrolled. |
+| `modal` | `boolean` | Default `true`. |
+
+## Examples
+
+**Standard kebab menu:**
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <IconButton icon={<Icon icon={IconDots} />} variant="ghost" aria-label="Actions" />
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuItem onSelect={() => edit(item)}>
+      <Icon icon={IconEdit} /> Edit
+    </DropdownMenuItem>
+    <DropdownMenuItem onSelect={() => duplicate(item)}>
+      <Icon icon={IconCopy} /> Duplicate
+    </DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem onSelect={() => remove(item)}>
+      <Icon icon={IconTrash} /> Delete
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+**With keyboard shortcut hints:**
+```tsx
+<DropdownMenuContent>
+  <DropdownMenuItem onSelect={save}>
+    Save
+    <DropdownMenuShortcut>⌘S</DropdownMenuShortcut>
+  </DropdownMenuItem>
+  <DropdownMenuItem onSelect={find}>
+    Find
+    <DropdownMenuShortcut>⌘F</DropdownMenuShortcut>
+  </DropdownMenuItem>
+</DropdownMenuContent>
+```
+
+`DropdownMenuShortcut` is decorative — it does NOT bind the shortcut globally. Bind shortcuts separately (e.g. with a `useHotkeys` hook).
+
+**Checkbox items (multi-select filters):**
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="soft" endIcon={IconChevronDown}>View</Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuLabel>Show columns</DropdownMenuLabel>
+    <DropdownMenuCheckboxItem
+      checked={cols.includes('owner')}
+      onCheckedChange={(checked) => toggleCol('owner', checked)}
+      onSelect={(e) => e.preventDefault()}
+    >
+      Owner
+    </DropdownMenuCheckboxItem>
+    <DropdownMenuCheckboxItem
+      checked={cols.includes('status')}
+      onCheckedChange={(checked) => toggleCol('status', checked)}
+      onSelect={(e) => e.preventDefault()}
+    >
+      Status
+    </DropdownMenuCheckboxItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+Calling `e.preventDefault()` inside `onSelect` keeps the menu open after toggling — standard for checkbox items.
+
+**Radio items (single-select sort):**
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="soft">Sort: {sort}</Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent>
+    <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+    <DropdownMenuRadioGroup value={sort} onValueChange={setSort}>
+      <DropdownMenuRadioItem value="recent">Most recent</DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="oldest">Oldest</DropdownMenuRadioItem>
+      <DropdownMenuRadioItem value="az">A → Z</DropdownMenuRadioItem>
+    </DropdownMenuRadioGroup>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+**Submenu:**
+```tsx
+<DropdownMenuContent>
+  <DropdownMenuItem onSelect={() => share(item)}>Share</DropdownMenuItem>
+  <DropdownMenuSub>
+    <DropdownMenuSubTrigger>
+      <Icon icon={IconFolder} /> Move to
+    </DropdownMenuSubTrigger>
+    <DropdownMenuSubContent>
+      <DropdownMenuItem onSelect={() => move('inbox')}>Inbox</DropdownMenuItem>
+      <DropdownMenuItem onSelect={() => move('archive')}>Archive</DropdownMenuItem>
+      <DropdownMenuItem onSelect={() => move('trash')}>Trash</DropdownMenuItem>
+    </DropdownMenuSubContent>
+  </DropdownMenuSub>
+</DropdownMenuContent>
+```
+
+Both `SubTrigger` AND `SubContent` are required — missing either silently breaks the hover-open behavior.
+
+**Account menu pattern:**
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <IconButton icon={<Avatar size="sm" src={user.avatar} alt={user.name} />} variant="ghost" aria-label="Account" />
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuLabel>{user.email}</DropdownMenuLabel>
+    <DropdownMenuSeparator />
+    <DropdownMenuGroup>
+      <DropdownMenuItem onSelect={() => router.push('/profile')}>Profile</DropdownMenuItem>
+      <DropdownMenuItem onSelect={() => router.push('/settings')}>Settings</DropdownMenuItem>
+    </DropdownMenuGroup>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem onSelect={signOut}>
+      <Icon icon={IconLogout} /> Sign out
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+## Composability
+
+- **Radix DropdownMenu** underneath — `open` / `onOpenChange` / `defaultOpen` / `modal` standard state.
+- **Keyboard:** Arrow keys navigate, Enter/Space activates, Esc closes, typeahead jumps to first letter. All pre-wired.
+- **Trigger:** `<DropdownMenuTrigger asChild>` around any button. `IconButton` is the common pairing for kebab menus.
+- **Closing from a handler:** `onSelect` auto-closes the menu. Call `e.preventDefault()` inside the handler to keep it open (checkbox items, multi-step interactions).
+- **z-popover (1400):** Stacks above Dialog. Nesting dropdowns inside dialogs works correctly.
+
+See `foundations/surfaces.md` for menu surface tokens, `foundations/motion.md` for the spring open animation.
+
+## Rules
+
+- Use `<DropdownMenuTrigger asChild>` around a Button or IconButton. Don't use Dropdown's default injected trigger.
+- For kebab menus, always set `aria-label` on the IconButton — "Actions" or the specific row context.
+- Submenus require BOTH `DropdownMenuSubTrigger` AND `DropdownMenuSubContent`. Missing either silently breaks hover-to-open.
+- `DropdownMenuShortcut` is decorative. Bind the actual shortcut separately.
+- For checkbox items, call `e.preventDefault()` inside `onSelect` to keep the menu open after toggling.
+- For interactive content beyond a list (calendars, forms), use `<Popover>` not DropdownMenu.
+- Don't nest a DropdownMenu inside another DropdownMenu — use `<DropdownMenuSub>` for hierarchy.
+- For right-click menus, use `<ContextMenu>` (separate component). DropdownMenu is click-triggered only.

--- a/packages/core/make-kit/components/form.md
+++ b/packages/core/make-kit/components/form.md
@@ -1,0 +1,189 @@
+# Form
+
+Wrap each form field in a `<FormField>`. It cascades state + a11y wiring to compatible controls automatically.
+
+```tsx
+import { FormField, FormHelperText, useFormField } from '@devalok/shilp-sutra/ui/form'
+import { Label } from '@devalok/shilp-sutra/ui/label'
+```
+
+## When to use
+
+- Every input field in a form. One `<FormField>` per logical field.
+- Provides: validation state, helper text, `aria-describedby`, `aria-invalid`, `aria-required` — wired automatically.
+- Not for layout — for stacking fields, use `<Stack gap="ds-05">`.
+
+## Compound shape
+
+```
+FormField (state, required)
+  Label                    ← htmlFor auto-resolves from FormField inputId
+  Input | Textarea | NumberInput | InputOTP | Select | Checkbox | ...
+  FormHelperText           ← reads state + helperTextId from context
+```
+
+`FormField` generates a shared `inputId`. Both `<Label>` (via `htmlFor`) and `<Input>` (via `id`) read it from context — drop the manual id-matching dance. Explicit `htmlFor` / `id` on a child still wins.
+
+## FormField props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `state` | `'helper'\|'error'\|'warning'\|'success'` | Default `helper`. Cascades to compatible controls + FormHelperText. |
+| `helperTextId` | `string` | Auto-generated if omitted. Used by `aria-describedby` wiring. |
+| `inputId` | `string` | Auto-generated if omitted. Shared between `<Label htmlFor>` and `<Input id>`. |
+| `required` | `boolean` | Sets `aria-required` on consuming controls. Does NOT auto-render the asterisk — that comes from `<Label required>`. |
+
+## FormHelperText props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `state` | `'helper'\|'error'\|'warning'\|'success'` | Inherits from FormField context. Override per-helper if needed. |
+
+When `state="error"`, FormHelperText renders `role="alert"` so screen readers interrupt.
+
+## Label props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `htmlFor` | `string` | Optional inside `<FormField>` — falls back to FormField's `inputId`. Required when used outside FormField. |
+| `required` | `boolean` | Renders red asterisk. Does NOT set `aria-required` (that comes from FormField). |
+
+## useFormField hook
+
+```ts
+const field = useFormField()
+// → { state, helperTextId, required } | undefined
+```
+
+Use inside a custom control to consume FormField context.
+
+## What auto-consumes FormField context
+
+| Control | Auto-receives |
+|---|---|
+| `<Input>` | `id` (from `inputId`), `state`, `aria-describedby`, `aria-invalid`, `aria-required` |
+| `<Textarea>` | same |
+| `<NumberInput>` | same |
+| `<InputOTP>` | `state`, `aria-describedby`, `aria-required` |
+| `<Label>` | `htmlFor` (from `inputId`) |
+
+| Control | Manual wiring needed |
+|---|---|
+| `<Select>` / `<SelectTrigger>` | Set `color="error"` on `SelectTrigger` from your validation state. |
+| `<Checkbox>`, `<Radio>`, `<Switch>` | Pair `<Label htmlFor>` manually. State is visual on the control. |
+
+## Examples
+
+**Standard text field with error:**
+```tsx
+<FormField state={errors.email ? 'error' : 'helper'}>
+  <Label htmlFor="email" required>Email</Label>
+  <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+  <FormHelperText>
+    {errors.email ?? 'We will never share your email.'}
+  </FormHelperText>
+</FormField>
+```
+
+The Input receives `aria-describedby` (linked to FormHelperText), `aria-invalid="true"` when state is error, and `aria-required="true"`.
+
+**Warning state:**
+```tsx
+<FormField state="warning">
+  <Label htmlFor="password" required>Password</Label>
+  <Input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+  <FormHelperText>Password strength: weak. Add a number or symbol.</FormHelperText>
+</FormField>
+```
+
+**Textarea:**
+```tsx
+<FormField state={errors.bio ? 'error' : 'helper'}>
+  <Label htmlFor="bio">Bio</Label>
+  <Textarea id="bio" rows={4} value={bio} onChange={(e) => setBio(e.target.value)} />
+  <FormHelperText>{errors.bio ?? `${bio.length} / 200`}</FormHelperText>
+</FormField>
+```
+
+**Required Checkbox (manual label pairing):**
+```tsx
+<FormField required state={errors.terms ? 'error' : 'helper'}>
+  <Stack direction="horizontal" gap="ds-03" align="center">
+    <Checkbox id="terms" checked={agreed} onCheckedChange={setAgreed} />
+    <Label htmlFor="terms">I agree to the terms.</Label>
+  </Stack>
+  {errors.terms && <FormHelperText>{errors.terms}</FormHelperText>}
+</FormField>
+```
+
+**Full form layout:**
+```tsx
+<form onSubmit={handleSubmit}>
+  <Stack gap="ds-05">
+    <FormField>
+      <Label htmlFor="name" required>Name</Label>
+      <Input id="name" />
+    </FormField>
+
+    <FormField>
+      <Label htmlFor="email" required>Email</Label>
+      <Input id="email" type="email" />
+      <FormHelperText>For account recovery only.</FormHelperText>
+    </FormField>
+
+    <FormField state={errors.role ? 'error' : 'helper'}>
+      <Label htmlFor="role">Role</Label>
+      <Select>
+        <SelectTrigger id="role" color={errors.role ? 'error' : 'default'}>
+          <SelectValue placeholder="Choose a role" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="admin">Admin</SelectItem>
+          <SelectItem value="member">Member</SelectItem>
+        </SelectContent>
+      </Select>
+      {errors.role && <FormHelperText>{errors.role}</FormHelperText>}
+    </FormField>
+
+    <Stack direction="horizontal" gap="ds-03" justify="end">
+      <Button variant="soft" type="button">Cancel</Button>
+      <Button type="submit">Save</Button>
+    </Stack>
+  </Stack>
+</form>
+```
+
+**Custom control consuming FormField context:**
+```tsx
+function ColorPickerField(props) {
+  const field = useFormField()
+  return (
+    <ColorPicker
+      {...props}
+      aria-describedby={field?.helperTextId}
+      aria-invalid={field?.state === 'error' || undefined}
+      aria-required={field?.required || undefined}
+    />
+  )
+}
+```
+
+## Composability
+
+- **Explicit props override context** — `<Input state="error">` inside a `<FormField state="helper">` makes only that input look errored. Same for `id` / `htmlFor`.
+- **Don't nest FormFields** — only the outermost context wins. Some a11y wiring silently breaks.
+- **Label-to-control pairing auto-wires inside FormField** via the shared `inputId`. Outside FormField, set `htmlFor` + `id` explicitly.
+- **For non-auto-wired controls** (Checkbox, Radio, Switch) where the visible label sits beside the control, you can still drop the `htmlFor` if you put the control inside FormField with no other Inputs — `inputId` resolves on the Checkbox via its `id` prop the same way.
+
+See `foundations/color.md` for state colors, `foundations/spacing.md` for inter-field spacing (`ds-05` default).
+
+## Rules
+
+- One FormField per logical field. Never nest FormFields.
+- For error display, drive `FormField state` from your validation state — every consuming control updates together.
+- For Select / Checkbox / Radio / Switch, set the control's error visual manually (`color="error"` on SelectTrigger) — they don't auto-consume FormField state, only ids and a11y attrs.
+- Don't use the removed `getFormFieldA11y()` helper — use the `useFormField()` hook.
+- Inside FormField, `<FormHelperText>` reads `state` + id from context — don't pass them again unless intentionally overriding.
+- Use `<Stack gap="ds-05">` to space fields vertically. Don't reach for `ds-04` or `ds-06` — see `foundations/spacing.md`.
+- `<Label required>` only renders the asterisk. The `aria-required` flag comes from `<FormField required>`.
+- You can omit `id` on `<Input>` and `htmlFor` on `<Label>` inside a `<FormField>` — both resolve from FormField's `inputId`. Set them explicitly only when overriding the auto-generated id.

--- a/packages/core/make-kit/components/icon.md
+++ b/packages/core/make-kit/components/icon.md
@@ -1,0 +1,152 @@
+# Icon
+
+Wrapper around Tabler icon components. Auto-sizes via `IconProvider` context.
+
+```tsx
+import { Icon } from '@devalok/shilp-sutra/ui'
+import { IconPlus, IconCheck, IconX } from '@tabler/icons-react'
+```
+
+For the broader icon system (which icons exist, how to register custom ones, the IconProvider tree), see `foundations/icons.md`. This guide covers the `<Icon>` component itself.
+
+## When to use
+
+- Any inline SVG icon — inside Button slots, IconButton, Badge slots, table cells, list rows.
+- Need an interactive icon button? Use `<IconButton>`, not Icon wrapped in `<button>`.
+- Need a static cluster of related icons? Use `<IconGroup>`.
+- Need a status indicator? Use `<StatusDot>` or `<Badge dot>` — they're optimized for that.
+
+Tabler-only. Don't mix icon libraries — see `foundations/icons.md` for the rationale.
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `icon` | `ForwardRefExoticComponent` (REQUIRED) | Tabler icon component (or any ForwardRef SVG icon matching the Tabler shape). |
+| `size` | `'xs'\|'sm'\|'md'\|'lg'\|'xl'\|'2xl'` | Reads from `IconContext` if not set. |
+| `stroke` | `'light'\|'regular'\|'bold'` | Reads from `IconContext` if not set. |
+| `label` | `string` | Accessible label — sets `role="img"`, `aria-label`, and `<title>`. Without it, icon is `aria-hidden="true"`. |
+| `animate` | `'spin'\|'pulse'\|'bounce'\|'draw'\|'none'` \| `{ rotate?, scale? }` | Static when undefined. |
+| `state` | `'idle'\|'loading'\|'success'\|'error'` | State machine — overrides `animate` when both set. |
+| `className` | `string` | |
+
+## Size scale
+
+| Size | Pixel | Default use |
+|---|---|---|
+| `xs` | 14 | Inside `xs` buttons / badges, dense table cells. |
+| `sm` | 16 | Inside `sm` buttons / badges, standard inline. |
+| `md` (default) | 18 | Inside `md` buttons / inputs. |
+| `lg` | 20 | Inside `lg` buttons / large inputs. |
+| `xl` | 24 | Standalone icons in card headers. |
+| `2xl` | 32 | Hero / illustration accents. |
+
+Stroke weight varies by size — smaller icons use lighter strokes for clarity. Override via `stroke` only when the visual weight feels off.
+
+## Accessibility
+
+| Use | Result |
+|---|---|
+| No `label` (inside a labeled Button / IconButton) | `aria-hidden="true"` — screen readers skip. |
+| With `label` (standalone) | `role="img"` + `aria-label` + SVG `<title>`. |
+
+Inside `<IconButton aria-label="Edit">` the icon is decorative — don't set `label` on the Icon.
+
+For standalone icons (status indicators, decorative bullets that convey meaning), pass `label`.
+
+## Examples
+
+**Inside a Button:**
+```tsx
+<Button startIcon={IconPlus}>New project</Button>
+```
+
+`startIcon` accepts the bare Tabler component — Button wraps it in `<Icon>` and provides size via IconProvider. You don't need to wrap manually.
+
+**Inside an IconButton (requires `<Icon>` wrapper):**
+```tsx
+<IconButton
+  icon={<Icon icon={IconEdit} />}
+  variant="ghost"
+  aria-label="Edit item"
+/>
+```
+
+IconButton's `icon` prop expects a React element, so wrap in `<Icon icon={...} />`. Size flows from the button via IconProvider.
+
+**Standalone with label (a11y):**
+```tsx
+<Icon icon={IconAlertCircle} label="Warning" size="lg" />
+```
+
+Renders `role="img"` with `aria-label="Warning"` — screen readers announce it.
+
+**Loading spinner via state:**
+```tsx
+<Icon icon={IconRefresh} state="loading" />
+```
+
+`state="loading"` renders a bare Spinner regardless of the `icon` prop. Use for inline loading affordances.
+
+**Success / error feedback:**
+```tsx
+<Icon icon={IconCheck} state="success" />
+<Icon icon={IconX} state="error" />
+```
+
+`state="success"` / `state="error"` render animated checkmark / cross via Framer Motion. Respects `prefers-reduced-motion`.
+
+**Path-draw animation (check / X / circle-check only):**
+```tsx
+<Icon icon={IconCheck} animate="draw" />
+```
+
+Draws the stroke progressively (0.35s easeOut). Works with `IconCheck`, `IconX`, and `IconCircleCheck` only — other icons fall back to static render.
+
+**Spin animation:**
+```tsx
+<Icon icon={IconLoader} animate="spin" />
+```
+
+For an actual loading state, prefer `state="loading"` — it renders the dedicated Spinner.
+
+**Inside a row, auto-sized from input:**
+```tsx
+<Input
+  size="lg"
+  startSection={<Icon icon={IconSearch} />}  {/* size: 'md' from IconProvider */}
+  placeholder="Search"
+/>
+```
+
+Input's IconProvider sets size by input size: `xs` / `sm` input → `sm` icon, `md` / `lg` input → `md` icon. Don't pass `size` on the nested Icon.
+
+**Status badge with custom-colored icon:**
+```tsx
+<Stack direction="horizontal" gap="ds-02" align="center">
+  <Icon icon={IconCircleFilled} size="xs" className="text-success-9" />
+  <Text variant="body-sm">Online</Text>
+</Stack>
+```
+
+For most status displays prefer `<StatusDot>` — purpose-built. Use this pattern only when you need a specific icon shape.
+
+## Composability
+
+- **IconProvider cascade:** Button, IconButton, Badge, Input (start/endSection), NumberInput, IconGroup all wrap children in an `IconProvider`. Nested `<Icon>` reads size + stroke automatically. Don't pass `size` on those nested Icons.
+- **Explicit props override context.** When you genuinely need a different size, pass `size` on the Icon — it wins.
+- **State overrides animate.** When both are set, `state` wins. `state="loading"` renders a Spinner; `state="success"` / `state="error"` render path-drawn animations.
+- **Reduced motion respected.** All animations fall back to static render under `prefers-reduced-motion: reduce`.
+
+See `foundations/icons.md` for the icon-system overview (Tabler-only rationale, IconProvider tree, custom icons), `foundations/motion.md` for animation tokens.
+
+## Rules
+
+- Use Tabler icons only. See `foundations/icons.md` for the rationale and registry.
+- Inside Button / IconButton / Badge slots, don't pass `size` on the nested Icon — IconProvider sets it.
+- For standalone icons that convey meaning (not in a labeled button), pass `label` — without it, screen readers skip the icon.
+- Inside `<IconButton aria-label="...">`, the Icon is decorative — don't set `label` on the Icon (would duplicate the announcement).
+- For loading affordances, use `state="loading"` — it renders the dedicated Spinner.
+- `animate="draw"` only works for `IconCheck`, `IconX`, `IconCircleCheck`. Other icons silently fall back to static.
+- Don't wrap Icon in `<button>` — use `<IconButton>`.
+- Stroke weight scales with size — only override `stroke` when the default truly feels off, not as a stylistic preference.

--- a/packages/core/make-kit/components/input.md
+++ b/packages/core/make-kit/components/input.md
@@ -1,0 +1,154 @@
+# Input
+
+Single-line text entry. Use instead of `<input type="text" | "email" | "url" | "tel" | "search" | "password">`.
+
+```tsx
+import { Input } from '@devalok/shilp-sutra/ui/input'
+```
+
+## When to use
+
+- Any single-line text capture: email, URL, search, name, password, phone.
+- Multi-line input? Use `<Textarea>`.
+- Number-only with steppers? Use `<NumberInput>`.
+- One-time-code / PIN entry? Use `<InputOTP>`.
+- Searchable list with selection? Use `<Combobox>` or `<Autocomplete>`.
+
+Wrap in a `<FormField>` for automatic a11y wiring (state, `aria-describedby`, `aria-invalid`, `aria-required`).
+
+## Sizes
+
+| Size | Pixel height | When |
+|---|---|---|
+| `xs` | 28 | Toolbar / inline filters. |
+| `sm` | 32 | Dense forms. |
+| `md` (default) | 40 | Standard. |
+| `lg` | 48 | Marketing / spacious layouts. |
+
+All sizes use 14 px text — sizes scale height + padding, not font.
+
+## States
+
+| State | Visual | Use |
+|---|---|---|
+| `default` (default) | Subtle border. | Resting. |
+| `error` | Red border + `aria-invalid="true"`. | Validation failure. |
+| `warning` | Amber border. | Soft caution (caps lock on, weak password). |
+| `success` | Green border. | Inline confirmation. |
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `size` | `'xs'\|'sm'\|'md'\|'lg'` | Default `md`. Excludes the HTML native `size` attribute. |
+| `state` | `'default'\|'error'\|'warning'\|'success'` | Inherits from `<FormField>` context if present. |
+| `startSection` | `ReactNode` | Leading slot — icon (React element) or label string. |
+| `endSection` | `ReactNode` | Trailing slot — icon or label. |
+| `startSectionType` | `'icon'\|'label'` | Auto-inferred from content type. Override only when needed. |
+| `endSectionType` | `'icon'\|'label'` | Auto-inferred. |
+| `startSectionClickable` | `boolean` | Enables pointer events on the section (e.g. clear button in slot). |
+| `endSectionClickable` | `boolean` | Same for trailing slot. |
+| `wrapperClassName` | `string` | Classes on the wrapper div (border, bg, ring live here). |
+| `className` | `string` | Classes on the raw `<input>` element (transparent — text only). |
+
+Plus all standard HTML input attributes except the native `size` (renamed to mean visual sizing).
+
+## Section type inference
+
+| Content | Renders as |
+|---|---|
+| React element (`<Icon icon={IconMail} />`) | `'icon'` — fixed-width centered cell. |
+| String (`"https://"`, `".00"`) | `'label'` — tinted bg + border separator. |
+
+Override via `startSectionType` / `endSectionType` when the inference is wrong.
+
+## Examples
+
+**Standard, with leading icon:**
+```tsx
+<Input
+  type="email"
+  placeholder="you@example.com"
+  startSection={<Icon icon={IconMail} />}
+/>
+```
+
+**URL prefix (label section):**
+```tsx
+<Input
+  startSection="https://"
+  placeholder="example.com"
+/>
+```
+
+**Currency with prefix icon + suffix label:**
+```tsx
+<Input
+  startSection={<Icon icon={IconCurrencyDollar} />}
+  endSection=".00"
+  placeholder="0"
+  inputMode="decimal"
+/>
+```
+
+**Clearable search (clickable trailing slot):**
+```tsx
+<Input
+  placeholder="Search projects"
+  startSection={<Icon icon={IconSearch} />}
+  endSection={
+    <button type="button" onClick={() => setValue('')} aria-label="Clear">
+      <Icon icon={IconX} />
+    </button>
+  }
+  endSectionClickable
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
+```
+
+**Inside a FormField (auto-wired a11y):**
+```tsx
+<FormField state="error">
+  <Label htmlFor="email" required>Email</Label>
+  <Input id="email" type="email" />
+  <FormHelperText>Enter a valid work email.</FormHelperText>
+</FormField>
+```
+
+The Input picks up `state="error"`, `aria-describedby` (linked to FormHelperText), `aria-invalid`, and `aria-required` from FormField context automatically.
+
+**Password with reveal toggle:**
+```tsx
+const [visible, setVisible] = useState(false)
+
+<Input
+  type={visible ? 'text' : 'password'}
+  placeholder="Password"
+  endSection={
+    <button type="button" onClick={() => setVisible((v) => !v)} aria-label={visible ? 'Hide password' : 'Show password'}>
+      <Icon icon={visible ? IconEyeOff : IconEye} />
+    </button>
+  }
+  endSectionClickable
+/>
+```
+
+## Composability
+
+- **FormField:** Inside a `<FormField>`, Input auto-reads `state`, `aria-describedby`, `aria-invalid`, `aria-required` from context. Explicit props override.
+- **IconProvider:** Icons in `startSection` / `endSection` are auto-sized via the input's `size`. Don't pass `size` on the nested `<Icon>`.
+- **Container-first architecture:** Border, background, and focus ring live on the wrapper div, not the input element. Style overrides go through `wrapperClassName`, not `className`. The raw `<input>` is transparent.
+
+See `foundations/color.md` for state-color tokens, `foundations/icons.md` for the IconProvider cascade.
+
+## Rules
+
+- Pair every Input with a `<Label htmlFor="x" />` and matching `<Input id="x" />`. FormField does NOT auto-wire labels.
+- Use `wrapperClassName` for border / bg / ring overrides. `className` only changes the raw input text styling.
+- Don't pass `size` on `<Icon>` inside a section — IconProvider sets it.
+- Don't use the HTML native `size` attribute — it's excluded. Use CSS width or the size prop.
+- For interactive sections (clear button, password toggle), set `startSectionClickable` / `endSectionClickable`. Without it, the slot is `pointer-events-none`.
+- For status / validation, set `state` — it sets `aria-invalid` automatically when `state="error"`.
+- Don't use the removed `startIcon` / `endIcon` props — they were removed in 0.38. Use `startSection` / `endSection`.
+- Prefer FormField wrapping for any input with a label + helper — manual a11y wiring is error-prone.

--- a/packages/core/make-kit/components/overview.md
+++ b/packages/core/make-kit/components/overview.md
@@ -1,0 +1,308 @@
+# Components — catalog & decision trees
+
+Catalog of every major component. Use this file to pick the right component before reaching for raw HTML. Per-component deep guides live alongside this file.
+
+## Decision tree — actions
+
+```
+User wants to commit / cancel / submit?
+  → primary CTA (1 per region)  → <Button variant="solid" color="accent">
+  → secondary action            → <Button variant="soft"> (NOT outline — see preference)
+  → tertiary / dismissive       → <Button variant="ghost">
+  → destructive action          → <Button variant="solid" color="error">
+  → link-styled action          → <Button variant="link">
+
+Action has a side-menu / overflow?
+  → <SplitButton> — primary + adjacent dropdown trigger.
+
+Action is icon-only?
+  → <IconButton> — same as Button, square aspect, aria-label required.
+
+Group of related actions?
+  → <ButtonGroup> — attached or not. Propagates disabled / size.
+```
+
+## Decision tree — input
+
+```
+Single-line text?
+  → <Input> — type="text"/"email"/"password"/"number"/"tel"/"url"/"search"
+  → For search specifically: <SearchInput> (has clear button + icon)
+  → For OTP code: <InputOTP>
+
+Multi-line text?
+  → <Textarea>
+
+Pick one from a list?
+  → static list ≤7 items     → <Select>
+  → static list >7 items     → <Combobox> (searchable)
+  → async / large list       → <Autocomplete>
+  → enum of 2–4 options      → <SegmentedControl> (always-visible) or <Tabs> (if scoping a section)
+
+Pick many?
+  → list with checkboxes     → <Checkbox> per item
+  → compact pills            → <ToggleGroup type="multiple">
+  → searchable               → <Combobox multiple>
+
+Boolean?
+  → <Switch> (settings-style on/off) — instant action
+  → <Checkbox> (form field) — confirmed-on-submit
+  → <Toggle> (button-like toggled state)
+
+Range / scalar?
+  → <Slider> (single or multi-thumb range)
+  → <NumberInput> (precise number with steppers)
+
+Date / time?
+  → <DatePicker> (single date)
+  → <DateRangePicker> (range)
+  → <DateTimePicker> (date + time)
+
+Color?
+  → <ColorInput> (popover swatch + manual hex)
+  → <ColorSwatch> (display-only)
+
+File?
+  → <FileUpload> (drag-drop + click)
+```
+
+## Decision tree — feedback
+
+```
+Permanent inline message?
+  → <Alert>     — page-level notice (info / success / warning / error)
+  → <Banner>    — full-bleed page banner (system status, announcements)
+  → <InfoBlock> — within a form / card (helper context)
+
+Status of an item?
+  → <Badge>          — pill label (status / tag)
+  → <StatusBadge>    — colored dot + label (discriminated union: status="online"/"away"/...)
+  → <StatusDot>      — just the colored dot
+
+Temporary notification?
+  → toast.success / error / warning / info (imperative) — must have <Toaster /> mounted
+
+Loading / pending?
+  → <Spinner>           — generic
+  → <ProgressRing>      — determinate ring
+  → <Progress>          — linear bar
+  → <Skeleton>          — content placeholder shimmer
+  → <PageSkeletons.*>   — pre-built page-level skeletons
+  → <GlobalLoading>     — app-wide loading overlay
+
+Empty state?
+  → <EmptyState> — icon + heading + body + action
+```
+
+## Decision tree — overlays
+
+```
+Confirm a destructive action?         → <AlertDialog> or <ConfirmDialog>
+Show a form / detailed flow?          → <Dialog>  (auto fullScreen on mobile)
+Show a side panel?                    → <Sheet>   (auto bottom-drawer on mobile)
+Show a small floating popup on click? → <Popover>
+Show a small floating popup on hover? → <HoverCard>
+Show a label on hover?                → <Tooltip>
+Show a menu from a button?            → <DropdownMenu>
+Show a menu from right-click?         → <ContextMenu>
+Show a menu in a toolbar?             → <Menubar>
+Show a command palette (cmd+K)?       → <AppCommandPalette> (shell) or <CommandPalette> (composed)
+```
+
+## Decision tree — navigation
+
+```
+Top of every page?
+  → <TopBar> (shell)
+
+Side nav (product)?
+  → <AppSidebar> (shell) — collapsible, with sections, footer
+
+Tabs within a page?
+  → <Tabs>            — horizontal default
+  → <Tabs orientation="vertical"> — side-nav within a card
+
+Pages within a flow?
+  → <Stepper>         — multi-step wizard, optional clickable
+
+Breadcrumb trail?
+  → <Breadcrumb>
+
+Pagination?
+  → <Pagination>
+
+Mobile bottom nav?
+  → <BottomNavbar>
+```
+
+## Decision tree — layout
+
+```
+Page wrapper?
+  → <Container size="..."> — max-width constraints (sm / md / lg / xl / 2xl / full)
+
+Vertical / horizontal stack?
+  → <Stack direction="col|row" gap="ds-*">
+
+A card / panel?
+  → <Card> — surface-raised + shadow-raised
+  → <Card variant="..."> — tinted by color prop
+
+A grid?
+  → use native CSS grid utilities (grid grid-cols-12 gap-ds-05) — no kit primitive for this
+
+Aspect-ratio box?
+  → <AspectRatio ratio={16/9}>
+
+Divider?
+  → <Separator> (horizontal default; orientation="vertical")
+
+Collapsible section?
+  → <Collapsible> (single)
+  → <Accordion> (group, single-open or multi-open)
+```
+
+## Decision tree — data display
+
+```
+Tabular data?
+  → <Table>      — simple, hand-roll rows/cells
+  → <DataTable>  — full-featured (sort, paginate, select, filter, export, density, mobile-card)
+
+Key-value display?
+  → <StatCard>          — single big stat
+  → 4 StatCards in a row → use <Stack direction="row" gap="ds-05">
+
+Activity / event log?
+  → <ActivityFeed>      — vertical timeline with dots
+
+User avatars?
+  → <Avatar>           — single
+  → <AvatarGroup>       — stack with overflow
+
+A list of selectable members?
+  → <MemberPicker>
+
+A chart?
+  → BarChart / LineChart / AreaChart / PieChart / RadarChart / GaugeChart / Sparkline (from /ui/charts)
+
+Code?
+  → <Code> inline
+  → <MarkdownViewer> for rendered markdown
+```
+
+## Component catalog by category
+
+### Actions
+| Component | Subpath | Purpose |
+|---|---|---|
+| Button | `/ui/button` | Primary action element. |
+| IconButton | `/ui/icon-button` | Icon-only square button. |
+| ButtonGroup | `/ui/button-group` | Visually attached group. |
+| SplitButton | `/ui/split-button` | Action + dropdown. |
+| OAuthButton | `/ui/oauth-button` | Brand-aware social login button. |
+| Toggle | `/ui/toggle` | Toggled-state button. |
+| ToggleGroup | `/ui/toggle-group` | Group of toggles (single / multiple). |
+| Link | `/ui/link` | Themed anchor. |
+
+### Inputs
+| Component | Subpath |
+|---|---|
+| Input | `/ui/input` |
+| Textarea | `/ui/textarea` |
+| Select | `/ui/select` |
+| Combobox | `/ui/combobox` |
+| Autocomplete | `/ui/autocomplete` |
+| SearchInput | `/ui/search-input` |
+| NumberInput | `/ui/number-input` |
+| InputOTP | `/ui/input-otp` |
+| Checkbox | `/ui/checkbox` |
+| Radio | `/ui/radio` |
+| Switch | `/ui/switch` |
+| Slider | `/ui/slider` |
+| FileUpload | `/ui/file-upload` |
+| ColorInput | `/ui/color-input` |
+| ColorSwatch | `/ui/color-swatch` |
+| DatePicker | `/composed/date-picker` |
+| Label | `/ui/label` |
+| Form / FormField | `/ui/form` |
+| SegmentedControl | `/ui/segmented-control` |
+
+### Overlays
+| Component | Subpath |
+|---|---|
+| Dialog | `/ui/dialog` |
+| AlertDialog | `/ui/alert-dialog` |
+| Sheet | `/ui/sheet` |
+| Popover | `/ui/popover` |
+| HoverCard | `/ui/hover-card` |
+| Tooltip | `/ui/tooltip` |
+| DropdownMenu | `/ui/dropdown-menu` |
+| ContextMenu | `/ui/context-menu` |
+| Menubar | `/ui/menubar` |
+
+### Feedback
+| Component | Subpath |
+|---|---|
+| Alert | `/ui/alert` |
+| Banner | `/ui/banner` |
+| Toast / Toaster | `/ui/toast`, `/ui/toaster` |
+| Spinner | `/ui/spinner` |
+| Progress | `/ui/progress` |
+| ProgressRing | `/ui/progress-ring` |
+| Skeleton | `/ui/skeleton` |
+| Badge | `/ui/badge` |
+| StatusBadge | `/composed/status-badge` |
+| StatusDot | `/ui/status-dot` |
+| EmptyState | `/composed/empty-state` |
+
+### Layout
+| Component | Subpath |
+|---|---|
+| Container | `/ui/container` |
+| Stack | `/ui/stack` |
+| Card | `/ui/card` |
+| AspectRatio | `/ui/aspect-ratio` |
+| Separator | `/ui/separator` |
+| Accordion | `/ui/accordion` |
+| Collapsible | `/ui/collapsible` |
+
+### Navigation
+| Component | Subpath |
+|---|---|
+| Tabs | `/ui/tabs` |
+| Breadcrumb | `/ui/breadcrumb` |
+| Pagination | `/ui/pagination` |
+| Stepper | `/ui/stepper` |
+| NavigationMenu | `/ui/navigation-menu` |
+| Sidebar (AppSidebar) | `/shell/sidebar` |
+| TopBar | `/shell/top-bar` |
+| BottomNavbar | `/shell/bottom-navbar` |
+
+### Data display
+| Component | Subpath |
+|---|---|
+| Table | `/ui/table` |
+| DataTable | `/ui/data-table` |
+| StatCard | `/ui/stat-card` |
+| ActivityFeed | `/composed/activity-feed` |
+| Avatar | `/ui/avatar` |
+| AvatarGroup | `/composed/avatar-group` |
+| Text | `/ui/text` |
+| Code | `/ui/code` |
+| Charts (bar / line / area / pie / radar / gauge / sparkline) | `/ui/charts/*` |
+
+## Common props across components
+
+| Prop | Type | Where |
+|---|---|---|
+| `className` | string | All. Use sparingly. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl'` | Button, Input, Select, Card, Alert, Badge, Tabs, Checkbox, Radio, Slider, etc. Not all sizes exist on every component. |
+| `color` | `'accent' \| 'error' \| 'success' \| 'warning' \| 'info' \| 'neutral'` | Button, Badge, Card, Tabs (subset), Alert. |
+| `variant` | varies | Button (`solid|soft|outline|ghost|link`), Card, Alert, Badge, Select, etc. |
+| `disabled` | boolean | All interactive. Propagates from ButtonGroup. |
+| `loading` | boolean | Button, IconButton, OAuthButton, async-aware components. |
+
+## Per-component guides
+
+See `components/{button|card|input|dialog|badge|select|tabs|toast|form|table|dropdown-menu|popover|text|stack|icon}.md` for prop tables, examples, and rules.

--- a/packages/core/make-kit/components/popover.md
+++ b/packages/core/make-kit/components/popover.md
@@ -1,0 +1,201 @@
+# Popover
+
+Click-triggered floating panel for interactive content anchored to a trigger.
+
+```tsx
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+} from '@devalok/shilp-sutra/ui/popover'
+```
+
+## When to use
+
+- Interactive panel anchored to a button: filter form, date picker, color picker, share popover.
+- A list of actions? Use `<DropdownMenu>` — keyboard model differs (arrow nav vs. Tab nav).
+- Inert hover label (tooltip)? Use `<Tooltip>`.
+- Rich hover preview (user card, link preview)? Use `<HoverCard>`.
+- Critical full-attention interaction? Use `<Dialog>`.
+
+On mobile, Popover auto-promotes to a bottom drawer when it would overflow the viewport — don't rebuild this manually.
+
+## Compound shape
+
+```
+Popover (root — open, onOpenChange, defaultOpen, modal)
+  PopoverTrigger          ← asChild around your button
+  PopoverAnchor           ← optional, decouples trigger from positioning origin
+  PopoverContent          ← portalled, accepts side/align/sideOffset
+```
+
+## Root state props (Radix passthrough)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `open` | `boolean` | Controlled. |
+| `onOpenChange` | `(open: boolean) => void` | |
+| `defaultOpen` | `boolean` | Uncontrolled. |
+| `modal` | `boolean` | Default `false`. Set `true` for backdrop + focus trap (rare — usually use Dialog). |
+
+## PopoverContent positioning
+
+| Prop | Type | Notes |
+|---|---|---|
+| `side` | `'top'\|'right'\|'bottom'\|'left'` | Preferred side. Floats to opposite side if it would overflow. |
+| `align` | `'start'\|'center'\|'end'` | Alignment relative to trigger. |
+| `sideOffset` | `number` (px) | Gap between trigger and content. |
+| `collisionPadding` | `number \| { top, right, bottom, left }` | Distance from viewport edges before flipping. |
+
+All Floating-UI positioning options pass through via Radix.
+
+## Examples
+
+**Filter form:**
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="soft" startIcon={IconFilter}>Filters</Button>
+  </PopoverTrigger>
+  <PopoverContent align="start">
+    <Stack gap="ds-04">
+      <FormField>
+        <Label htmlFor="status">Status</Label>
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger id="status">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="active">Active</SelectItem>
+            <SelectItem value="archived">Archived</SelectItem>
+          </SelectContent>
+        </Select>
+      </FormField>
+      <Stack direction="horizontal" gap="ds-03" justify="end">
+        <Button variant="ghost" size="sm" onClick={reset}>Clear</Button>
+        <Button size="sm" onClick={apply}>Apply</Button>
+      </Stack>
+    </Stack>
+  </PopoverContent>
+</Popover>
+```
+
+**Date picker:**
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="soft" startIcon={IconCalendar}>
+      {date ? formatDate(date) : 'Pick a date'}
+    </Button>
+  </PopoverTrigger>
+  <PopoverContent>
+    <Calendar value={date} onChange={(d) => { setDate(d); setOpen(false) }} />
+  </PopoverContent>
+</Popover>
+```
+
+**Share popover with copy link:**
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="soft" startIcon={IconShare}>Share</Button>
+  </PopoverTrigger>
+  <PopoverContent side="bottom" align="end">
+    <Stack gap="ds-03">
+      <Text variant="label-sm">Share link</Text>
+      <Stack direction="horizontal" gap="ds-02">
+        <Input value={shareUrl} readOnly className="flex-1" />
+        <IconButton
+          icon={<Icon icon={copied ? IconCheck : IconCopy} />}
+          variant="soft"
+          aria-label="Copy link"
+          onClick={() => { navigator.clipboard.writeText(shareUrl); setCopied(true) }}
+        />
+      </Stack>
+    </Stack>
+  </PopoverContent>
+</Popover>
+```
+
+**Decoupled anchor (trigger ≠ positioning origin):**
+```tsx
+<Popover>
+  <PopoverAnchor>
+    <Card>
+      <CardHeader>
+        <CardTitle>Project</CardTitle>
+        <PopoverTrigger asChild>
+          <IconButton icon={<Icon icon={IconInfo} />} variant="ghost" size="sm" aria-label="About" />
+        </PopoverTrigger>
+      </CardHeader>
+    </Card>
+  </PopoverAnchor>
+  <PopoverContent side="top">
+    Popover positions relative to the whole Card, not the small info button.
+  </PopoverContent>
+</Popover>
+```
+
+**Inside a Dialog (nested overlays work correctly):**
+```tsx
+<Dialog>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>Schedule meeting</DialogTitle>
+    </DialogHeader>
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="soft">Pick a time</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <TimePicker value={time} onChange={setTime} />
+      </PopoverContent>
+    </Popover>
+  </DialogContent>
+</Dialog>
+```
+
+Popover uses `z-popover` (1400), above `z-dialog`. Nesting works without z-index fights.
+
+**Controlled with custom close behavior:**
+```tsx
+const [open, setOpen] = useState(false)
+
+<Popover open={open} onOpenChange={setOpen}>
+  <PopoverTrigger asChild>
+    <Button>Open</Button>
+  </PopoverTrigger>
+  <PopoverContent
+    onInteractOutside={(e) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault()
+        confirmClose().then((ok) => ok && setOpen(false))
+      }
+    }}
+  >
+    <UnsavedForm />
+  </PopoverContent>
+</Popover>
+```
+
+## Composability
+
+- **Built on Radix Popover** — every standard Radix prop passes through.
+- **Portal rendering:** PopoverContent portals to body. CSS `overflow: hidden` / `transform` on ancestors don't clip it.
+- **z-popover (1400):** Above Dialog (`z-dialog`). Nested popovers inside dialogs stack correctly.
+- **PopoverAnchor:** Decouples the visual anchor from the interactive trigger. Useful when the trigger is small (icon button) but the popover should position relative to a larger surrounding element.
+
+See `foundations/surfaces.md` for overlay surface, `foundations/motion.md` for the spring open animation, `foundations/spacing.md` for internal popover padding.
+
+## Rules
+
+- Use Popover for interactive content (forms, pickers). Use DropdownMenu for action lists — different keyboard model.
+- `<PopoverTrigger asChild>` around any focusable element — usually a Button or IconButton.
+- Set `modal={true}` only when the popover blocks interaction with the rest of the page. Default `false` is correct for filters / pickers.
+- Set explicit `side` + `align` for predictable positioning. Defaults bottom-center, but designs often want `align="end"` for right-anchored triggers.
+- Don't use Popover for tooltips — Tooltip is for inert hover labels. Popover requires explicit click.
+- Don't nest Popover inside Popover. Use a single Popover with stepped content, or close the first before opening the second.
+- For complex form flows that need full attention, switch to Dialog. Popovers shouldn't host multi-step wizards.
+- The internal padding inside `PopoverContent` is preset — don't add wrapper divs with extra padding. Use `<Stack gap>` to space content.

--- a/packages/core/make-kit/components/select.md
+++ b/packages/core/make-kit/components/select.md
@@ -1,0 +1,148 @@
+# Select
+
+Single-choice picker from a short fixed list. Use instead of `<select>`.
+
+```tsx
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectGroup,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+} from '@devalok/shilp-sutra/ui/select'
+```
+
+## When to use
+
+- Fixed list under ~15 items, no search needed (status, priority, role).
+- Need typeahead / search across many options? Use `<Combobox>`.
+- Free-text with suggestions? Use `<Autocomplete>`.
+- Multi-select? Use `<MultiSelect>` or `<Combobox multiple>`.
+- Yes/no toggle? Use `<Switch>` or `<RadioGroup>` with 2 options.
+
+## Compound shape
+
+```
+Select (root — value, onValueChange, defaultValue)
+  SelectTrigger              ← variant / color / size go HERE
+    SelectValue (placeholder)
+  SelectContent
+    SelectGroup (optional)
+      SelectLabel            ← non-interactive section header
+      SelectItem (value)     ← REQUIRED value, unique
+    SelectSeparator
+```
+
+## SelectTrigger props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `variant` | `'default'\|'outline'\|'ghost'` | Default `default`. |
+| `color` | `'default'\|'error'\|'success'\|'warning'` | Default `default`. `error` sets `aria-invalid`. |
+| `size` | `'xs'\|'sm'\|'md'\|'lg'` | Default `md`. |
+
+Styling lives on the **Trigger**, not on `Select` root. Setting `<Select size="lg">` does nothing — TypeScript won't catch it.
+
+## Root state props (Radix passthrough)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `value` | `string` | Controlled value. |
+| `onValueChange` | `(value: string) => void` | Fires on select. |
+| `defaultValue` | `string` | Uncontrolled. |
+| `open` | `boolean` | Controlled open state. |
+| `onOpenChange` | `(open: boolean) => void` | |
+
+## Examples
+
+**Standard:**
+```tsx
+<Select onValueChange={setStatus}>
+  <SelectTrigger>
+    <SelectValue placeholder="Status" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="todo">To do</SelectItem>
+    <SelectItem value="doing">In progress</SelectItem>
+    <SelectItem value="done">Done</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+**With grouped items and a separator:**
+```tsx
+<Select value={assignee} onValueChange={setAssignee}>
+  <SelectTrigger size="sm">
+    <SelectValue placeholder="Assignee" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>Team</SelectLabel>
+      <SelectItem value="alice">Alice</SelectItem>
+      <SelectItem value="bob">Bob</SelectItem>
+    </SelectGroup>
+    <SelectSeparator />
+    <SelectGroup>
+      <SelectLabel>External</SelectLabel>
+      <SelectItem value="contractor-1">Contractor 1</SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>
+```
+
+**Inside a FormField (manual error wiring):**
+```tsx
+<FormField state={errors.role ? 'error' : 'helper'}>
+  <Label htmlFor="role">Role</Label>
+  <Select value={role} onValueChange={setRole}>
+    <SelectTrigger id="role" color={errors.role ? 'error' : 'default'}>
+      <SelectValue placeholder="Choose a role" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="admin">Admin</SelectItem>
+      <SelectItem value="member">Member</SelectItem>
+      <SelectItem value="viewer">Viewer</SelectItem>
+    </SelectContent>
+  </Select>
+  {errors.role && <FormHelperText>{errors.role}</FormHelperText>}
+</FormField>
+```
+
+Select doesn't auto-consume FormField context (unlike Input / Textarea). Set `color="error"` on `SelectTrigger` manually.
+
+**Ghost variant in a toolbar:**
+```tsx
+<Select value={sort} onValueChange={setSort} defaultValue="recent">
+  <SelectTrigger variant="ghost" size="sm">
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="recent">Most recent</SelectItem>
+    <SelectItem value="oldest">Oldest</SelectItem>
+    <SelectItem value="az">A → Z</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+## Composability
+
+- **Radix Select** underneath — `value` / `onValueChange` / `defaultValue` / `open` / `onOpenChange` standard state.
+- **Portal + z-popover (1400):** SelectContent portals to body, stacks above Dialog / Sheet / other overlays.
+- **SelectItem requires a unique `value`** — duplicates produce undefined selection behavior.
+- **FormField integration is manual** — wire `color="error"` on SelectTrigger from your validation state.
+
+See `foundations/surfaces.md` for the overlay surface, `foundations/color.md` for state colors.
+
+## Rules
+
+- Put `variant` / `color` / `size` on `SelectTrigger`, NOT on `Select` root.
+- Every `SelectItem` needs a unique `value` prop.
+- For lists over ~15 items or when users will scan for a term, switch to `<Combobox>` — Select has no typeahead.
+- Set `color="error"` on `SelectTrigger` for validation failures — Select doesn't auto-consume FormField state.
+- Don't use Select for multi-value capture — use `<MultiSelect>` or `<Combobox multiple>`.
+- Always render `<SelectValue placeholder="..." />` — without it, the trigger renders empty before any selection.
+- Group related items with `<SelectGroup>` + `<SelectLabel>` — flat lists over 8 items get hard to scan.
+- Don't customize the dropdown surface — overlays use `surface-1` per `foundations/surfaces.md`.

--- a/packages/core/make-kit/components/stack.md
+++ b/packages/core/make-kit/components/stack.md
@@ -1,0 +1,165 @@
+# Stack
+
+Flexbox layout primitive. Use instead of `<div className="flex flex-col gap-4">` everywhere.
+
+```tsx
+import { Stack } from '@devalok/shilp-sutra/ui/stack'
+```
+
+## When to use
+
+- Stacking elements vertically or horizontally with consistent gap.
+- Any time you'd write `flex` + `gap-*` + `items-*` + `justify-*` on a div.
+- Centering + width-capping a page section? Use `<Container>`, then a `<Stack>` inside.
+- Grid layouts (rows × columns)? Use a Tailwind `grid` div directly — Stack is for one-axis layouts.
+
+Server-safe — no hydration, no context.
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `direction` | `'vertical'\|'horizontal'\|'row'\|'column'` | Default `vertical`. `row` = `horizontal`, `column` = `vertical` (aliases). |
+| `gap` | `'ds-01'..'ds-13'` \| `0..13` | Design-system spacing token. Numbers map 1:1 to `ds-0N`. |
+| `align` | `'start'\|'center'\|'end'\|'stretch'\|'baseline'` | Cross-axis alignment (`align-items`). |
+| `justify` | `'start'\|'center'\|'end'\|'between'\|'around'\|'evenly'` | Main-axis alignment (`justify-content`). |
+| `wrap` | `boolean` | Enables `flex-wrap`. |
+| `as` | `ElementType` | Default `'div'`. Polymorphic. |
+| `className` | `string` | For overrides — don't reach for raw `flex-*` utilities. |
+
+## Gap cadence
+
+Default to the 3-tier cadence from `foundations/spacing.md`:
+
+| Gap | Use |
+|---|---|
+| `ds-03` (8 px) | Related items inside a group (icon + label, button row). |
+| `ds-05` (16 px) | Grouped sections within a card / form. |
+| `ds-07` (32 px) | Page sections / major regions. |
+
+Don't reach for every adjacent token. If `ds-04` "feels right," it usually means a parent's padding or the section relationship needs a rethink.
+
+## Examples
+
+**Vertical form layout:**
+```tsx
+<Stack gap="ds-05">
+  <FormField>
+    <Label htmlFor="name">Name</Label>
+    <Input id="name" />
+  </FormField>
+  <FormField>
+    <Label htmlFor="email">Email</Label>
+    <Input id="email" />
+  </FormField>
+</Stack>
+```
+
+**Horizontal toolbar:**
+```tsx
+<Stack direction="horizontal" gap="ds-03" align="center">
+  <Button variant="soft" startIcon={IconFilter}>Filter</Button>
+  <Button variant="soft" startIcon={IconSortDescending}>Sort</Button>
+  <Separator orientation="vertical" className="h-6" />
+  <Button variant="solid" startIcon={IconPlus}>New</Button>
+</Stack>
+```
+
+**Avatar + label cluster:**
+```tsx
+<Stack direction="horizontal" gap="ds-03" align="center">
+  <Avatar size="sm" src={user.avatar} alt={user.name} />
+  <Stack gap="ds-01">
+    <Text variant="label-plain-sm">{user.name}</Text>
+    <Text variant="body-xs" className="text-fg-muted">{user.role}</Text>
+  </Stack>
+</Stack>
+```
+
+**Page-section spacing:**
+```tsx
+<Container>
+  <Stack gap="ds-07">
+    <PageHeader title="Projects" description="A workspace for everything you ship." />
+    <Stack gap="ds-05">
+      <SectionHeader title="Active" />
+      <ProjectGrid projects={active} />
+    </Stack>
+    <Stack gap="ds-05">
+      <SectionHeader title="Archived" />
+      <ProjectGrid projects={archived} />
+    </Stack>
+  </Stack>
+</Container>
+```
+
+**Wrap for tag cluster:**
+```tsx
+<Stack direction="horizontal" gap="ds-02" wrap>
+  {tags.map((tag) => <Badge key={tag} color="neutral">{tag}</Badge>)}
+</Stack>
+```
+
+For tag clusters specifically, prefer `<Badge.Group>` — it handles overflow with `+N` automatically.
+
+**Justify-between (label + action):**
+```tsx
+<Stack direction="horizontal" gap="ds-04" align="center" justify="between">
+  <Text variant="heading-md">Team</Text>
+  <Button variant="soft" startIcon={IconPlus} size="sm">Invite</Button>
+</Stack>
+```
+
+**Polymorphic — semantic list:**
+```tsx
+<Stack as="ul" gap="ds-03">
+  {items.map((item) => (
+    <Stack as="li" key={item.id} direction="horizontal" gap="ds-03" align="center">
+      <Icon icon={IconCheck} />
+      <Text variant="body-sm">{item.label}</Text>
+    </Stack>
+  ))}
+</Stack>
+```
+
+**Numeric gap shortcut:**
+```tsx
+<Stack gap={5}>  {/* same as gap="ds-05" */}
+  …
+</Stack>
+```
+
+**Inside Card (no extra padding):**
+```tsx
+<Card>
+  <CardContent>
+    <Stack gap="ds-04">
+      <Text variant="label-sm" className="text-fg-muted">REVENUE</Text>
+      <Text variant="heading-xl">$2.4M</Text>
+      <Text variant="body-sm" className="text-fg-muted">+18% YoY</Text>
+    </Stack>
+  </CardContent>
+</Card>
+```
+
+CardContent already supplies the outer padding. Stack just spaces the children.
+
+## Composability
+
+- **Server-safe.** Nothing to hydrate. Use in RSC trees.
+- **Polymorphic via `as`** — `<Stack as="ul">`, `<Stack as="section">`, `<Stack as="nav">`. Inherits flex behavior on the chosen element.
+- **Compose with Container:** `<Container><Stack>...</Stack></Container>`. Container centers + caps width; Stack arranges children.
+- **No responsive direction prop** — for `flex-col md:flex-row` use a plain div with Tailwind utilities directly, or render two Stacks with display toggling.
+
+See `foundations/spacing.md` for the gap cadence, `foundations/surfaces.md` for layout-on-surfaces context.
+
+## Rules
+
+- Default to the `ds-03 / ds-05 / ds-07` cadence. Reach for other tokens only with a deliberate reason.
+- Use Stack everywhere you'd write `flex` + `gap` on a div. Don't mix Stack and raw flex utilities in the same tree.
+- For grid (2D) layouts, use a plain `grid` div. Stack is one-axis only.
+- For responsive direction changes, drop to a plain div with Tailwind responsive flex utilities. Stack doesn't have a responsive direction prop.
+- Don't add padding to a Stack — wrap it in a Container or Card. Padding lives on containers, not layout primitives.
+- For tag clusters with potential overflow, use `<Badge.Group>` instead of `<Stack wrap>` — it handles `+N` collapsing.
+- Numeric `gap={4}` and string `gap="ds-04"` are equivalent. Pick a convention per file and stick with it.
+- `direction="row"` and `direction="column"` are aliases for `horizontal` / `vertical`. Pick one naming pair per codebase.

--- a/packages/core/make-kit/components/table.md
+++ b/packages/core/make-kit/components/table.md
@@ -1,0 +1,215 @@
+# Table
+
+Server-safe semantic wrappers around `<table>`. For static / presentational tables.
+
+```tsx
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableRow,
+  TableHead,
+  TableCell,
+  TableCaption,
+} from '@devalok/shilp-sutra/ui/table'
+```
+
+## When to use
+
+- Static or small data displays where you control every row and cell.
+- Marketing / pricing comparison tables.
+- Documentation tables (API references, prop tables).
+- Server-rendered tables (RSC) — Table and sub-components are server-safe.
+- Need sorting / filtering / pagination / selection / virtualization? Use `<DataTable>` from `@devalok/shilp-sutra/ui/data-table` — out of scope for this guide.
+
+## Compound shape
+
+```
+Table (<table>)
+  TableCaption (<caption>)        ← optional summary for screen readers
+  TableHeader (<thead>)
+    TableRow (<tr>)
+      TableHead (<th scope="col">)
+  TableBody (<tbody>)
+    TableRow (<tr>)
+      TableCell (<td>)
+  TableFooter (<tfoot>)
+    TableRow
+      TableCell
+```
+
+Each component is a thin semantic wrapper — no props beyond standard HTML attributes plus `className`.
+
+## Examples
+
+**Standard:**
+```tsx
+<Table>
+  <TableHeader>
+    <TableRow>
+      <TableHead>Name</TableHead>
+      <TableHead>Status</TableHead>
+      <TableHead>Owner</TableHead>
+      <TableHead>Updated</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {projects.map((p) => (
+      <TableRow key={p.id}>
+        <TableCell>{p.name}</TableCell>
+        <TableCell>
+          <Badge color={p.status === 'active' ? 'success' : 'neutral'}>
+            {p.status}
+          </Badge>
+        </TableCell>
+        <TableCell>
+          <Stack direction="horizontal" gap="ds-02" align="center">
+            <Avatar size="xs" src={p.owner.avatar} alt={p.owner.name} />
+            <Text variant="body-sm">{p.owner.name}</Text>
+          </Stack>
+        </TableCell>
+        <TableCell>
+          <Text variant="body-sm" className="text-fg-muted">
+            {formatDate(p.updatedAt)}
+          </Text>
+        </TableCell>
+      </TableRow>
+    ))}
+  </TableBody>
+</Table>
+```
+
+**With caption + footer:**
+```tsx
+<Table>
+  <TableCaption>Q4 revenue by region.</TableCaption>
+  <TableHeader>
+    <TableRow>
+      <TableHead>Region</TableHead>
+      <TableHead>Revenue</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow><TableCell>NA</TableCell><TableCell>$1.2M</TableCell></TableRow>
+    <TableRow><TableCell>EU</TableCell><TableCell>$0.8M</TableCell></TableRow>
+    <TableRow><TableCell>APAC</TableCell><TableCell>$0.4M</TableCell></TableRow>
+  </TableBody>
+  <TableFooter>
+    <TableRow>
+      <TableCell><Text variant="label-sm">Total</Text></TableCell>
+      <TableCell><Text variant="label-sm">$2.4M</Text></TableCell>
+    </TableRow>
+  </TableFooter>
+</Table>
+```
+
+**Row actions (IconButton in last cell):**
+```tsx
+<Table>
+  <TableHeader>
+    <TableRow>
+      <TableHead>File</TableHead>
+      <TableHead>Size</TableHead>
+      <TableHead className="w-12" />
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {files.map((f) => (
+      <TableRow key={f.id}>
+        <TableCell>{f.name}</TableCell>
+        <TableCell>{formatFileSize(f.size)}</TableCell>
+        <TableCell>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton icon={<Icon icon={IconDots} />} variant="ghost" size="sm" aria-label="Actions" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onSelect={() => download(f)}>Download</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => remove(f)}>Delete</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </TableCell>
+      </TableRow>
+    ))}
+  </TableBody>
+</Table>
+```
+
+**Inside a Card:**
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>Team members</CardTitle>
+  </CardHeader>
+  <CardContent>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Member</TableHead>
+          <TableHead>Role</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {members.map((m) => (
+          <TableRow key={m.id}>
+            <TableCell>{m.name}</TableCell>
+            <TableCell><Badge color="neutral">{m.role}</Badge></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </CardContent>
+</Card>
+```
+
+When inside a `<Card>`, the Table's surrounding padding comes from `CardContent`. Don't add extra padding on the Table.
+
+**Server-rendered table (RSC):**
+```tsx
+// app/projects/page.tsx — no 'use client'
+export default async function ProjectsPage() {
+  const projects = await db.projects.findMany()
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {projects.map((p) => (
+          <TableRow key={p.id}>
+            <TableCell>{p.name}</TableCell>
+            <TableCell><Badge>{p.status}</Badge></TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  )
+}
+```
+
+Table + Badge (server-safe via Badge.Group context — verify per use) + Avatar all render in RSC trees. Skip client components.
+
+## Composability
+
+- **Server-safe:** Table and its sub-components are pure HTML semantic wrappers. No state, no context. Use in RSC trees without `'use client'`.
+- **TableHead scope:** Headers automatically get `scope="col"` for screen-reader navigation. Don't override it.
+- **Composes with primitives:** Drop `<Badge>`, `<Avatar>`, `<IconButton>`, `<StatusDot>` inside cells. Check each component's server-safety if you need RSC compatibility.
+- **TableCaption:** Renders as HTML `<caption>` — screen readers announce it before content. Use it for any non-trivial table.
+
+See `foundations/typography.md` for the body / label variants inside cells, `foundations/surfaces.md` for table-in-card surface guidance.
+
+## Rules
+
+- For anything with sorting / filtering / pagination / selection / virtualization, use `<DataTable>` from `/ui/data-table`. Don't rebuild that machinery on bare Table.
+- Always wrap header cells in `<TableHead>` (renders `<th>`). Don't use `<TableCell>` (`<td>`) in headers — breaks screen-reader column scope.
+- Use `<TableCaption>` for any table that's not self-evident. Renders the HTML `<caption>` which screen readers announce.
+- Inside Card, drop the Table directly in `<CardContent>` — don't add wrapper divs that fight the card's padding cascade.
+- For wide tables on mobile, wrap in an `overflow-x-auto` container. Don't try to make a Table responsive via column stacking — switch to a card list on small viewports.
+- Don't style cell text with raw Tailwind palette utilities. Use `text-fg-muted` from `foundations/color.md`.
+- Compose with Badge for status, Avatar for users, IconButton for row actions. Don't invent new primitives per table.
+- Keep TableCell content single-line where possible — multi-line cells make scanning hard. Use `<Stack>` only when each row genuinely needs two lines.

--- a/packages/core/make-kit/components/tabs.md
+++ b/packages/core/make-kit/components/tabs.md
@@ -1,0 +1,162 @@
+# Tabs
+
+Switch between sibling views inside a single region. Not for top-level navigation.
+
+```tsx
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@devalok/shilp-sutra/ui/tabs'
+```
+
+## When to use
+
+- Sub-sections of a single page / panel that share context (Overview / Activity / Settings on a project).
+- Filtered views over the same dataset (All / Mine / Archived).
+- Need URL-driven routes per tab? Wire `value` / `onValueChange` to router state.
+- Top-level app navigation? Use `<Sidebar>` / `<TopBar>`, not Tabs.
+- Multi-step flows? Use `<Stepper>` or a wizard pattern.
+
+## Compound shape
+
+```
+Tabs (root — value, defaultValue, onValueChange)
+  TabsList (variant, size, orientation)
+    TabsTrigger (value)         ← inherits variant/size/orientation from TabsList
+  TabsContent (value)           ← rendered inline (not portalled)
+```
+
+## TabsList props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `variant` | `'line'\|'contained'` | Default `line`. |
+| `size` | `'sm'\|'md'\|'lg'` | Default `md`. |
+| `orientation` | `'horizontal'\|'vertical'` | Default `horizontal`. Vertical also changes keyboard nav to ArrowUp/Down. |
+| `color` | `'accent'\|'neutral'` | Affects the line-variant active indicator. |
+
+## Variants
+
+| Variant | When |
+|---|---|
+| `line` (default) | Underline active indicator. Most common — pairs with section headings. |
+| `contained` | Pill background per active trigger. Use inside cards or compact toolbars. |
+
+## Root state props (Radix passthrough)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `value` | `string` | Controlled active tab. |
+| `defaultValue` | `string` | Uncontrolled initial tab. |
+| `onValueChange` | `(value: string) => void` | Fires on tab change. |
+
+## TabsTrigger / TabsContent
+
+Both require a `value: string` prop. The values must match between a trigger and its content.
+
+`TabsTrigger` reads `variant` / `size` / `orientation` from `TabsList` via context. Override per-trigger if needed, but normally don't.
+
+## Examples
+
+**Standard line tabs:**
+```tsx
+<Tabs defaultValue="overview">
+  <TabsList>
+    <TabsTrigger value="overview">Overview</TabsTrigger>
+    <TabsTrigger value="activity">Activity</TabsTrigger>
+    <TabsTrigger value="settings">Settings</TabsTrigger>
+  </TabsList>
+  <TabsContent value="overview">
+    <ProjectOverview />
+  </TabsContent>
+  <TabsContent value="activity">
+    <ActivityFeed />
+  </TabsContent>
+  <TabsContent value="settings">
+    <ProjectSettings />
+  </TabsContent>
+</Tabs>
+```
+
+**Contained variant inside a card:**
+```tsx
+<Card>
+  <CardContent>
+    <Tabs defaultValue="day">
+      <TabsList variant="contained" size="sm">
+        <TabsTrigger value="day">Day</TabsTrigger>
+        <TabsTrigger value="week">Week</TabsTrigger>
+        <TabsTrigger value="month">Month</TabsTrigger>
+      </TabsList>
+      <TabsContent value="day"><Chart range="day" /></TabsContent>
+      <TabsContent value="week"><Chart range="week" /></TabsContent>
+      <TabsContent value="month"><Chart range="month" /></TabsContent>
+    </Tabs>
+  </CardContent>
+</Card>
+```
+
+**Vertical orientation (settings-style):**
+```tsx
+<Tabs defaultValue="account" orientation="vertical">
+  <Stack direction="horizontal" gap="ds-07" align="start">
+    <TabsList orientation="vertical">
+      <TabsTrigger value="account">Account</TabsTrigger>
+      <TabsTrigger value="billing">Billing</TabsTrigger>
+      <TabsTrigger value="notifications">Notifications</TabsTrigger>
+    </TabsList>
+    <div className="flex-1">
+      <TabsContent value="account"><AccountForm /></TabsContent>
+      <TabsContent value="billing"><BillingForm /></TabsContent>
+      <TabsContent value="notifications"><NotificationsForm /></TabsContent>
+    </div>
+  </Stack>
+</Tabs>
+```
+
+**With icons + badges:**
+```tsx
+<Tabs defaultValue="inbox">
+  <TabsList>
+    <TabsTrigger value="inbox">
+      <Icon icon={IconInbox} /> Inbox
+      <Badge size="xs" color="accent">12</Badge>
+    </TabsTrigger>
+    <TabsTrigger value="sent">
+      <Icon icon={IconSend} /> Sent
+    </TabsTrigger>
+  </TabsList>
+  <TabsContent value="inbox"><InboxList /></TabsContent>
+  <TabsContent value="sent"><SentList /></TabsContent>
+</Tabs>
+```
+
+**Router-driven (Next.js App Router):**
+```tsx
+'use client'
+const router = useRouter()
+const pathname = usePathname()
+const tab = pathname.split('/').pop() ?? 'overview'
+
+<Tabs value={tab} onValueChange={(v) => router.push(`/projects/${id}/${v}`)}>
+  <TabsList>
+    <TabsTrigger value="overview">Overview</TabsTrigger>
+    <TabsTrigger value="activity">Activity</TabsTrigger>
+  </TabsList>
+</Tabs>
+```
+
+## Composability
+
+- **Context cascade:** `TabsList` propagates `variant` / `size` / `orientation` to every child `TabsTrigger`. Don't repeat those props on each trigger.
+- **Inline content:** `TabsContent` renders inline (not portalled). Container-scoped queries in tests work.
+- **Keyboard:** Roving tabindex via Radix — ArrowLeft/Right (horizontal) or ArrowUp/Down (vertical). Home / End jump to first / last. Don't re-implement.
+
+See `foundations/spacing.md` for the gap between TabsList and TabsContent, `foundations/icons.md` for icon sizing inside triggers.
+
+## Rules
+
+- Put `variant` / `size` / `orientation` on `TabsList`, NOT on `Tabs` root or `TabsTrigger`.
+- Every `TabsTrigger` and `TabsContent` needs a `value` — the values must match.
+- For top-level app navigation use Sidebar / TopBar, not Tabs.
+- Don't stack two Tabs inside the same region — pick one. Nested tabs confuse keyboard nav and section structure.
+- For router-bound tabs, keep `value` controlled — don't mix `defaultValue` with router-driven URLs.
+- For 5+ tabs that overflow on mobile, consider a Select dropdown on small viewports or wrap in a horizontally scrollable container.
+- Icons in TabsTrigger don't auto-size via IconProvider — set explicit `<Icon icon={...} size="sm" />` when the trigger feels off.

--- a/packages/core/make-kit/components/text.md
+++ b/packages/core/make-kit/components/text.md
@@ -1,0 +1,139 @@
+# Text
+
+Typography primitive. Use instead of raw `<h1>`–`<h6>`, `<p>`, `<span>` for any visible text.
+
+```tsx
+import { Text } from '@devalok/shilp-sutra/ui/text'
+```
+
+## When to use
+
+- Any visible text: headings, body copy, captions, section labels, inline microcopy.
+- Inline code spans inside body text? Pair with `<Code>`.
+- Polymorphic — `<Text as="span">`, `<Text as="div">`, etc. — to demote semantics while keeping visual weight.
+- Server-safe — renders in RSC trees without `'use client'`.
+
+## Variants
+
+| Variant | Default element | Use |
+|---|---|---|
+| `heading-2xl` | `h1` | Page title / hero. |
+| `heading-xl` | `h2` | Section title. |
+| `heading-lg` | `h3` | Sub-section title. |
+| `heading-md` | `h4` | Card title (used by `<CardTitle>`). |
+| `heading-sm` | `h5` | Compact sub-heading. |
+| `heading-xs` | `h6` | Smallest heading. |
+| `body-lg` | `p` | Lead paragraphs. |
+| `body-md` (default) | `p` | Standard body. |
+| `body-sm` | `p` | Dense body — captions inside cards, table cells. |
+| `body-xs` | `p` | Footnotes, fine print. |
+| `label-lg` / `md` / `sm` / `xs` | `span` | UPPERCASE section labels, eyebrows. |
+| `label-plain-lg` / `md` / `sm` / `xs` | `span` | Mixed-case labels (form labels, inline UI text). |
+| `caption` | `span` | Image / chart captions. |
+| `overline` | `span` | UPPERCASE marketing eyebrow. |
+| `code` | `code` | Inline monospace code. |
+
+`label-*` and `overline` variants are automatically uppercase. `label-plain-*` keeps mixed case.
+
+## Props
+
+| Prop | Type | Notes |
+|---|---|---|
+| `variant` | See variants table | Default `body-md`. |
+| `as` | `ElementType` | Override the auto-selected HTML element. |
+| `className` | `string` | For color / alignment overrides. Use semantic tokens only. |
+
+Plus all standard HTML attributes for whatever element it renders.
+
+## Examples
+
+**Page heading + body:**
+```tsx
+<Stack gap="ds-04">
+  <Text variant="heading-2xl">Projects</Text>
+  <Text variant="body-md" className="text-fg-muted">
+    A workspace for everything you ship.
+  </Text>
+</Stack>
+```
+
+**Section label + heading pair:**
+```tsx
+<Stack gap="ds-02">
+  <Text variant="label-sm" className="text-fg-muted">REVENUE</Text>
+  <Text variant="heading-xl">$2.4M</Text>
+  <Text variant="body-sm" className="text-fg-muted">+18% YoY</Text>
+</Stack>
+```
+
+**Visual demotion via `as`:**
+```tsx
+{/* h2-sized heading rendered as a div — useful when the element already has a heading ancestor */}
+<Card>
+  <CardHeader>
+    <CardTitle>Activity</CardTitle> {/* h4 */}
+    <Text variant="heading-xl" as="div">Weekly summary</Text>
+  </CardHeader>
+</Card>
+```
+
+**Inline span inside a paragraph:**
+```tsx
+<Text>
+  Press <Text as="kbd" variant="code">⌘ K</Text> to open the command palette.
+</Text>
+```
+
+**Caption under an image:**
+```tsx
+<Stack gap="ds-02">
+  <img src={chart} alt="" />
+  <Text variant="caption" className="text-fg-muted">
+    Figure 1. Active users by region.
+  </Text>
+</Stack>
+```
+
+**Form field label (label-plain variant):**
+```tsx
+<Stack gap="ds-02">
+  <Text variant="label-plain-sm" as="label" htmlFor="email">Email</Text>
+  <Input id="email" type="email" />
+</Stack>
+```
+
+Use `<Label>` for form fields when wired with FormField — `Text` is for non-form labels.
+
+**Body with inline code:**
+```tsx
+<Text>
+  Call <Code>onSubmit</Code> with the form values, or pass <Code>asChild</Code> to merge with a child element.
+</Text>
+```
+
+**Truncated single line:**
+```tsx
+<Text variant="body-sm" className="truncate max-w-[200px]">
+  {longUserName}
+</Text>
+```
+
+## Composability
+
+- **Server-safe.** No client hooks. Use freely in RSC trees.
+- **No context cascade** — pure typography primitive. Variants don't propagate through children.
+- **Underpins other components.** `<CardTitle>`, `<Alert>`'s title, `<PageHeader>`, `<EmptyState>`, `<SectionHeader>` all render Text internally with specific variants. Don't wrap another Text inside them.
+- **`as` overrides element only, not variant.** Visual weight stays. Use to demote semantics when you have a heading ancestor.
+
+See `foundations/typography.md` for the full type scale, line-height tokens, font stack.
+
+## Rules
+
+- Use Text for every visible text element. Don't write raw `<h1>` / `<p>` / `<span>` with manual classes.
+- Pick variant by semantic intent, not visual size. `heading-xl` is an `<h2>` — use it for section headings, not because you want big text in a body paragraph (use `as="div"` for that).
+- Don't wrap a `<Text>` inside `<CardTitle>` / `<Alert>` title — they already render Text internally.
+- `label-*` and `overline` variants are automatically uppercase. Don't add `uppercase` class.
+- For form labels paired with controls, use `<Label htmlFor>` from `/ui/label`. `Text variant="label-plain-*"` is for non-form labels.
+- Color overrides go through semantic tokens (`text-fg-muted`, `text-fg`, `text-fg-subtle`). Never raw Tailwind palette utilities.
+- Don't use Text inside another semantic heading — it produces nested headings that break screen-reader navigation.
+- For inline code, use `<Code>`. `Text variant="code"` works but Code is the dedicated primitive.

--- a/packages/core/make-kit/components/toast.md
+++ b/packages/core/make-kit/components/toast.md
@@ -1,0 +1,193 @@
+# Toast
+
+Transient floating notification. Imperative API — call from event handlers, never render JSX.
+
+```tsx
+import { toast } from '@devalok/shilp-sutra/ui/toast'
+import { Toaster } from '@devalok/shilp-sutra/ui/toaster'
+```
+
+## When to use
+
+- Confirmation after an action (saved, copied, sent).
+- Non-blocking error feedback (failed to save — try again).
+- Async progress with success/failure resolution — use `toast.promise`.
+- File upload progress — use `toast.upload`.
+- Inline in-flow message that must stay visible? Use `<Alert>`.
+- Page-level strip (cookie banner, account warning)? Use `<Banner>`.
+- Modal interruption? Use `<Dialog>`.
+
+## Setup
+
+Mount `<Toaster />` **once** at the app root. Every `toast.*` call routes to this single container.
+
+```tsx
+// app/layout.tsx (Next.js) or src/App.tsx
+import { Toaster } from '@devalok/shilp-sutra/ui/toaster'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Toaster />
+      </body>
+    </html>
+  )
+}
+```
+
+Without a mounted Toaster, every `toast.*` call is a silent no-op.
+
+## API
+
+```ts
+toast('Plain message')                                    // no icon, no accent
+toast.message('Same as plain')                            // alias
+toast.success('Saved!')                                   // green accent + check
+toast.error('Failed', { description })                    // red accent + X (assertive a11y)
+toast.warning('Disk low')                                 // yellow accent + triangle
+toast.info('New version available')                       // blue accent + info
+toast.loading('Saving...')                                // spinner, duration: Infinity
+toast.promise(asyncFn, { loading, success, error })       // one toast, three states
+toast.undo('Item deleted', { onUndo, duration? })         // 8s default, Undo button
+toast.upload({ files, id?, onRetry?, onRemove? })         // per-file progress
+toast.custom((id) => <MyComponent />, options)            // escape hatch
+toast.dismiss(id?)                                        // specific or all
+```
+
+## Options (every method)
+
+| Option | Type | Notes |
+|---|---|---|
+| `id` | `string` | Stable id — pass the same id to update / dismiss. |
+| `description` | `ReactNode` | Subline under the main message. |
+| `action` | `{ label, onClick }` | Right-aligned action button. |
+| `cancel` | `{ label, onClick }` | Right-aligned dismiss button. |
+| `duration` | `number` (ms) | Default `5000`. `Infinity` for loading toasts. |
+
+## Toaster props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `position` | `'top-left' \| 'top-center' \| 'top-right' \| 'bottom-left' \| 'bottom-center' \| 'bottom-right'` | `'bottom-right'` | Global default. |
+| `closeButton` | `boolean` | `false` | Show X on every toast. |
+| `duration` | `number` (ms) | `5000` | Global default — overridable per toast. |
+| `hotkey` | `string[]` | `['altKey', 'KeyT']` | Keyboard shortcut to focus the toast region. |
+| `visibleToasts` | `number` | `3` | Max stacked toasts; older ones move to a "+N" stack. |
+
+## Examples
+
+**Confirmation after save:**
+```tsx
+async function handleSave() {
+  await api.save(data)
+  toast.success('Changes saved')
+}
+```
+
+**Error with description:**
+```tsx
+toast.error('Upload failed', {
+  description: 'File is larger than 10 MB.',
+})
+```
+
+**Async with three states (`toast.promise`):**
+```tsx
+toast.promise(
+  api.publishPost(post),
+  {
+    loading: 'Publishing post...',
+    success: 'Published',
+    error: (err) => `Failed: ${err.message}`,
+  }
+)
+```
+
+One toast, transitions loading → success / error. No manual `.loading()` + `.success()` choreography.
+
+**Undo pattern (soft-delete):**
+```tsx
+function deleteTask(task) {
+  const snapshot = task
+  setTasks((prev) => prev.filter((t) => t.id !== task.id))
+  toast.undo('Task deleted', {
+    onUndo: () => setTasks((prev) => [...prev, snapshot]),
+  })
+}
+```
+
+Default 8s duration — gives the user time to react.
+
+**File upload progress:**
+```tsx
+const id = 'upload-' + Date.now()
+
+toast.upload({
+  id,
+  files: [
+    { id: 'f1', name: 'doc.pdf', size: 1_200_000, status: 'uploading', progress: 0 },
+  ],
+})
+
+xhr.onprogress = (e) => {
+  toast.upload({
+    id,
+    files: [{ id: 'f1', name: 'doc.pdf', size: 1_200_000, status: 'uploading', progress: (e.loaded / e.total) * 100 }],
+  })
+}
+
+xhr.onload = () => {
+  toast.upload({
+    id,
+    files: [{ id: 'f1', name: 'doc.pdf', size: 1_200_000, status: 'complete', progress: 100 }],
+  })
+}
+```
+
+Passing the same `id` updates the existing toast in place — no flicker.
+
+**Custom action:**
+```tsx
+toast('Project archived', {
+  action: { label: 'Open', onClick: () => router.push(`/archive/${id}`) },
+})
+```
+
+**Loading + manual resolution:**
+```tsx
+const id = toast.loading('Compiling...')
+try {
+  await compile()
+  toast.success('Compiled', { id })  // replaces the loading toast
+} catch (err) {
+  toast.error('Compile failed', { id, description: err.message })
+}
+```
+
+## Accessibility
+
+- `toast.error` uses `aria-live="assertive"` — screen readers interrupt the current announcement.
+- Other variants use `aria-live="polite"` — announced after current speech.
+- `<Toaster hotkey={['altKey', 'KeyT']}>` lets keyboard users jump to the toast region.
+
+## Composability
+
+- **One Toaster, many toasts:** Mount once in the root layout. Don't mount per-route — toasts will disappear on navigation.
+- **Imperative only:** No JSX render path. Call `toast.*` from event handlers, async flows, error boundaries.
+- **z-toast (top layer):** Sits above Dialog, Popover, everything. Don't wrap Toaster in a stacking context.
+- **SSR:** Toaster is marked `'use client'` — renders nothing on the server, hydrates on mount.
+
+See `foundations/motion.md` for the spring enter/exit, `foundations/color.md` for accent-bar colors.
+
+## Rules
+
+- Mount `<Toaster />` exactly once, at the app root. Multiple Toasters double-render every toast.
+- Never call `toast()` in render. Always from a handler, effect, or async function.
+- Don't use the removed `useToast()` hook or `toast({ title, color })` object syntax — both were removed in 0.18.
+- Use `toast.promise` for async flows — manual loading → success choreography is error-prone.
+- For undo affordances, use `toast.undo` — gives the consistent 8s duration plus the styled button.
+- Don't use Toast for content the user must read — they auto-dismiss. Use Alert or Banner instead.
+- Pass a stable `id` when you want to update / replace a toast — without an id, repeated calls stack.
+- `toast.error` is assertive — don't use it for soft warnings. Use `toast.warning`.

--- a/packages/core/make-kit/foundations/color.md
+++ b/packages/core/make-kit/foundations/color.md
@@ -1,0 +1,128 @@
+# Color
+
+The kit ships an OKLCH 12-step ramp per color family (`1`=app-bg, `9`=solid/accent, `12`=hi-contrast text) plus semantic role tokens that map onto those steps. **Use the semantic role.** Reach for the numeric step only when authoring custom states.
+
+## Philosophy
+
+- ~90% of surfaces should be neutral. Accent is for the primary CTA and ~1 emphasis per screen.
+- Never write hex / rgb / hsl. Never use Tailwind's stock palette utilities (`text-zinc-*`, `bg-blue-*`). They don't dark-mode-flip, they aren't themable.
+- Status color (error / success / warning / info) is reserved for state communication, not for decoration.
+
+## Decision tree — "what color do I use?"
+
+```
+Surface (background of a region)?
+  → page bg                → bg-surface-base
+  → card / widget / panel  → bg-surface-raised
+  → sidebar / topbar       → bg-surface-sunken
+  → dialog / popover / dropdown / input → bg-surface-overlay
+  → tooltip                → bg-surface-inverted
+  → disabled control       → bg-surface-disabled
+
+Text on a surface?
+  → primary body / heading → text-fg
+  → secondary / metadata   → text-fg-muted
+  → tertiary / hint        → text-fg-subtle
+  → on inverted bg         → text-surface-inverted-fg
+  → on accent-9 / solid    → text-accent-fg
+  → on error / success / warning / info solid → text-{error|success|warning|info}-fg
+
+Border?
+  → standard hairline      → border-surface-border
+  → emphasized             → border-surface-border-strong
+  → subtle divider         → border-surface-border-subtle
+  → state (form invalid)   → border-error-7 (or use Input state="error" instead)
+
+Status?
+  → error    → bg-error-3 / text-error-11 / border-error-7
+  → success  → bg-success-3 / text-success-11 / border-success-7
+  → warning  → bg-warning-3 / text-warning-11 / border-warning-7
+  → info     → bg-info-3 / text-info-11 / border-info-7
+
+Brand emphasis?
+  → primary CTA           → use <Button> default (no className needed)
+  → small accent tint     → bg-accent-3 / text-accent-11
+  → link                  → text-link (auto-handles hover + visited)
+```
+
+## Semantic surface tokens
+
+| Token | Use |
+|---|---|
+| `surface-base` | Page background. The "back wall" of the app. |
+| `surface-raised` | Cards, widgets, panels, anything that sits **on** the page. |
+| `surface-raised-hover` | Hover state on a `surface-raised` element. |
+| `surface-raised-active` | Pressed / active state. |
+| `surface-sunken` | Shell chrome (sidebar, topbar), board columns, segmented-control tracks. |
+| `surface-overlay` | Floating layers — dialogs, popovers, dropdowns, inputs, toasts. |
+| `surface-inverted` | Tooltips, inverted badges. Pair with `surface-inverted-fg`. |
+| `surface-disabled` | Disabled controls. Pair with `surface-fg-disabled`. |
+
+Available as: `bg-surface-*`, `text-surface-*`, `border-surface-*`.
+
+See `foundations/surfaces.md` for elevation rules and the shadow pairing matrix.
+
+## Foreground / text tokens
+
+| Token | Use |
+|---|---|
+| `text-fg` | Primary body + headings. |
+| `text-fg-muted` | Secondary content, metadata, helper text. |
+| `text-fg-subtle` | Tertiary content, placeholder text. |
+| `text-surface-inverted-fg` | Text on `surface-inverted`. |
+| `text-accent-fg` | Text on `bg-accent-9` (solid brand). |
+| `text-{error\|success\|warning\|info}-fg` | Text on the solid color background. Brand-swap safe. |
+| `text-link` | Anchor color (auto-hover + visited). |
+
+## Border tokens
+
+| Token | Use |
+|---|---|
+| `border-surface-border` | Default 1px line. |
+| `border-surface-border-strong` | Emphasized line — section dividers, table headers. |
+| `border-surface-border-subtle` | Hairline, lower contrast than default. |
+
+## Accent ramp (12 steps)
+
+Available as `accent-1` … `accent-12`. Apply via `bg-accent-N`, `text-accent-N`, `border-accent-N`. Steps map to roles:
+
+| Step | Role |
+|---|---|
+| 1 | App background tint |
+| 2 | Subtle background |
+| 3 | Component background (e.g. soft Button rest) |
+| 4 | Hover bg |
+| 5 | Active / pressed bg |
+| 6 | Border subtle |
+| 7 | Border default |
+| 8 | Border strong |
+| 9 | Solid fill (primary CTA, badge solid) |
+| 10 | Solid hover |
+| 11 | Lo-contrast text |
+| 12 | Hi-contrast text |
+
+The same 12-step pattern repeats for `error-*`, `success-*`, `warning-*`, `info-*` (subset: 2, 3, 4, 5, 6, 7, 9, 10, 11).
+
+## Theming — never hardcode
+
+Consumers swap the accent by overriding `--color-accent-1` through `--color-accent-12` in a `:root { }` block placed **after** the kit's CSS import. Dark mode is derived algorithmically — no separate dark overrides needed.
+
+```css
+/* In consumer's global.css, after @import "@devalok/shilp-sutra/css"; */
+:root {
+  --color-accent-9: oklch(0.55 0.18 230); /* swap brand to blue */
+  /* … the kit will compute related steps via OKLCH curves */
+}
+```
+
+## Rules
+
+- **Never** `bg-white` / `bg-black` / `bg-zinc-*` / `bg-pink-*`. Use semantic tokens.
+- **Never** put a color directly on a Button via className. Set `color="error"` (or whichever).
+- **Never** combine `border-*` and `shadow-*` tokens — shadow tokens contain a ring layer.
+- **Never** use `text-fg` on `bg-accent-9`. Use `text-accent-fg` (brand-swap safe).
+- **Never** invent step numbers. Steps 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12 exist. Step 8 exists only on accent / neutral.
+
+## Forced-colors / Windows high-contrast
+
+The kit auto-remaps every semantic color to system keywords (`Canvas`, `CanvasText`, `Highlight`, `LinkText`, `GrayText`) under `@media (forced-colors: active)`. As long as you use semantic tokens, high-contrast mode just works. Hardcoded hex breaks it.

--- a/packages/core/make-kit/foundations/dark-mode.md
+++ b/packages/core/make-kit/foundations/dark-mode.md
@@ -1,0 +1,81 @@
+# Dark mode
+
+`.dark` class on `<html>` or `<body>` flips every token. No theme provider, no JS reshuffle.
+
+## How it works
+
+The kit declares a custom variant: `@custom-variant dark (&:where(.dark *))`. Identical semantics to Tailwind's old `darkMode: 'class'`. Adding `.dark` higher in the DOM cascades every semantic token to its dark counterpart.
+
+Dark tokens are **algorithmically derived** from the OKLCH primitives, not hand-tuned hex overrides. This means:
+
+- Surfaces *lighten* with elevation in dark mode (opposite of light mode). `surface-overlay` is brighter than `surface-base` when `.dark` is active.
+- Brand swaps (consumer overrides `--color-accent-9`) produce a coherent dark palette without extra work.
+- Status colors stay legible — solid backgrounds darken slightly (L=0.63→0.54 in dark mode) to maintain WCAG AA.
+
+## Wiring the toggle
+
+```tsx
+import { useColorMode } from '@devalok/shilp-sutra/hooks/use-color-mode'
+
+function ThemeToggle() {
+  const { mode, resolvedMode, setMode } = useColorMode()
+  // mode: 'light' | 'dark' | 'system'
+  // resolvedMode: 'light' | 'dark' (after resolving 'system')
+
+  return (
+    <Button
+      variant="soft"
+      onClick={() => setMode(resolvedMode === 'dark' ? 'light' : 'dark')}
+    >
+      <Icon icon={resolvedMode === 'dark' ? IconSun : IconMoon} />
+      {resolvedMode === 'dark' ? 'Light' : 'Dark'}
+    </Button>
+  )
+}
+```
+
+`useColorMode()` handles:
+- Persisting to `localStorage` (`shilp-sutra-color-mode`)
+- Listening to `prefers-color-scheme` when mode is `'system'`
+- Syncing across browser tabs
+- Adding/removing `.dark` on `<html>`
+
+## What you have to do per-component
+
+Nothing. Semantic tokens flip automatically. As long as you use `bg-surface-raised` not `bg-white`, dark mode works.
+
+The only exception: **images, illustrations, decorative SVGs**. These don't flip. Author them as theme-aware:
+
+```tsx
+{resolvedMode === 'dark' ? <img src="/logo-dark.svg" /> : <img src="/logo-light.svg" />}
+```
+
+Or use a single CSS-variable-driven SVG (`fill="currentColor"` + `text-fg`).
+
+## Forced-colors (Windows high-contrast)
+
+Independent of `.dark`. Activated by the OS. Every semantic color remaps to system keywords (`Canvas`, `CanvasText`, `Highlight`, `LinkText`, `GrayText`) under `@media (forced-colors: active)`. No work needed if you use semantic tokens.
+
+## Initial load — avoid the flash
+
+Set the mode **before** React hydrates. Insert this script tag in `<head>` (Next.js: `app/layout.tsx`):
+
+```html
+<script>
+  (function () {
+    var m = localStorage.getItem('shilp-sutra-color-mode') || 'system';
+    var dark = m === 'dark' || (m === 'system' && matchMedia('(prefers-color-scheme: dark)').matches);
+    if (dark) document.documentElement.classList.add('dark');
+  })();
+</script>
+```
+
+Without this, light mode flashes on first paint when the user prefers dark.
+
+## Rules
+
+- **Never** hardcode hex / Tailwind palette colors. They don't dark-mode flip.
+- **Never** write a `dark:bg-*` override on a semantic token — the token already handles dark mode.
+- **For images**, use conditional rendering off `resolvedMode`.
+- **Wire the head script** to prevent the FOUC on first paint.
+- Default to `'system'` mode unless the product is explicitly light-only or dark-only.

--- a/packages/core/make-kit/foundations/icons.md
+++ b/packages/core/make-kit/foundations/icons.md
@@ -1,0 +1,107 @@
+# Icons
+
+The kit uses **Tabler Icons** exclusively. Custom icon libraries are not supported.
+
+## Install
+
+`@tabler/icons-react` is declared as a peer dependency:
+
+```bash
+npm i @tabler/icons-react
+```
+
+## Import + use
+
+```tsx
+import { Icon } from '@devalok/shilp-sutra/ui/icon'
+import { IconHome, IconUser, IconSettings } from '@tabler/icons-react'
+
+<Icon icon={IconHome} />
+<Icon icon={IconUser} size={20} />
+<Icon icon={IconSettings} className="text-fg-muted" />
+```
+
+Or pass the component directly to a prop that accepts `IconInput`:
+
+```tsx
+<Button startIcon={IconPlus}>Add</Button>
+<Badge icon={IconCheck}>Verified</Badge>
+```
+
+## `IconInput` (universal icon prop type)
+
+Every icon-accepting prop across the kit (`startIcon`, `endIcon`, `icon`, `leftIcon`, `rightIcon`) takes `IconInput`. Four shapes work interchangeably:
+
+```tsx
+// 1. Component reference (Tabler component)
+<Button startIcon={IconPlus} />
+
+// 2. Rendered <Icon> element
+<Button startIcon={<Icon icon={IconPlus} />} />
+
+// 3. Rendered Tabler element directly
+<Button startIcon={<IconPlus />} />
+
+// 4. Any custom node (svg, span with bg)
+<Button startIcon={<MyCustomIcon />} />
+```
+
+Prefer shape 1 (component ref) — the kit applies the right size and color via context.
+
+## Sizing via `IconProvider`
+
+Don't add `className="h-4 w-4"` on every Icon. Wrap a subtree:
+
+```tsx
+import { IconProvider } from '@devalok/shilp-sutra/ui/icon-context'
+
+<IconProvider size={16}>
+  <NavSection>
+    <Icon icon={IconHome} />
+    <Icon icon={IconUser} />
+    {/* all icons here = 16px */}
+  </NavSection>
+</IconProvider>
+```
+
+Override per-icon with `<Icon icon={...} size={24} />`.
+
+Default sizes by component context:
+
+| Context | Default size |
+|---|---|
+| Button (md) | 16 |
+| Button (sm / xs) | 14 |
+| Button (lg / xl) | 18 / 20 |
+| Input (any size) | 16 |
+| Badge | 12 |
+| Standalone | 16 (recommended) |
+
+## Color
+
+Icons inherit `currentColor` by default. To color one:
+
+```tsx
+<Icon icon={IconAlertTriangle} className="text-warning-11" />
+<Icon icon={IconCheck} className="text-success-11" />
+```
+
+Inside a `<Button>` or `<Badge>`, color is inherited from the button/badge — don't override.
+
+## Multi-color / branded icons (OAuth, etc.)
+
+OAuthButton ships brand glyphs for 13 providers. To use a brand's official multi-color SVG, pass `icon` to override:
+
+```tsx
+<OAuthButton provider="google" icon={<GoogleColorSVG />} />
+```
+
+For custom branded icons elsewhere, use raw `<svg>` — `<Icon>` is for Tabler outline glyphs.
+
+## Rules
+
+- **Tabler only** — no lucide-react, no heroicons, no mui-icons. The kit is sized for Tabler's stroke weight.
+- **Use `<Icon icon={...} />`** — don't render Tabler components directly when inside a kit component that accepts `IconInput`.
+- **Don't size with className** (`h-4 w-4`) — use `size` prop or `IconProvider`.
+- **Don't color icons inside Button / Badge** — they inherit from the parent. Color only on standalone icons.
+- **Don't pass a string** (`"check"`) — `IconInput` excludes strings/numbers. Always a component or element.

--- a/packages/core/make-kit/foundations/motion.md
+++ b/packages/core/make-kit/foundations/motion.md
@@ -1,0 +1,134 @@
+# Motion
+
+framer-motion is the kit's animation engine. **Don't write CSS keyframes** — use motion primitives.
+
+## Required setup
+
+```tsx
+import { MotionProvider } from '@devalok/shilp-sutra/motion'
+
+<MotionProvider reducedMotion="user">
+  <App />
+</MotionProvider>
+```
+
+`reducedMotion="user"` respects the OS's "reduce motion" preference. Without `MotionProvider`, the primitives still work but reduced-motion is ignored — accessibility regression.
+
+## Primitives
+
+```tsx
+import {
+  MotionFade,
+  MotionCollapse,
+  MotionSlide,
+  MotionPop,
+  MotionScale,
+  MotionStagger,
+} from '@devalok/shilp-sutra/motion/primitives'
+```
+
+| Primitive | Use |
+|---|---|
+| `MotionFade` | Mount/unmount with opacity fade. |
+| `MotionCollapse` | Height-based expand/collapse. |
+| `MotionSlide` | Slide in from a direction (`from="top"|"bottom"|"left"|"right"`). |
+| `MotionPop` | Scale + fade pop. Good for tooltips, badges entering. |
+| `MotionScale` | Scale only. |
+| `MotionStagger` | Stagger children with a configurable delay. |
+
+```tsx
+<MotionFade>
+  <Card>This card fades in on mount.</Card>
+</MotionFade>
+
+<MotionStagger gap={0.05}>
+  {items.map((item) => (
+    <ListItem key={item.id}>{item.name}</ListItem>
+  ))}
+</MotionStagger>
+```
+
+## Springs & tweens
+
+```tsx
+import { springs, tweens } from '@devalok/shilp-sutra/motion'
+```
+
+| Spring | Feel |
+|---|---|
+| `springs.snappy` | Decisive, quick. Default for controls. |
+| `springs.smooth` | Smooth, no overshoot. Default for layout. |
+| `springs.bouncy` | Playful overshoot. Use sparingly — only for delight moments. |
+| `springs.gentle` | Soft, slow. For ambient motion. |
+
+| Tween | Duration |
+|---|---|
+| `tweens.fade` | 0.11s — color/opacity. |
+| `tweens.colorShift` | 0.07s — hover color changes. |
+
+Apply via framer's `transition` prop:
+
+```tsx
+import { motion } from 'framer-motion'
+import { springs } from '@devalok/shilp-sutra/motion'
+
+<motion.div animate={{ y: open ? 0 : -8 }} transition={springs.snappy}>
+  …
+</motion.div>
+```
+
+## Duration tokens (CSS, when motion primitives aren't right)
+
+| Token | Duration |
+|---|---|
+| `--duration-fast-01` | 70 ms |
+| `--duration-fast-02` | 110 ms |
+| `--duration-moderate-01` | 150 ms |
+| `--duration-moderate-02` | 240 ms |
+| `--duration-slow-01` | 400 ms |
+| `--duration-slow-02` | 700 ms |
+
+Tailwind utilities: `duration-fast-01`, `duration-moderate-01`, etc. CSS variables: `var(--duration-moderate-01)`.
+
+The system easing is `ease-productive-standard` — apply via `transition` shorthand:
+
+```tsx
+<div className="transition-colors duration-fast-02">…</div>
+```
+
+## Patterns
+
+**Drawer / Sheet slide-in:** already built into `<Sheet>`. Don't reimplement.
+
+**Dialog backdrop fade + content scale:** already built into `<Dialog>`. Don't reimplement.
+
+**List item enter (e.g. new card appears):**
+
+```tsx
+<MotionFade>
+  <Card>New item</Card>
+</MotionFade>
+```
+
+**Staggered table rows:**
+
+```tsx
+<MotionStagger gap={0.03}>
+  {rows.map((row) => <TableRow key={row.id}>{row.cells}</TableRow>)}
+</MotionStagger>
+```
+
+**Async button feedback:** use `<Button onClickAsync>` — it auto-animates idle → loading → success/error → idle. Don't hand-roll spinner toggling.
+
+```tsx
+<Button onClickAsync={async () => { await save() }}>Save</Button>
+```
+
+## Rules
+
+- **Wrap the app in `<MotionProvider reducedMotion="user">` once.** Without it, OS reduce-motion preference is ignored.
+- **Never** write CSS `@keyframes` for app animations — use framer primitives.
+- **Use motion primitives** before reaching for raw `motion.*` — they bundle the right spring + reduced-motion respect.
+- **Don't animate layout** (height, width, top, left) — animate `transform` and `opacity`. The primitives do this for you.
+- **Don't overuse `bouncy`** — bouncy works for one delight moment per session, not for every hover.
+- For async button states, use `onClickAsync` + `asyncFeedbackDuration`, not manual `loading` toggling.

--- a/packages/core/make-kit/foundations/radius.md
+++ b/packages/core/make-kit/foundations/radius.md
@@ -1,0 +1,78 @@
+# Radius
+
+Two layers: a primitive scale and semantic role tokens. **Components reference roles. Override roles, not individual components.**
+
+## Two-layer model
+
+**Primitive scale** (size buckets):
+
+| Token | Pixels |
+|---|---|
+| `radius-ds-none` | 0 |
+| `radius-ds-sm` | 2 |
+| `radius-ds-md` | 6 |
+| `radius-ds-lg` | 10 |
+| `radius-ds-xl` | 16 |
+| `radius-ds-2xl` | 24 |
+| `radius-ds-full` | 9999 (pill) |
+
+**Semantic roles** (mapped to scale at the default preset):
+
+| Role | Default | Where it applies |
+|---|---|---|
+| `radius-control` | 6 | Button, Input, Select, IconButton, segmented item, Tab trigger. |
+| `radius-control-inner` | 2 | Inner elements inside a control (e.g. selected segment indicator). |
+| `radius-surface` | 10 | Cards, widgets, panels. |
+| `radius-overlay-sm` | 6 | Tooltip, Toast. |
+| `radius-overlay` | 10 | Popover, Dropdown, Menubar. |
+| `radius-overlay-lg` | 16 | Dialog, Sheet. |
+| `radius-pill` | 9999 | Badge, Switch, Radio dot, Avatar circle. Pill always wins. |
+| `radius-bubble` | 24 | Chat bubbles. |
+
+## How to apply
+
+In components: never — they apply the right role automatically.
+
+In your own elements (rare):
+
+```tsx
+<div className="bg-surface-raised rounded-(--radius-surface) p-ds-05">…</div>
+```
+
+TW4 shorthand `rounded-(--radius-surface)` is the right way. **Do not** use `rounded-ds-lg` directly — it's not a semantic role, and the pre-publish audit rejects it in `src/ui/`.
+
+## Shape presets
+
+The kit ships three shape presets, switchable via `[data-shape]` on `<html>`:
+
+| Preset | Roles |
+|---|---|
+| `sharp` | control 2 / control-inner 0 / surface 4 / overlay 4–6 |
+| `slightly-rounded` (default) | control 6 / control-inner 2 / surface 10 / overlay 6–16 |
+| `rounded` | control 10 / control-inner 4 / surface 16 / overlay 10–24 |
+
+Toggle by setting `data-shape="rounded"` on `<html>` (or any subtree) — every component re-skins instantly. Pill shapes (Badge, Switch, Radio dot, Avatar circle) stay pill regardless of preset.
+
+```html
+<html data-shape="rounded">
+```
+
+## Custom override
+
+Consumers can swap any role in their global CSS:
+
+```css
+:root {
+  --radius-control: 4px;     /* sharper buttons + inputs */
+  --radius-surface: 12px;    /* gentler cards */
+}
+```
+
+Override the role, not individual components. That way one declaration re-skins the whole system.
+
+## Rules
+
+- **Never** hand-pick a pixel radius (`rounded-[12px]`). Use a role.
+- **Never** use `rounded-ds-*` directly in component-level code — that's the primitive scale, not the role.
+- **Never** override `<Card>`, `<Button>` etc. radius via className. Override the role instead.
+- **Pill shapes** are uncontested — Badge, Switch, Radio dot, Avatar circle stay pill no matter the preset.

--- a/packages/core/make-kit/foundations/spacing.md
+++ b/packages/core/make-kit/foundations/spacing.md
@@ -1,0 +1,110 @@
+# Spacing
+
+The kit uses a `ds-*` spacing scale (2 → 160 px) so utilities never collide with consumer values. **Default to a three-tier cadence — `ds-03` / `ds-05` / `ds-07` — not every adjacent token.**
+
+## Three-tier cadence (the rule)
+
+| Tier | Token | Pixels | Use |
+|---|---|---|---|
+| Related | `ds-03` | 8 | Items that read as one chunk — icon + label, label + input, badges in a row. |
+| Grouped | `ds-05` | 16 | Sections within a card — heading group, controls group, body. |
+| Section | `ds-07` | 32 | Distinct page sections, big breaks. |
+
+**Do not** reach for `ds-04` (12 px) or `ds-06` (24 px) just because they exist. Three tiers create rhythm; five create noise.
+
+If you need a *fourth* tier (e.g. between heading and body inside one group), use `ds-02` (4 px) — that's the "tight pair" tier (caption to value, hint to input).
+
+## Full scale
+
+| Token | Pixels | Typical use |
+|---|---|---|
+| `ds-01` | 2 | Hairline gap. Rare. |
+| `ds-02` | 4 | Tight pair (caption under value, icon to text inside dense control). |
+| `ds-02b` | 6 | Off-cadence; use sparingly. |
+| `ds-03` | 8 | **Related** (default). |
+| `ds-04` | 12 | Use only when 8 is too tight and 16 is too loose. |
+| `ds-05` | 16 | **Grouped** (default). |
+| `ds-05b` | 20 | Off-cadence; rare. |
+| `ds-06` | 24 | Comfortable section gap; prefer `ds-07` unless 32 is too much. |
+| `ds-06b` | 28 | Off-cadence. |
+| `ds-07` | 32 | **Section** (default). |
+| `ds-08` | 40 | Big section. |
+| `ds-09` | 48 | Hero spacing. |
+| `ds-10` | 64 | Marketing. |
+| `ds-11+` | 80 / 96 / 160 | Marketing only. |
+
+## How to apply
+
+```tsx
+// Padding
+<Card className="p-ds-05">…</Card>          // inside-card spacing
+<div className="px-ds-07 py-ds-09">…</div>  // page region
+
+// Gaps
+<Stack gap="ds-03">…</Stack>                // related items
+<Stack gap="ds-05">…</Stack>                // grouped items
+<Stack gap="ds-07">…</Stack>                // sections
+
+// Margins (rare — prefer gap)
+<Text className="mt-ds-02">helper</Text>    // tight pair
+```
+
+## `<Stack>` over flex divs
+
+Don't write `<div className="flex flex-col gap-ds-05">`. Use `<Stack>`:
+
+```tsx
+<Stack gap="ds-05">
+  <Text variant="heading-md">Heading</Text>
+  <Text variant="body-md">Body</Text>
+  <Button>CTA</Button>
+</Stack>
+
+<Stack direction="row" gap="ds-03" align="center">
+  <Icon icon={IconUser} />
+  <Text>Username</Text>
+</Stack>
+```
+
+`<Stack>` ships with `direction` (row | col, default col), `gap` (ds-* token), `align`, `justify`, `wrap`, `as` (polymorphic).
+
+## Component sizing (separate from spacing)
+
+Heights for controls use `ds-{size}` aliases:
+
+| Token | Pixels | Component sizes |
+|---|---|---|
+| `ds-xs` | 24 | n/a (rare) |
+| `ds-xs-plus` | 28 | Button/Input/Select **xs** |
+| `ds-sm` | 32 | Button/Input/Select **sm** |
+| `ds-md` | 40 | Button/Input/Select **md** (default) |
+| `ds-lg` | 48 | Button/Input/Select **lg** |
+| `ds-xl` | 56 | Button **xl** |
+
+Apply via component `size` prop, not className.
+
+## Page layout tokens
+
+| Token | Use |
+|---|---|
+| `--spacing-page-x` | Horizontal page padding. Responsive: 16 → 24 → 40 px. |
+| `--spacing-section-gap` | Vertical gap between major page sections. |
+| `--spacing-card-gap` | Vertical gap between adjacent cards. |
+
+Apply via:
+
+```tsx
+<main className="px-(--spacing-page-x) py-ds-09">
+  <Stack gap="(--spacing-section-gap)">
+    …
+  </Stack>
+</main>
+```
+
+## Rules
+
+- **Default** to `ds-03 / ds-05 / ds-07`. Justify any deviation.
+- **Never** use raw Tailwind spacing (`p-4`, `gap-6`). The kit's spacing is `ds-*` namespaced.
+- **Never** mix arbitrary pixel values (`p-[14px]`). Pick a scale token.
+- **Prefer `<Stack gap>` over `flex … gap-*`**. Cleaner semantics, polymorphic via `as`.
+- Component sizes (xs / sm / md / lg / xl) come from the size prop, not from manual height utilities.

--- a/packages/core/make-kit/foundations/surfaces.md
+++ b/packages/core/make-kit/foundations/surfaces.md
@@ -1,0 +1,121 @@
+# Surfaces & Shadows
+
+The kit ships five semantic surface tiers and a paired shadow system. **Picking the right surface is mandatory** — the wrong one breaks elevation hierarchy and dark mode adaptation. There is a hard rule about never combining surfaces with borders.
+
+## The five surface tiers
+
+| Tier | Token | What sits here |
+|---|---|---|
+| **Base** | `surface-base` | Page background. The "back wall." |
+| **Raised** | `surface-raised` | Cards, widgets, panels — anything that floats **on** the page. |
+| **Sunken** | `surface-sunken` | Shell chrome (Sidebar, TopBar), board columns, segmented-control tracks. |
+| **Overlay** | `surface-overlay` | Floating layers — Dialog, Sheet, Popover, Dropdown, Toast, Tooltip-when-light, Input field. |
+| **Inverted** | `surface-inverted` | Tooltips, inverted badges. Pair with `text-surface-inverted-fg`. |
+
+Each tier has hover / active variants:
+
+- `surface-raised-hover` — hover on a raised element.
+- `surface-raised-active` — pressed / selected raised element.
+
+And a disabled state:
+
+- `surface-disabled` + `text-surface-fg-disabled`.
+
+## Decision matrix
+
+| Building… | Surface | Shadow |
+|---|---|---|
+| Page / layout shell | `surface-base` | none |
+| Sidebar / TopBar (shell) | `surface-sunken` | `shadow-raised` |
+| Card / widget / panel | `surface-raised` | `shadow-raised` |
+| Card on hover | `surface-raised` | `shadow-raised-hover` |
+| Board column / well / track | `surface-sunken` | none |
+| Popover / dropdown / menu | `surface-overlay` | `shadow-floating` |
+| Dialog / modal / sheet | `surface-overlay` | `shadow-overlay` |
+| Tooltip | `surface-inverted` | `shadow-floating` |
+| Toast | `surface-overlay` | `shadow-floating` |
+| Input (rest) | `surface-overlay` | none |
+| Input (focus) | `surface-overlay` | `shadow-ring` |
+| Button (solid) | accent colors | `shadow-raised` |
+| Button (disabled) | `surface-disabled` | none |
+| Segmented track | `surface-sunken` | `shadow-inset` |
+| Selected item | current surface | `shadow-glow` |
+| Backdrop (under modal) | `bg-backdrop` | none |
+
+## Shadow tokens
+
+| Token | When |
+|---|---|
+| `shadow-raised` | Cards, panels, shell chrome at rest. |
+| `shadow-raised-hover` | Cards on hover. Subtle lift. |
+| `shadow-floating` | Popovers, dropdowns, menus, tooltips. |
+| `shadow-overlay` | Dialogs, sheets. Deepest. |
+| `shadow-brand` | Optional brand-tinted glow. Use on hero CTA. |
+| `shadow-glow` | Selection / focus accent. |
+| `shadow-inset` | Toggle / segmented track deboss. |
+| `shadow-ring` | Focus ring (2px accent). |
+| `shadow-ring-sm` | Subtle separator (1px border-color). |
+| `shadow-kbd` | Inset for keyboard shortcut badges. |
+| `shadow-success` / `shadow-error` / `shadow-warning` | Status glow. Use on status notifications. |
+
+## The hard rule: never combine `border-*` with `shadow-*`
+
+Shadow tokens include a 1-px ring layer (inset hairline + drop shadow). Adding an explicit `border-surface-border` on top creates a 2-px edge that looks broken.
+
+❌ **Wrong:**
+```tsx
+<div className="bg-surface-raised border border-surface-border shadow-raised rounded-(--radius-surface)">
+```
+
+✅ **Right (shadow only):**
+```tsx
+<div className="bg-surface-raised shadow-raised rounded-(--radius-surface)">
+```
+
+✅ **Right (border only — when shadow is unwanted, e.g. dense lists):**
+```tsx
+<div className="bg-surface-raised border border-surface-border rounded-(--radius-surface)">
+```
+
+`<Card>` already follows this rule. Don't override with extra border classes.
+
+## Elevation reasoning
+
+Surfaces describe **what kind of layer** something is, not **how high** it is. Two cards next to each other are both `raised`. A dialog over them isn't `raised-more` — it's `overlay`. A sidebar isn't `raised-but-lower` — it's `sunken`.
+
+This means: **don't stack `raised` on `raised`**. If you'd reach for that, the inner element is probably `overlay` or wants a `surface-sunken` recess instead.
+
+## Dark mode
+
+In dark mode the kit lightens surfaces with elevation (so `surface-overlay` is *brighter* than `surface-base`). This is the inverse of light mode and is intentional — it's how Stripe / Linear / Material 3 model elevation in dark. Don't fight it.
+
+## Page composition example
+
+```tsx
+<div className="min-h-screen bg-surface-base">
+  <aside className="bg-surface-sunken">  {/* Sidebar */}
+    …
+  </aside>
+  <main className="bg-surface-base p-ds-07">
+    <Card className="bg-surface-raised shadow-raised p-ds-05">  {/* Card */}
+      …
+      <Dialog>
+        <DialogContent className="bg-surface-overlay shadow-overlay">
+          …  {/* Modal */}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  </main>
+</div>
+```
+
+(In practice you wouldn't write the `bg-*` / `shadow-*` directly — `<Card>`, `<DialogContent>`, `<AppSidebar>` apply them. This is just the layer model.)
+
+## Rules
+
+- **Card-like elements** (anything that reads as a panel on the page) → `surface-raised`, never `surface-base`.
+- **Overlay-like elements** → `surface-overlay`, always.
+- **Never** combine an explicit border with a shadow token.
+- **Never** invent a sixth tier. Five is the system.
+- **Don't** override `<Card>`, `<DialogContent>`, `<PopoverContent>` surface — they pick the right one for you.
+- For Storybook authors and pre-publish audit: components in `src/ui/` that render as cards must NOT use `bg-surface-base`. The audit script will reject it.

--- a/packages/core/make-kit/foundations/typography.md
+++ b/packages/core/make-kit/foundations/typography.md
@@ -1,0 +1,120 @@
+# Typography
+
+The kit ships an 11-step type scale (`text-ds-xs` through `text-ds-6xl`) with paired line-heights. **Use the scale, not arbitrary pixel values.**
+
+## Philosophy
+
+- One scale, applied with intent. A page should land on 3–4 text sizes max — heading + body + caption.
+- Larger headings (3xl and up) use `clamp()` to scale fluidly between mobile and desktop. Smaller sizes are fixed.
+- Default font is Inter Variable (sans). `Ranade` Variable is the accent display face for marketing-heavy treatments. SF Mono is the monospace.
+- Letter spacing on body sizes is tuned per-size (`body-lg: -0.01em`, `body-md: 0`, `body-sm: +0.01em`, `body-xs: +0.02em`).
+
+## Size scale
+
+| Token | Size | Use |
+|---|---|---|
+| `text-ds-xs` | 10px | Footnotes, fine print, only when space is at premium. Never for primary content. |
+| `text-ds-sm` | 12px | Captions, table labels, helper text, badges. |
+| `text-ds-md` | 14px | Default UI body. All input fields. Default Button label. |
+| `text-ds-base` | 16px | Body copy in marketing / docs. Mobile input minimum. |
+| `text-ds-lg` | 18px | Lead paragraphs, large body. |
+| `text-ds-xl` | 20px | Small heading (h4). |
+| `text-ds-2xl` | 24px | Section heading (h3). |
+| `text-ds-3xl` | clamp 24→32 | Page heading (h2). Fluid. |
+| `text-ds-4xl` | clamp 28→36 | Large page heading (h1 in product). |
+| `text-ds-5xl` | clamp 32→48 | Marketing hero. |
+| `text-ds-6xl` | clamp 36→60 | Marketing display. |
+
+Pair each size with a line-height: `leading-ds-{none|tight|snug|normal|relaxed|loose}`. Default for body: `leading-ds-normal` (1.4). For headings: `leading-ds-tight` (1.15) or `leading-ds-snug` (1.25).
+
+## Composite typography utilities
+
+Prefer these — they bundle size + leading + weight + tracking:
+
+| Utility | Use |
+|---|---|
+| `text-heading-xl` | Page hero heading. |
+| `text-heading-lg` | Section heading. |
+| `text-heading-md` | Card / panel heading. |
+| `text-heading-sm` | Sub-heading. |
+| `text-body-lg` | Lead body. |
+| `text-body-md` | Default body. |
+| `text-body-sm` | Secondary body. |
+| `text-body-xs` | Caption, footnote. |
+| `text-code` | Inline / block code. |
+| `text-label-plain-lg` / `-md` / `-sm` | Form labels (non-tab). |
+
+These are what `<Text>` applies internally. When generating raw text, prefer using `<Text variant="heading-md">` (or similar) over manually composing utilities.
+
+## Font families
+
+| Token | Family | Use |
+|---|---|---|
+| `font-sans` | Inter | Default. UI body + headings. |
+| `font-display` | Inter | Marketing headings (same family by default, separate token for theming). |
+| `font-accent` | Ranade | Optional display accent. Only for marketing hero / brand moments. |
+| `font-mono` | SF Mono / Fira Code | Code blocks, keyboard shortcuts, tabular data. |
+
+## Weights
+
+`font-weight-{light|regular|medium|semibold|bold}` = 300 / 400 / 500 / 600 / 700.
+
+Apply via Tailwind's `font-light` / `font-medium` / `font-semibold` / `font-bold`. Default is regular (400). Headings default to `font-medium` (500). **Avoid bold (700)** for headings — the kit uses medium for refined feel. Use semibold for emphasized labels.
+
+## Hierarchy patterns
+
+**Card heading + body:**
+
+```tsx
+<Card className="p-ds-05">
+  <Text variant="heading-md">Project</Text>
+  <Text variant="body-md" className="text-fg-muted mt-ds-02">
+    Sub-description with metadata.
+  </Text>
+</Card>
+```
+
+**Page header:**
+
+```tsx
+<Stack gap="ds-03" className="mb-ds-07">
+  <Text variant="heading-xl">Dashboard</Text>
+  <Text variant="body-lg" className="text-fg-muted">
+    Overview of every active project.
+  </Text>
+</Stack>
+```
+
+**Form label + input:**
+
+```tsx
+<FormField>
+  <Label>Email</Label>
+  <Input type="email" placeholder="you@company.com" />
+  <FormHelperText>We'll never share this.</FormHelperText>
+</FormField>
+```
+
+`<Label>` already applies `text-label-plain-md`. Don't override with size utilities.
+
+## Polymorphic `<Text>`
+
+`<Text>` is polymorphic via `as` prop:
+
+```tsx
+<Text as="h1" variant="heading-xl">Page title</Text>
+<Text as="p" variant="body-md">Body copy.</Text>
+<Text as="label" htmlFor="email">Email</Text>
+<Text as="a" href="/x">A link</Text>
+```
+
+The `as` prop widens accepted HTML attributes to the rendered element — `htmlFor` / `href` typecheck correctly.
+
+## Rules
+
+- **Never** hand-pick a pixel font-size (`text-[15px]`, `text-[18px]`). Use the scale.
+- **Never** use `font-bold` on headings. Use `font-medium` or `font-semibold`.
+- **Never** apply two size utilities at once (`text-ds-md text-ds-lg`). Use composite variants.
+- **Never** use small text (`text-ds-xs`) for anything except captions and footnotes.
+- **Prefer `<Text variant="...">` over raw `<p>` / `<span>`** when typographic semantics matter.
+- Inputs must be at least `text-ds-md` (14px) on desktop and `16px` on mobile (the kit enforces the iOS-zoom-safe minimum automatically).

--- a/packages/core/make-kit/setup.md
+++ b/packages/core/make-kit/setup.md
@@ -1,0 +1,130 @@
+# Setup
+
+Required to use this kit. Every generated app needs all of these.
+
+## Install
+
+```bash
+npm i @devalok/shilp-sutra @tabler/icons-react framer-motion tailwindcss @tailwindcss/vite
+# optional, only if you render toasts:
+npm i sonner
+```
+
+`framer-motion` and `tailwindcss` are **required peer dependencies.** Without them, motion contexts split and tokens don't compile.
+
+## Vite config
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+})
+```
+
+## Single CSS entry
+
+In `src/index.css` (or your global stylesheet):
+
+```css
+@import "tailwindcss";
+@import "@devalok/shilp-sutra/css";
+```
+
+Import that CSS file once at the app root (`main.tsx`):
+
+```tsx
+import './index.css'
+```
+
+**Do not add `tailwind.config.ts`.** This kit is Tailwind 4 CSS-first. There is no JS preset. All tokens come from the CSS import via `@theme` blocks.
+
+## Provider tree
+
+Wrap the app once at the root:
+
+```tsx
+import { MotionProvider } from '@devalok/shilp-sutra/motion'
+import { Toaster } from '@devalok/shilp-sutra/ui/toaster'
+import { IconProvider } from '@devalok/shilp-sutra/ui/icon-context'
+
+export default function App({ children }) {
+  return (
+    <MotionProvider reducedMotion="user">
+      <IconProvider size={16}>
+        {children}
+        <Toaster />
+      </IconProvider>
+    </MotionProvider>
+  )
+}
+```
+
+- `MotionProvider` — required. `reducedMotion="user"` respects OS preference. Without this provider, motion primitives still work but reduced-motion is ignored.
+- `IconProvider` — optional but recommended. Sets default icon size for all `<Icon>` children. Override per-call with `<Icon size={20} />`.
+- `Toaster` — only needed if the app calls `toast(...)`. Mount exactly once.
+
+## Dark mode toggle
+
+Add the `.dark` class on `<html>` or `<body>` to flip the entire token system to dark. The kit ships `useColorMode()`:
+
+```tsx
+import { useColorMode } from '@devalok/shilp-sutra/hooks/use-color-mode'
+
+function ThemeToggle() {
+  const { mode, setMode } = useColorMode() // 'light' | 'dark' | 'system'
+  return (
+    <Button onClick={() => setMode(mode === 'dark' ? 'light' : 'dark')}>
+      Toggle theme
+    </Button>
+  )
+}
+```
+
+The hook persists choice to `localStorage`, syncs across tabs, and respects `prefers-color-scheme` when set to `'system'`.
+
+## Import paths
+
+Two valid styles:
+
+```tsx
+// Per-component (preferred — smaller bundle, server-component safe):
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Card } from '@devalok/shilp-sutra/ui/card'
+
+// Barrel (fine for client-only apps):
+import { Button, Card, Dialog } from '@devalok/shilp-sutra'
+```
+
+A few components are **per-component only** (their barrel was removed in v0.40 because they statically import optional peer deps). These must use the subpath:
+
+- `Toaster`, `toast` → `@devalok/shilp-sutra/ui/toaster`, `/ui/toast`
+- `DatePicker*` → `@devalok/shilp-sutra/composed/date-picker`
+- `EmojiPicker*` → `@devalok/shilp-sutra/composed/emoji-picker`
+- `FilePreview` → `@devalok/shilp-sutra/composed/file-preview`
+- `MarkdownViewer` → `@devalok/shilp-sutra/composed/markdown-viewer`
+- `RichTextEditor*` → `@devalok/shilp-sutra/composed/rich-text-editor`
+- `InputOTP*` → `@devalok/shilp-sutra/ui/input-otp`
+
+## Verify
+
+After install, this should render without errors:
+
+```tsx
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Card } from '@devalok/shilp-sutra/ui/card'
+
+export default function Page() {
+  return (
+    <div className="min-h-screen bg-surface-base p-ds-07">
+      <Card className="max-w-md mx-auto p-ds-05">
+        <Button>Hello</Button>
+      </Card>
+    </div>
+  )
+}
+```
+
+If `bg-surface-base` doesn't apply, the CSS import is missing or out of order. The kit's CSS must come **after** `@import "tailwindcss"`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -793,7 +793,9 @@
       "import": "./dist/ai/types.js",
       "default": "./dist/ai/types.js"
     },
-    "./docs/*": "./docs/components/*"
+    "./docs/*": "./docs/components/*",
+    "./make-kit": "./make-kit/Guidelines.md",
+    "./make-kit/*": "./make-kit/*"
   },
   "files": [
     "dist",
@@ -801,6 +803,7 @@
     "docs/recipes",
     "docs/rollback.md",
     "fonts",
+    "make-kit",
     "skill",
     "scripts/welcome.mjs",
     "AGENTS.md",


### PR DESCRIPTION
## Summary

Ship a 26-file Make-kit guideline set at `packages/core/make-kit/` so `@devalok/shilp-sutra` can be registered as a [Figma Make kit](https://developers.figma.com/docs/code/bring-your-design-system-package/) — Figma's mechanism for letting AI app/prototype generation use a real DS package + its conventions.

## Contents

- `Guidelines.md` — top-level entry, product character + 10 mandatory rules + workflow + file map
- `setup.md` — install, Vite config, provider tree, dark-mode init
- `foundations/` — 8 files: color, typography, spacing, surfaces, radius, motion, dark-mode, icons
- `components/overview.md` — catalog by category + 7 decision trees
- `components/{button,card,input,dialog,badge,select,tabs,toast,form,table,dropdown-menu,popover,text,stack,icon}.md` — 15 deep guides

Wired via `package.json`:
- `files[]` includes `make-kit/` → ships in npm tarball (~140 KB)
- Subpath exports: `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `@devalok/shilp-sutra/make-kit/*` → individual files

## Smoke test (2026-06-01)

Built a fresh Vite 8 + React 19 + TW4 + framer-motion 12 app per Figma Make's setup recipe. Installed `@devalok/shilp-sutra@0.41.0` + peers. All green:

| Check | Result |
|---|---|
| `npm install` | 179 pkgs, 0 vulns, no dedupe drift |
| `tsc -b` against React 19 types | Pass |
| `vite build` | 547 KB JS / 170 KB CSS / 0 errors |
| TW4 `@import "@devalok/shilp-sutra/css"` via `@tailwindcss/vite` | Pass |
| Per-component exports (`./ui/button`, `./ui/card`, `./ui/badge`) | Pass |
| Dev server transform + 200 OK on Button/Card/Badge | Pass |
| DS utilities emit (`p-ds-07`, `bg-surface-1`, `gap-ds-03`) | Pass |

React 19 risk dead — Vite's `react-ts` template ships React 19 by default. TW4 risk dead — `@tailwindcss/vite` 4.3 handles our CSS-first entry. Peer-dedupe risk dead — single copies of framer-motion / sonner / tailwindcss / react.

## Authoring notes

- Voice: direct + prescriptive, no marketing copy. Each component file: import → When to use → Variants / Colors / Sizes (tables) → Props table → Examples (4–6) → Rules.
- Source-of-truth: CVA in `src/ui/*.tsx`. Caught one stale section in `llms-full.txt` mid-authoring (FormField auto-wiring — line 2410 contradicts the actual source). Fixed in `make-kit/components/form.md`; flagged for `llms-full.txt` regen as backlog.
- Per-component prop tables verified against `llms-full.txt` line ranges.

## Test plan

- [ ] Pre-publish-audit clean locally (gate failures: git-clean → fixed by commit; SKILL.md frontmatter false-positive on Windows due to CRLF working-tree, passes on Linux CI)
- [ ] `npm pack --dry-run` lists all 26 `make-kit/*.md` files in tarball
- [ ] Changeset queues a minor bump
- [ ] After merge: Version Packages PR auto-opens
- [ ] After Version PR merge: `release.yml` publishes via OIDC; tarball reachable at `unpkg.com/@devalok/shilp-sutra@0.42.0/make-kit/Guidelines.md`
- [ ] Register kit in Figma Make UI (paste-in or auto-gen, then patch from ours)
- [ ] Validate Make-generated app uses kit components correctly; iterate on guidelines based on what Make fumbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)