### PR TITLE
fix(release): add MIGRATION 0.42.0 no-op section

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,14 @@ This page indexes all breaking changes across `@devalok/shilp-sutra` versions. F
 
 > **Upgrading from &lt; 0.36?** Start here, then read each intermediate version section. Breaking changes stack — skipping versions means stacking migrations.
 
+## v0.42.0 — Figma Make kit guidelines (no migration needed)
+
+**Non-breaking minor.** No consumer code changes required.
+
+- **New:** `packages/core/make-kit/` ships in the tarball — 26 guideline files Figma Make consumes when registering this package as a Make kit. Includes `Guidelines.md`, `setup.md`, 8 `foundations/*.md`, `components/overview.md`, and 15 per-component deep guides. Reachable at `node_modules/@devalok/shilp-sutra/make-kit/` after install, or via subpath exports `@devalok/shilp-sutra/make-kit` and `/make-kit/*`. Adds ~140 KB to tarball.
+- No source code changes. No runtime impact. Existing consumers see a slightly larger install footprint and nothing else.
+- See https://developers.figma.com/docs/code/bring-your-design-system-package/ for the Figma Make kit registration flow.
+
 ## v0.41.0 — `BREAKING.json` manifest + recipe polish (no migration needed)
 
 **Non-breaking minor.** No consumer code changes required.


### PR DESCRIPTION
## Summary

Unblock 0.42.0 publish. Pre-publish audit failed in the release run after Version PR #78 merged with: `MIGRATION.md has no section matching v0.42 (CHANGELOG target is 0.42.0)`.

0.42.0 ships only the new `make-kit/` guideline directory — non-breaking, no consumer code changes — but the audit gate is shape-checking for a heading. Same pattern as the 0.41.0 no-op MIGRATION fix.

## Test plan

- [ ] Merge → release.yml re-fires
- [ ] Pre-publish audit passes (all 45 gates green)
- [ ] `@devalok/shilp-sutra@0.42.0` lands on npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)