### PR TITLE
feat(site): /figma-make consumer setup page

### DIFF
--- a/.changeset/figma-make-rollout.md
+++ b/.changeset/figma-make-rollout.md
@@ -1,0 +1,11 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Document the Figma Make kit shipped in 0.42.0:
+
+- `llms.txt` — new "NEW (v0.42.0)" entry pointing to `make-kit/` + the consumer setup walkthrough.
+- `AGENTS.md` — new "Figma Make" section so coding agents route users to the kit setup page when they ask about Figma Make.
+- README — Make-kit badge + section linking to https://shilp-sutra.devalok.in/figma-make.
+
+No code change. Tarball gains ~1 KB of docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,16 @@ Consumers can override any role globally (`:root { --radius-control: 4px; }`) or
 
 For the per-component RSC-safety matrix and import patterns, see **`packages/core/docs/recipes/server-components.md`**.
 
+## Figma Make
+
+If the user mentions Figma Make, generating designs against a kit, or registering a Make kit:
+
+- shilp-sutra ships a Make kit at `node_modules/@devalok/shilp-sutra/make-kit/` (26 markdown files: top-level `Guidelines.md` + `setup.md`, eight `foundations/*.md`, sixteen `components/*.md`).
+- Walkthrough lives at https://shilp-sutra.devalok.in/figma-make — six-step setup, paste-ready guideline blocks, FAQ.
+- Pin the kit to a specific npm version. Figma does not auto-update when a new npm version publishes.
+- Cross-org sharing is not supported by Figma. Each consumer org registers its own kit against the same npm package and pastes the same guideline files.
+- Free and Pro Figma plans can install the npm package directly, but Make-kit registration needs Organization or Enterprise.
+
 ## Reporting feedback
 
 If you find that a recipe is wrong, a constraint above is no longer accurate, or a component behavior contradicts the docs:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The Devalok Design System -- tokens, components, and patterns for React & Next.j
 [![Storybook](https://img.shields.io/badge/Storybook-ff4785?logo=storybook&logoColor=white)](https://devalok-design.github.io/shilp-sutra/)
 [![AI agents ready](https://img.shields.io/badge/AI%20agents-AGENTS.md-7c3aed)](./AGENTS.md)
 [![Themer](https://img.shields.io/badge/Themer-shilp--sutra.devalok.in%2Fthemer-d946a6)](https://shilp-sutra.devalok.in/themer)
+[![Figma Make kit](https://img.shields.io/badge/Figma_Make-kit_ready-a259ff)](https://shilp-sutra.devalok.in/figma-make)
 
 ## Packages
 
@@ -125,6 +126,14 @@ Do not invent CSS variables. Use exactly what the JSON `css` field contains. Don
 ````
 
 Already been to the Themer? The result page has a **Copy AI agent prompt** button that pre-fills the URL with your archetype + accent so the agent skips persona triage.
+
+## Figma Make
+
+`@devalok/shilp-sutra@0.42.0+` ships a Make kit at `node_modules/@devalok/shilp-sutra/make-kit/` — 26 guideline files that teach Figma Make to generate apps against the production design system. Same components, same tokens, same conventions as production code.
+
+→ **[shilp-sutra.devalok.in/figma-make](https://shilp-sutra.devalok.in/figma-make)** — six-step setup, paste-ready guidelines, update cadence.
+
+Make kits need a Figma Organization or Enterprise plan. Free / Pro users can still install the npm package directly in any React project.
 
 ## Setup recipes (per framework)
 

--- a/apps/site/app/figma-make/page.tsx
+++ b/apps/site/app/figma-make/page.tsx
@@ -1,0 +1,373 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import {
+  IconBrandFigma,
+  IconBrandGithub,
+  IconCircleCheck,
+  IconClockExclamation,
+  IconExternalLink,
+  IconPackage,
+  IconClipboardText,
+  IconRocket,
+  IconStack2,
+} from '@tabler/icons-react'
+import { Alert } from '@devalok/shilp-sutra/ui/alert'
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
+import { Text } from '@devalok/shilp-sutra/ui/text'
+import { CodeBlock } from '@/components/code-block'
+import { MakeKitPaster } from '@/components/make-kit-paster'
+import { PageHeader } from '@/components/page-header'
+import { SiteFooter } from '@/components/site-footer'
+import { SiteHeader } from '@/components/site-header'
+import { concatGroup, fileCount, getGuidelineGroups } from '@/lib/make-kit-content'
+
+export const metadata: Metadata = {
+  title: 'Figma Make kit',
+  description:
+    'Generate apps in Figma Make against the production shilp-sutra design system. Register the npm package as a Make kit, paste twenty-six guideline files, and ship prototypes that match the same conventions as production code.',
+}
+
+const KIT_VERSION = process.env.NEXT_PUBLIC_SHILP_SUTRA_VERSION ?? '0.42.0'
+
+const STEPS = [
+  {
+    icon: IconBrandFigma,
+    title: 'Open the Resources panel',
+    body: 'From Figma\'s top-right menu, head to Resources → Make kits tab → Create Make kit. Name it shilp-sutra. Description below.',
+    snippet: 'Devalok Design System — React + Tailwind 4 + CVA. OKLCH tokens, framer-motion, dark mode, accessibility baked in.',
+    snippetLang: 'text',
+  },
+  {
+    icon: IconPackage,
+    title: 'Pick public npm',
+    body: 'Two registry options show up: public npm and Figma\'s private registry. Pick public npm. shilp-sutra lives at @devalok/shilp-sutra on npmjs.com.',
+    snippet: '@devalok/shilp-sutra',
+    snippetLang: 'text',
+  },
+  {
+    icon: IconStack2,
+    title: 'Pin the version',
+    body: `Type the package name above and version ${KIT_VERSION}. Figma fetches the tarball — confirm version, size (about 6 MB), and dependency count look right before continuing.`,
+    snippet: KIT_VERSION,
+    snippetLang: 'text',
+  },
+  {
+    icon: IconClipboardText,
+    title: 'Choose manual guidelines',
+    body: 'Figma offers auto-gen or manual. Pick manual. Auto-gen reads the package and drafts what it thinks the rules are; the files below are written from inside the system, with conventions and anti-patterns baked in.',
+    snippet: null,
+    snippetLang: null,
+  },
+  {
+    icon: IconCircleCheck,
+    title: `Paste the ${fileCount()} files`,
+    body: 'Recreate the file tree from the section below. Paste Guidelines.md first — Figma always reads that as the entry point. Within each group, order does not matter.',
+    snippet: null,
+    snippetLang: null,
+  },
+  {
+    icon: IconRocket,
+    title: 'Publish the kit',
+    body: 'Hit Publish kit. Figma assigns a kit version separate from the npm version — kit 1.0.0, npm ' + KIT_VERSION + '. Teammates see the kit in their Make kit picker on next session.',
+    snippet: null,
+    snippetLang: null,
+  },
+] as const
+
+const FAQ = [
+  {
+    q: 'Can I use the kit on a free Figma plan?',
+    a: 'Make kits need an Organization or Enterprise plan. Free and Pro can still install @devalok/shilp-sutra in any React project — the kit registration is the part that needs the higher tier.',
+  },
+  {
+    q: 'Does Figma Make pull new versions automatically?',
+    a: 'No. Publishing a new npm version does not flow into Figma. Open the kit in Figma → Update kit → bump the npm version field → republish. Files using the kit get a notification next session.',
+  },
+  {
+    q: 'Why does Figma bump the kit version on every republish?',
+    a: 'Kit version (Figma-internal) is separate from npm version. Figma auto-increments the kit version every republish. If your CI also publishes the npm tarball, both can move independently — pick one to drive bumps to avoid "package version already exists" errors.',
+  },
+  {
+    q: 'Make generated a raw <button> instead of <Button>. What now?',
+    a: 'Open components/button.md in the kit, tighten the rule that was missed, republish. File an issue against shilp-sutra so the upstream guideline catches it for everyone else.',
+  },
+  {
+    q: 'Auto-gen guidelines look fine. Should I use those instead?',
+    a: 'Acceptable starting point. Ours are stricter on conventions (soft over outline default, ds-* spacing cadence, surface tiers, no mixing border with shadow). Swap them in when you start seeing drift in Make output.',
+  },
+  {
+    q: 'Can I share the kit with another Figma org?',
+    a: 'Not directly. Each consumer org registers its own kit against the same npm package and pastes the same guidelines. The npm tarball is the shared source of truth.',
+  },
+] as const
+
+export default function FigmaMakePage() {
+  const groups = getGuidelineGroups()
+  const groupConcat: Record<string, string> = Object.fromEntries(
+    groups.map((g) => [g.id, concatGroup(g)]),
+  )
+
+  return (
+    <>
+      <SiteHeader />
+      <main id="main" className="flex-1">
+        <div className="mx-auto max-w-5xl px-page-x pt-[5.5rem] sm:pt-[5rem] pb-ds-09">
+          <PageHeader
+            eyebrow="For Figma Make"
+            title="Generate apps in Figma against the real design system."
+            subtitle={`One npm version. ${fileCount()} guideline files. Same conventions as production.`}
+            description="Figma Make turns prompts into React. shilp-sutra-as-a-Make-kit teaches it which Button to reach for, which surface a card sits on, why soft beats outline. The Buttons your team already ships, applied to AI-generated screens."
+          />
+
+          {/* Hero CTAs */}
+          <div className="flex flex-wrap items-center gap-ds-03 mb-ds-09 -mt-ds-04">
+            <Link href="https://www.figma.com/make" target="_blank" rel="noreferrer">
+              <Button startIcon={<IconBrandFigma size={16} />}>
+                Open Figma Make
+              </Button>
+            </Link>
+            <Link href="#setup">
+              <Button variant="soft">Read the setup ↓</Button>
+            </Link>
+            <Link
+              href={`https://www.npmjs.com/package/@devalok/shilp-sutra/v/${KIT_VERSION}`}
+              target="_blank"
+              rel="noreferrer"
+              className="ml-auto"
+            >
+              <Badge variant="soft" color="neutral" size="md">
+                v{KIT_VERSION} on npm
+              </Badge>
+            </Link>
+          </div>
+
+          {/* Eligibility */}
+          <Alert
+            color="info"
+            title="Make kits need an Organization or Enterprise Figma plan."
+            className="mb-ds-09"
+          >
+            Free and Pro plans can install the npm package directly in any React project. Registering
+            a private Make kit is the part that needs the higher tier — that's a Figma platform limit,
+            not ours.
+          </Alert>
+
+          {/* Steps */}
+          <section id="setup" className="mb-ds-12">
+            <header className="flex flex-col gap-ds-02 max-w-2xl mb-ds-06">
+              <Text variant="label-sm" className="text-surface-fg-subtle">
+                Setup
+              </Text>
+              <Text variant="heading-md" className="text-surface-fg">
+                Six steps. Fifteen minutes, mostly pasting.
+              </Text>
+            </header>
+            <ol className="flex flex-col gap-ds-04">
+              {STEPS.map((step, i) => (
+                <li key={step.title}>
+                  <Card>
+                    <CardHeader>
+                      <div className="flex items-start gap-ds-04">
+                        <span className="w-10 h-10 rounded-control bg-accent-3 text-accent-11 flex items-center justify-center shrink-0 font-semibold text-ds-md">
+                          {i + 1}
+                        </span>
+                        <div className="flex flex-col gap-ds-02 flex-1 min-w-0">
+                          <CardTitle className="flex items-center gap-ds-03">
+                            <step.icon size={18} className="text-fg-muted shrink-0" />
+                            {step.title}
+                          </CardTitle>
+                          <CardDescription>{step.body}</CardDescription>
+                        </div>
+                      </div>
+                    </CardHeader>
+                    {step.snippet ? (
+                      <CardContent>
+                        <CodeBlock language={step.snippetLang ?? 'text'} code={step.snippet} />
+                      </CardContent>
+                    ) : null}
+                  </Card>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {/* Guideline paster */}
+          <section className="mb-ds-12">
+            <header className="flex flex-col gap-ds-02 max-w-2xl mb-ds-06">
+              <Text variant="label-sm" className="text-surface-fg-subtle">
+                Guidelines
+              </Text>
+              <Text variant="heading-md" className="text-surface-fg">
+                {`Paste these ${fileCount()} files into the kit's guideline editor.`}
+              </Text>
+              <Text variant="body-md" className="text-fg-muted">
+                Each file ships in the npm tarball at{' '}
+                <code className="font-mono text-ds-sm bg-surface-overlay px-ds-02 rounded-control-inner">
+                  node_modules/@devalok/shilp-sutra/make-kit/
+                </code>{' '}
+                — copy from there, or copy from below. Both reach the same content. The "Copy all" button
+                concatenates a group with file-path separators so you can paste a whole tier in one shot.
+              </Text>
+            </header>
+            <div className="flex flex-col gap-ds-09">
+              {groups.map((g) => (
+                <MakeKitPaster
+                  key={g.id}
+                  title={g.title}
+                  description={g.description}
+                  files={g.files}
+                  concat={groupConcat[g.id]}
+                  version={KIT_VERSION}
+                />
+              ))}
+            </div>
+          </section>
+
+          {/* Update cadence */}
+          <section className="mb-ds-12">
+            <header className="flex flex-col gap-ds-02 max-w-2xl mb-ds-06">
+              <Text variant="label-sm" className="text-surface-fg-subtle">
+                Update cadence
+              </Text>
+              <Text variant="heading-md" className="text-surface-fg">
+                When to refresh the kit in your Figma org.
+              </Text>
+            </header>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-ds-04">
+              <Card color="warning" accent="left" accentColor="warning">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-ds-03">
+                    <IconClockExclamation size={18} className="text-warning-11" />
+                    No auto-update from Figma
+                  </CardTitle>
+                  <CardDescription>
+                    Publishing a new npm version does not push to Figma Make. The republish step lives
+                    inside Figma's kit UI. Track shilp-sutra releases in npm or our changelog, then trigger
+                    the kit republish on the cadence below.
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle>The rhythm</CardTitle>
+                  <CardDescription>
+                    <ul className="flex flex-col gap-ds-02 mt-ds-02 list-none">
+                      <li>
+                        <strong className="text-fg">Minor bumps</strong> (0.43, 0.44…) — bump the kit's
+                        npm version in Figma, re-paste any guideline file that changed.
+                      </li>
+                      <li>
+                        <strong className="text-fg">Patch bumps</strong> — usually skip. Re-paste only
+                        when the patch fixes Make-visible behavior (rare).
+                      </li>
+                      <li>
+                        <strong className="text-fg">Major bumps</strong> — full re-paste. Treat as a
+                        fresh kit setup, especially for breaking API changes.
+                      </li>
+                    </ul>
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section className="mb-ds-12">
+            <header className="flex flex-col gap-ds-02 max-w-2xl mb-ds-06">
+              <Text variant="label-sm" className="text-surface-fg-subtle">
+                FAQ
+              </Text>
+              <Text variant="heading-md" className="text-surface-fg">
+                Things people ask before they hit publish.
+              </Text>
+            </header>
+            <div className="flex flex-col gap-ds-03">
+              {FAQ.map((item) => (
+                <details
+                  key={item.q}
+                  className="group rounded-control border border-surface-border bg-surface-raised"
+                >
+                  <summary className="cursor-pointer px-ds-05 py-ds-04 text-ds-md font-medium text-fg list-none flex items-center justify-between gap-ds-03">
+                    <span>{item.q}</span>
+                    <span className="text-fg-muted text-ds-lg shrink-0 group-open:rotate-45 transition-transform">
+                      +
+                    </span>
+                  </summary>
+                  <div className="px-ds-05 pb-ds-05 text-ds-md text-fg-muted leading-relaxed border-t border-surface-border-subtle pt-ds-04">
+                    {item.a}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          {/* Footer cross-links */}
+          <section className="pt-ds-08 border-t border-surface-border-subtle">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-ds-04">
+              <Link
+                href={`https://www.npmjs.com/package/@devalok/shilp-sutra/v/${KIT_VERSION}`}
+                target="_blank"
+                rel="noreferrer"
+                className="group"
+              >
+                <Card variant="outline" interactive>
+                  <CardHeader>
+                    <CardTitle className="text-ds-md flex items-center gap-ds-02">
+                      <IconPackage size={16} className="text-fg-muted" />
+                      npm
+                      <IconExternalLink size={12} className="text-fg-subtle opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
+                    </CardTitle>
+                    <CardDescription className="text-ds-sm">
+                      @devalok/shilp-sutra@{KIT_VERSION} — sigstore provenance, public registry.
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+              <Link
+                href="https://github.com/devalok-design/shilp-sutra/tree/main/packages/core/make-kit"
+                target="_blank"
+                rel="noreferrer"
+                className="group"
+              >
+                <Card variant="outline" interactive>
+                  <CardHeader>
+                    <CardTitle className="text-ds-md flex items-center gap-ds-02">
+                      <IconBrandGithub size={16} className="text-fg-muted" />
+                      GitHub source
+                      <IconExternalLink size={12} className="text-fg-subtle opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
+                    </CardTitle>
+                    <CardDescription className="text-ds-sm">
+                      Read the guidelines in context. File issues, suggest sharper rules.
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+              <Link
+                href="https://forum.figma.com/report-a-problem-6/figma-make-auto-check-of-new-design-system-npm-version-50979"
+                target="_blank"
+                rel="noreferrer"
+                className="group"
+              >
+                <Card variant="outline" interactive>
+                  <CardHeader>
+                    <CardTitle className="text-ds-md flex items-center gap-ds-02">
+                      <IconBrandFigma size={16} className="text-fg-muted" />
+                      Vote for auto-update
+                      <IconExternalLink size={12} className="text-fg-subtle opacity-0 group-hover:opacity-100 transition-opacity ml-auto" />
+                    </CardTitle>
+                    <CardDescription className="text-ds-sm">
+                      Open Figma forum request to detect new npm versions without manual republish.
+                    </CardDescription>
+                  </CardHeader>
+                </Card>
+              </Link>
+            </div>
+          </section>
+        </div>
+      </main>
+      <SiteFooter />
+    </>
+  )
+}

--- a/apps/site/components/make-kit-paster.tsx
+++ b/apps/site/components/make-kit-paster.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  IconCheck,
+  IconChevronDown,
+  IconChevronUp,
+  IconCopy,
+  IconExternalLink,
+} from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+
+type Item = {
+  path: string
+  label: string
+  content: string
+  sizeKB: number
+}
+
+type Props = {
+  /** Display name shown in the group header (e.g. "Foundations") */
+  title: string
+  /** Short prescriptive sentence describing what to paste */
+  description: string
+  /** Files in the group */
+  files: Item[]
+  /** Concatenated content for the "Copy all" button */
+  concat: string
+  /** Package version used to build unpkg "View" links */
+  version: string
+}
+
+export function MakeKitPaster({ title, description, files, concat, version }: Props) {
+  const [allCopied, setAllCopied] = useState(false)
+
+  const copyAll = async () => {
+    try {
+      await navigator.clipboard.writeText(concat)
+      setAllCopied(true)
+      setTimeout(() => setAllCopied(false), 1800)
+    } catch {
+      // older browsers without clipboard permission — silent
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-ds-05">
+      <header className="flex flex-col gap-ds-03 sm:flex-row sm:items-end sm:justify-between">
+        <div className="flex flex-col gap-ds-02">
+          <div className="flex items-center gap-ds-03">
+            <h3 className="text-ds-xl font-medium text-fg">{title}</h3>
+            <Badge variant="soft" size="sm">
+              {files.length} {files.length === 1 ? 'file' : 'files'}
+            </Badge>
+          </div>
+          <p className="text-ds-md text-fg-muted max-w-prose">{description}</p>
+        </div>
+        <Button
+          variant="soft"
+          size="sm"
+          startIcon={allCopied ? IconCheck : IconCopy}
+          onClick={copyAll}
+        >
+          {allCopied ? 'Copied all' : `Copy all ${files.length} files`}
+        </Button>
+      </header>
+      <ul className="flex flex-col gap-ds-02">
+        {files.map((file) => (
+          <FileRow key={file.path} file={file} version={version} />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function FileRow({ file, version }: { file: Item; version: string }) {
+  const [copied, setCopied] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(file.content)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // silent
+    }
+  }
+
+  const viewUrl = `https://unpkg.com/@devalok/shilp-sutra@${version}/make-kit/${file.path}`
+
+  return (
+    <li className="rounded-control border border-surface-border bg-surface-raised overflow-hidden">
+      <div className="flex items-center justify-between px-ds-04 py-ds-03 gap-ds-03">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex items-center gap-ds-03 text-left flex-1 min-w-0"
+          aria-expanded={expanded}
+          aria-controls={`preview-${file.path}`}
+        >
+          {expanded ? (
+            <IconChevronUp size={14} className="text-fg-muted shrink-0" />
+          ) : (
+            <IconChevronDown size={14} className="text-fg-muted shrink-0" />
+          )}
+          <code className="text-ds-sm font-mono text-fg truncate">{file.path}</code>
+          <span className="text-ds-xs text-fg-subtle shrink-0">{file.sizeKB} KB</span>
+        </button>
+        <div className="flex items-center gap-ds-02 shrink-0">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`View ${file.path} on unpkg`}
+            asChild
+          >
+            <a href={viewUrl} target="_blank" rel="noreferrer">
+              <IconExternalLink size={14} />
+            </a>
+          </Button>
+          <Button
+            variant={copied ? 'soft' : 'ghost'}
+            color={copied ? 'success' : 'accent'}
+            size="icon-sm"
+            aria-label={copied ? `${file.path} copied` : `Copy ${file.path}`}
+            onClick={copy}
+          >
+            {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+          </Button>
+        </div>
+      </div>
+      {expanded && (
+        <pre
+          id={`preview-${file.path}`}
+          className="px-ds-04 py-ds-04 border-t border-surface-border-subtle bg-surface-overlay text-ds-xs font-mono leading-relaxed text-fg-muted overflow-x-auto max-h-80 whitespace-pre-wrap"
+        >
+          {file.content}
+        </pre>
+      )}
+    </li>
+  )
+}

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -15,6 +15,7 @@ const navLinks = [
   { href: '/blocks', label: 'Blocks' },
   { href: '/theming', label: 'Theming' },
   { href: '/docs', label: 'Docs' },
+  { href: '/figma-make', label: 'Figma Make' },
   { href: '/agents', label: 'For AI editors', accent: true },
 ] as const
 

--- a/apps/site/lib/make-kit-content.ts
+++ b/apps/site/lib/make-kit-content.ts
@@ -1,0 +1,112 @@
+/**
+ * Make kit content loader — reads packages/core/make-kit/*.md at build time.
+ * Single source of truth shared with the npm tarball.
+ */
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const REPO_ROOT = resolve(process.cwd(), '..', '..')
+const MAKE_KIT_DIR = join(REPO_ROOT, 'packages', 'core', 'make-kit')
+
+export type GuidelineFile = {
+  /** Path within make-kit/ (e.g. "foundations/color.md") */
+  path: string
+  /** Short label shown in UI (e.g. "color") */
+  label: string
+  /** File content (markdown) */
+  content: string
+  /** Bytes (rounded to KB) — shown next to filename */
+  sizeKB: number
+}
+
+export type GuidelineGroup = {
+  id: 'top' | 'foundations' | 'components'
+  title: string
+  description: string
+  files: GuidelineFile[]
+}
+
+const TOP_LEVEL = ['Guidelines.md', 'setup.md']
+const FOUNDATIONS = [
+  'color.md',
+  'typography.md',
+  'spacing.md',
+  'surfaces.md',
+  'radius.md',
+  'motion.md',
+  'dark-mode.md',
+  'icons.md',
+]
+const COMPONENTS = [
+  'overview.md',
+  'button.md',
+  'card.md',
+  'input.md',
+  'dialog.md',
+  'badge.md',
+  'select.md',
+  'tabs.md',
+  'toast.md',
+  'form.md',
+  'table.md',
+  'dropdown-menu.md',
+  'popover.md',
+  'text.md',
+  'stack.md',
+  'icon.md',
+]
+
+function load(relPath: string): GuidelineFile {
+  const abs = join(MAKE_KIT_DIR, relPath)
+  const content = readFileSync(abs, 'utf8')
+  const label = relPath
+    .replace(/^(foundations|components)\//, '')
+    .replace(/\.md$/, '')
+  return {
+    path: relPath,
+    label,
+    content,
+    sizeKB: Math.round(Buffer.byteLength(content, 'utf8') / 1024),
+  }
+}
+
+export function getGuidelineGroups(): GuidelineGroup[] {
+  return [
+    {
+      id: 'top',
+      title: 'Top level',
+      description:
+        'Entry point + setup. Figma Make reads Guidelines.md first, so paste it before anything else.',
+      files: TOP_LEVEL.map((f) => load(f)),
+    },
+    {
+      id: 'foundations',
+      title: 'Foundations',
+      description:
+        'Tokens, surfaces, spacing cadence, motion, dark mode, icons. Paste all eight before moving to components.',
+      files: FOUNDATIONS.map((f) => load(`foundations/${f}`)),
+    },
+    {
+      id: 'components',
+      title: 'Components',
+      description:
+        'Per-component guides. Overview first, then any order. 15 components covered — extend over time as Make fumbles surface.',
+      files: COMPONENTS.map((f) => load(`components/${f}`)),
+    },
+  ]
+}
+
+/**
+ * Concatenate all files in a group with a "## File: <path>" separator so a
+ * single-paste flow still tracks which file each section is for. Used by
+ * the "Copy all foundations" / "Copy all components" buttons.
+ */
+export function concatGroup(group: GuidelineGroup): string {
+  return group.files
+    .map((f) => `<!-- ===== File: ${f.path} ===== -->\n\n${f.content.trim()}\n`)
+    .join('\n')
+}
+
+export function fileCount(): number {
+  return TOP_LEVEL.length + FOUNDATIONS.length + COMPONENTS.length
+}

--- a/docs/plans/2026-06-03-figma-make-rollout-plan.md
+++ b/docs/plans/2026-06-03-figma-make-rollout-plan.md
@@ -1,0 +1,203 @@
+# Figma Make consumer rollout — plan
+
+**Status:** Plan, not implemented.
+**Date:** 2026-06-03.
+**Context:** `@devalok/shilp-sutra@0.42.0` shipped the `make-kit/` guideline directory. Kit registered in Devalok Figma org. Need to make external consumers (humans + AI agents) discover and self-install the kit, since Figma offers no public Make-kit gallery, no cross-org share, no install deep-link.
+
+---
+
+## What we're solving
+
+After 0.42.0, the npm tarball IS the public Make kit distribution channel. Every external consumer org has to:
+
+1. Know the kit exists.
+2. Know it requires Figma org/enterprise plan + Make access.
+3. Register `@devalok/shilp-sutra@0.42.0` in their own Figma org.
+4. Paste our 26 guideline files into their kit.
+5. Publish kit in their org.
+
+If we don't build the consumer-facing path, only Devalok org will ever use it. The 26 files in the tarball become dead weight.
+
+## Phase 1 scope (this plan)
+
+Four deliverables. Order is implementation order; (1) is biggest, drives the rest.
+
+### 1. `/figma-make` setup wizard page on `shilp-sutra.devalok.in`
+
+**Route:** `apps/site/app/figma-make/page.tsx`
+
+**Purpose:** one-page path from "I saw shilp-sutra exists" → "kit live in my Figma org." Mirrors `/agents` page in structure + vocabulary.
+
+**Sections (top to bottom):**
+
+#### a. Hero
+- `<PageHeader>` — title "Use shilp-sutra in Figma Make"
+- One-line value: "Generate apps + prototypes in Figma Make against the production design system. Components, tokens, dark mode, and conventions baked in."
+- Two CTAs:
+  - Primary `<Button>` — "Open Figma Make" → `https://www.figma.com/make` (plain link, no deep-link available)
+  - Soft `<Button>` — "Read setup ↓" → smooth-scroll to step 1
+
+#### b. Eligibility callout
+- `<Alert color="info" size="md">` — "Figma Make kits require an Organization or Enterprise Figma plan. Free / Pro plans can install the npm package but can't register a private Make kit."
+
+#### c. The 6-step wizard
+Each step = `<Card variant="outline" size="md">` with a numbered badge, title, body, and copy-to-clipboard blocks:
+
+1. **Open Figma → Resources → Make kits → Create**  
+   Screenshot or 2-line instruction.
+2. **Pick "Public npm registry"**  
+   With a copy-block: `@devalok/shilp-sutra` + version `0.42.0` (pinned).
+3. **Choose "Manual guidelines"**  
+   "Auto-gen is a fast fallback — ours are tighter."
+4. **Paste guidelines** — see below ("Guidelines paste blocks").
+5. **Publish kit**  
+   Note: kit version is separate from npm version. Figma assigns `1.0.0`.
+6. **Attach kit to a Make file and prompt**  
+   Example prompt: "Build a settings page with sidebar, email + password form, primary/cancel buttons. Use shilp-sutra."
+
+#### d. Guidelines paste blocks
+- Tabbed or accordion layout listing all 26 files in the order they paste:
+  - `Guidelines.md`
+  - `setup.md`
+  - 8× `foundations/*.md`
+  - `components/overview.md`
+  - 15× `components/*.md`
+- Each row: filename label + "Copy" button + "View" link (opens `unpkg.com/@devalok/shilp-sutra@0.42.0/make-kit/<path>` in new tab).
+- Content fetched at **build time** via Next's RSC + `fs.readFileSync` from `node_modules/@devalok/shilp-sutra/make-kit/*` (the site app depends on core, so the directory ships in `node_modules`). Build-time read keeps the bundle thin and pins content to whatever core version the site builds against. When core bumps and site rebuilds, the page auto-refreshes.
+- Two top-level copy buttons:
+  - "Copy all foundations as one block" — concatenated with `## File: foundations/<name>.md` separators.
+  - "Copy all components as one block" — same pattern.
+  - For consumers who prefer one paste over 26.
+
+#### e. What Make generates (visual proof)
+- 2–3 example screenshots: same prompt against vanilla Make vs against the kit. Show kit-flavored output (Button soft variant, proper surface tokens, no raw HTML).
+- Captions: "Without the kit" / "With shilp-sutra@0.42.0 Make kit."
+- If we don't have screenshots yet → defer to Phase 2 + leave placeholder.
+
+#### f. Update cadence section
+- `<Card variant="outline">` "When to refresh the kit in your org"
+- Bullets:
+  - On a shilp-sutra **minor** bump (0.43, 0.44…) → bump kit's npm version, re-paste any changed guidelines.
+  - On a **patch** bump → usually skip unless the patch fixes Make-visible behavior.
+  - No auto-update from Figma side. [Open feature request](https://forum.figma.com/report-a-problem-6/figma-make-auto-check-of-new-design-system-npm-version-50979).
+
+#### g. FAQ / troubleshoot
+- "Can I use the kit on a free Figma plan?" — No, org/enterprise only.
+- "Does Make pull new versions automatically?" — No, manual republish in Figma UI.
+- "Why does Figma bump the kit version on every republish?" — Known UX quirk. Kit version ≠ npm version.
+- "Make generates raw `<button>` instead of `<Button>` — what now?" — Patch `components/button.md` in your kit, republish. Or file an issue against us so we tighten the source.
+- "Auto-gen looks fine — should I use that instead?" — Acceptable starting point. Ours are stricter on conventions (soft-over-outline default, ds-* cadence, surface tiers). Re-paste later if you hit drift.
+
+#### h. Footer CTAs
+- Link to npm: `npm view @devalok/shilp-sutra`
+- Link to GitHub: `make-kit/` directory source
+- Link to filed Figma forum threads (for "vote on auto-update")
+
+**Layout / style:**
+- Match `/agents` page composition exactly. Same `<PageHeader>` + `<SiteHeader>` + `<SiteFooter>` shell. Same Card grid pattern for the 6 steps.
+- Spacing: `ds-07` between sections, `ds-05` within a section, `ds-03` for tight pairs. Three-tier cadence rule applies.
+- Dark mode: free (uses semantic tokens).
+- Mobile: stacks to single column ≤ md.
+
+**Components used (no new code):**
+- `<PageHeader>`, `<SiteHeader>`, `<SiteFooter>` (existing site composed)
+- `<Card>`, `<Button>`, `<Text>`, `<Alert>`, `<Stack>`, `<CodeBlock>` (existing site usage)
+- New tiny component `apps/site/components/copy-button.tsx` — wraps `navigator.clipboard.writeText`, animates check on success. Or use existing one if there is one — TBD during impl.
+- New `apps/site/components/make-kit-paster.tsx` — the per-file paste block UI. Reads file content as a prop, renders label + copy button + view link.
+
+### 2. README badge + section
+
+Top of `README.md`, in the badge row:
+
+```markdown
+[![Figma Make compatible](https://img.shields.io/badge/Figma_Make-compatible-purple)](https://shilp-sutra.devalok.in/figma-make)
+```
+
+New section after "Setup" (before "Tech stack"):
+
+```markdown
+## Figma Make
+
+`@devalok/shilp-sutra@0.42.0+` ships [Make kit guidelines](packages/core/make-kit/)
+at `node_modules/@devalok/shilp-sutra/make-kit/`. Register the kit in your
+Figma org to generate apps + prototypes in Figma Make against the production
+design system — components, tokens, dark mode, and conventions baked in.
+
+→ [Setup guide](https://shilp-sutra.devalok.in/figma-make)
+```
+
+### 3. AGENTS.md row
+
+Add a new section after the existing "When working ON shilp-sutra" block:
+
+```markdown
+## Figma Make
+
+If the user mentions Figma Make, generating designs against a kit, or
+registering a Make kit:
+
+- shilp-sutra ships Make kit guidelines at
+  `node_modules/@devalok/shilp-sutra/make-kit/`.
+- Walkthrough at https://shilp-sutra.devalok.in/figma-make.
+- Pin kit to a specific npm version. No auto-update from Figma side.
+- Cross-org sharing not possible — each consumer org self-registers.
+```
+
+### 4. llms.txt + llms-full.txt update
+
+In `packages/core/llms.txt` at the top "NEW (v0.42.0)" section (add this block):
+
+```
+## NEW (v0.42.0)
+
+- **Figma Make kit.** 26 guideline files at `node_modules/@devalok/shilp-sutra/make-kit/`. Subpath exports `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `/make-kit/*` → individual files. Used by Figma Make to generate apps + prototypes against the DS. Setup guide: https://shilp-sutra.devalok.in/figma-make. Public npm registry; cross-org sharing not possible; pin to a specific version, no auto-update.
+```
+
+In `packages/core/llms-full.txt` — adds via `scripts/build-component-docs.mjs` on next core build. No manual edit.
+
+## Implementation order
+
+1. Write `apps/site/components/copy-button.tsx` (~30 lines, reusable).
+2. Write `apps/site/components/make-kit-paster.tsx` (~80 lines, takes filename + content).
+3. Build `apps/site/app/figma-make/page.tsx` — RSC, reads `make-kit/*.md` from `node_modules` at build time, renders the sections above.
+4. Add `/figma-make` route to `apps/site/components/site-header.tsx` `navLinks`.
+5. Add `<a>` row at the top of `apps/site/app/page.tsx` hero (existing "now Make-compatible" announcement bar).
+6. Update README — badge row + section.
+7. Update AGENTS.md — Figma Make section.
+8. Update llms.txt — NEW v0.42.0 section.
+9. Test: `pnpm --filter site dev`, walk through the page, copy buttons, mobile, dark mode, every paste block fetches content correctly.
+10. Pre-publish-audit (locally; site app changes don't gate core publish but llms.txt does).
+11. Commit, branch `feat/figma-make-rollout`, PR, admin-merge.
+12. Since no core API change, no changeset needed for shilp-sutra. Site app gets a patch via changesets (existing site versioning flow).
+
+## Out of scope (Phase 2)
+
+- Visual proof screenshots (need a real Make session to capture them; defer until kit hits some usage).
+- Blog / LinkedIn announcement.
+- Twitter clip.
+- Devalok studio voice quote.
+- Forum thread asking Figma for cross-org sharing + deep-link install. File later when we have multiple consumer orgs asking.
+- Diff script: detect which guideline files changed since last npm tag, auto-flag re-paste candidates in release notes.
+- Embeddable iframe showing live Make output (blocked by Figma CSP `frame-ancestors 'self'`).
+
+## Risk + open questions
+
+- **Build-time file read from `node_modules`.** Vite-with-RSC + `fs.readFileSync` works on Vercel. If site deploy is on a different runtime, may need to copy `make-kit/` into `apps/site/public/` at build. Check site CI before committing.
+- **Copy-button + clipboard API.** Needs HTTPS + `navigator.clipboard` polyfill consideration for older browsers. Site already does this elsewhere — check `apps/site/components/code-block.tsx` for the existing pattern.
+- **Guideline content drift.** When core bumps make-kit content, site must rebuild + redeploy to pick it up. Acceptable — site rebuilds on every shilp-sutra publish anyway via Vercel hook.
+- **Mobile UX of 26 paste blocks.** Long list. Consider collapsible category sections (foundations / components) on mobile to shorten scroll.
+- **Filed forum thread for Figma to expose deep-link install** — should we file it now while it's fresh? Cheap to file, signal demand. Add as Phase 1.5 task.
+
+## Success criteria
+
+- New visitor lands on `/figma-make`, can register kit in their Figma org without leaving the page.
+- AI agent reading our `AGENTS.md` knows to point users at the route.
+- Consumer org admin running shilp-sutra upgrade ritual sees in our llms.txt v0.42 notes that Make kit exists.
+- Cross-team visibility: post a Linear / Notion entry in your studio's tracker so next quarterly review can see uptake.
+
+## Estimated effort
+
+- Page + components: ~3–4 hr (matches `/agents` complexity).
+- README / AGENTS.md / llms.txt updates: ~30 min.
+- Testing + polish: ~1 hr.
+- Total: half day.

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -41,6 +41,10 @@ Paste the snippet *after* `@import "@devalok/shilp-sutra/css";` in the global st
 
 The repo URL for these files is `https://github.com/devalok-design/shilp-sutra/tree/main/packages/core/docs/recipes`. Consumer projects should also have an `AGENTS.md` at their root with the rules above pre-loaded — read that first if it exists.
 
+## NEW (v0.42.0)
+
+- **Figma Make kit.** 26 guideline files at `node_modules/@devalok/shilp-sutra/make-kit/` (top-level `Guidelines.md` + `setup.md`, eight `foundations/*.md`, sixteen `components/*.md`). Subpath exports `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `/make-kit/*` → individual files. Used by Figma Make to generate apps + prototypes against the DS. Setup walkthrough: https://shilp-sutra.devalok.in/figma-make. Public npm registry; cross-org sharing not supported by Figma — each consumer org self-registers. Pin to a specific npm version; no auto-update flow yet. Make kits need Organization / Enterprise Figma plan; Free + Pro can still install the package directly in React projects.
+
 ## NEW (v0.40.0)
 
 - **OAuthButton.** Brand-aware social/login buttons. Subpath: `@devalok/shilp-sutra/ui/oauth-button`. 13 providers (`google` `apple` `github` `microsoft` `x` `linkedin` `facebook` `discord` `slack` `gitlab` `sso` `email` `passkey`). Props: `provider`, `intent` (`continue|signin|signup`), `appearance` (`brand|outline|dark`), `icon` (override default glyph), `iconOnly`, `compact` (renders just "Google" instead of "Continue with Google"; aria-label keeps long form), `lastUsed` (inline right-edge pill inside button), `helperText`. Inherits Button async/loading/sizes. Siblings: `OAuthGroup` (with `reorderLastUsedFirst` for Stripe-style ordering), `OAuthDivider`, `OAuthConnectionRow` (settings-page linked state). Default glyphs from Tabler peer dep; pass `icon` to drop in a brand's official multicolour SVG. In dark mode every brand appearance lands on the same DS surface — brand identity comes from the glyph, not the bg, so rows stay visually coherent.


### PR DESCRIPTION
## Summary

Public-facing rollout for the Figma Make kit shipped in `@devalok/shilp-sutra@0.42.0`.

**Page:** [`/figma-make`](https://shilp-sutra.devalok.in/figma-make) — six-step walkthrough, paste-ready guideline blocks (26 files), update-cadence card, FAQ, footer cross-links.

**Auto-update reality** ([surfaced from Figma forum](https://forum.figma.com/report-a-problem-6/publishing-figma-make-kit-from-github-ci-52996)): Figma Make does not auto-pull new npm versions. Each consumer org self-registers + republishes manually. Page is explicit about this, includes the [open feature request](https://forum.figma.com/report-a-problem-6/figma-make-auto-check-of-new-design-system-npm-version-50979) so consumers can vote.

**Voice:** matches `/agents` page — terse, prescriptive, no marketing copy. Drafted against Devalok AI-RULES (no banned vocab, no contrastive negation, no AI-redundancy stacks).

## Changes

### New
- `apps/site/app/figma-make/page.tsx` — the setup page (RSC).
- `apps/site/components/make-kit-paster.tsx` — client component, per-group paste UI with copy-each + copy-all + collapsible markdown preview + unpkg "view" link.
- `apps/site/lib/make-kit-content.ts` — server-only loader, reads `packages/core/make-kit/*.md` at build time so page can never drift from tarball.
- `docs/plans/2026-06-03-figma-make-rollout-plan.md` — the plan doc this PR implements.
- `.changeset/figma-make-rollout.md` — patch bump on core (docs only).

### Tarball-shipping doc updates (core patch)
- `packages/core/llms.txt` — NEW v0.42.0 entry routes AI agents to the kit + setup page.
- `AGENTS.md` — Figma Make section.

### Other
- `README.md` — Figma Make badge + section.
- `apps/site/components/site-header.tsx` — `/figma-make` nav entry.

## Test plan

- [x] `pnpm -F site typecheck` clean
- [x] `pnpm -F site lint` clean
- [x] `pnpm -F site dev` → `http://localhost:3000/figma-make` returns 200, all 26 paste blocks render with correct file paths
- [ ] CI green
- [ ] Vercel preview deploy renders correctly
- [ ] Dark mode spot-check on preview
- [ ] Mobile spot-check on preview (26 paste blocks scroll length acceptable)
- [ ] After merge: site auto-deploys; AI editors / consumer orgs can self-install the kit from the page

## Out of scope (Phase 2)

- Visual proof screenshots (need real Make sessions to capture)
- Blog post / LinkedIn announcement
- Twitter clip
- Drift-detector script (flag changed guideline files between tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)