### PR TITLE
feat(core)!: anti-convergence surface & elevation pass

### DIFF
--- a/.changeset/anti-convergence-surface.md
+++ b/.changeset/anti-convergence-surface.md
@@ -1,0 +1,28 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Anti-convergence surface & elevation pass — components no longer stack a visible border and a drop shadow on the same element (the DS's own make-kit Guidelines rule #6: the shadow tokens already carry a 1px ring).
+
+**BREAKING — `StatCard` `accent` prop removed.** The colored left-rail (`accent="success" | "error" | …`) is gone (it was the single most recognizable AI design tell — an accent rail on a rounded, shadowed card). Replace with the new accent system, or drop it (the `delta` already carries trend direction + colour):
+
+```diff
+- <StatCard label="Revenue" value="$48k" accent="success" />
++ <StatCard label="Revenue" value="$48k" accentStyle="tint" />
++ <StatCard label="Revenue" value="$48k" icon={<IconCurrencyDollar />} accentStyle="icon" />
+```
+
+**New — `StatCard` surface, accent & motion (all composable, all opt-in):**
+
+- `surface="raised" | "flat"` (default `raised`) — elevation-led (ring-in-shadow, no border) or border-led (border, no shadow).
+- `accentStyle="none" | "icon" | "tint"` (default `none`) + `iconFill="soft" | "solid"`.
+- `flash` + `flashSpeed` — opt-in entrance animation: a toned state glyph (`'up' | 'down' | 'goal' | 'record' | 'alert' | 'live'`, or `{ tone, icon }`) flashes, then settles to the metric's `icon`. Gated by `prefers-reduced-motion`.
+
+**New — `StatFlash` component.** The state→identity flash primitive used by StatCard's `flash`, exported standalone for use in list rows, badges, etc. Composable speed (`speed` preset + `holdMs` / `settleTransition` / `flashTransition` overrides).
+
+**Visual changes (non-breaking):**
+
+- Overlays (Dialog, AlertDialog, Popover, HoverCard, Dropdown/Context/Menubar menus, Select, Combobox, Autocomplete, NavigationMenu, Toast, ColorInput picker, SplitButton menu, DataTable bulk actions, floating Sidebar) drop their explicit `border`; the shadow's own ring carries the edge. `--shadow-floating` / `--shadow-overlay` ring strengthened (0.04 → 0.09); dark mode uses a light ring via the new `--shadow-edge-ring` token.
+- `Card` `default` / `elevated` are now ring-in-shadow (no border). Use `variant="outline"` for a border-led card.
+- `StatCard` base no longer stacks border + shadow.
+- `InputOTP` cells are border-led (dropped the redundant `shadow-raised`).

--- a/packages/core/docs/components/ui/stat-card.md
+++ b/packages/core/docs/components/ui/stat-card.md
@@ -16,7 +16,11 @@
     comparisonLabel: string (shown after delta, e.g. "vs last month")
     secondaryLabel: string (below main value, e.g. "of $50,000 target")
     progress: number (0-100, renders thin progress bar below value)
-    accent: "default" | "success" | "warning" | "error" | "info" (left border color)
+    surface: "raised" | "flat" (raised = ring-in-shadow, no border [default]; flat = border, no shadow)
+    accentStyle: "none" | "icon" | "tint" (none [default]; icon = accent chip around icon; tint = accent surface wash + accent value)
+    iconFill: "soft" | "solid" (chip style when accentStyle="icon"; default soft)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (opt-in entrance flash; requires icon)
+    flashSpeed: "fast" | "normal" | "slow" (default normal)
     sparkline: number[] (renders mini SVG line chart)
     onClick: () => void (makes card clickable with hover state)
     href: string (makes card a link via LinkContext)
@@ -34,7 +38,8 @@
   delta={{ value: "+12%", direction: "up" }}
   comparisonLabel="vs last month"
   icon={<IconCurrencyDollar />}
-  accent="success"
+  accentStyle="icon"
+  flash="up"
 />
 
 <StatCard
@@ -51,7 +56,8 @@
 - **High-density metric card** — optimized for dashboards. Everything optional except `value`. Mix and match features (delta, sparkline, progress, secondary label, footer) per metric's needs.
 - **Router integration via href:** Internally uses `LinkContext` to resolve framework-specific Link components (Next.js, react-router). Set `href` in a LinkProvider-wrapped tree to get seamless client-side navigation without custom asChild wiring.
 - **Interactive modes:** `onClick` makes the entire card a button; `href` makes it a link. Mutually exclusive — href wins if both are set.
-- **Accent bar semantic:** Use `accent` to signal metric health at a glance (success for positive, warning for at-risk, error for over-target). Combine with delta.direction for layered emphasis.
+- **Accent (composable, opt-in):** `accentStyle="icon"` wraps `icon` in an accent chip (`iconFill="soft" | "solid"`); `accentStyle="tint"` applies a subtle accent surface wash + accent value. `surface` picks edge-vs-elevation. No colored rail — the DS never stacks a border + drop shadow (make-kit rule #6). Trend health reads from `delta.direction` (up=green, down=red).
+- **Flash motion (opt-in):** `flash` mounts a toned state glyph (`up`/`down`/`goal`/`record`/`alert`/`live`, or `{ tone, icon }`) that settles to `icon`; `flashSpeed` tunes timing. Reuses the standalone `StatFlash` primitive. Honors `prefers-reduced-motion`.
 - **Sparkline:** Pure SVG, lightweight — no chart library. For rich charts use Chart components. Minimum 2 data points.
 - **Icon auto-sizing:** Accepts `ComponentType<{ className }>` OR `ReactNode`. The component prop (e.g. `icon={IconBolt}`) is preferred — icon is rendered at a consistent size.
 - **Loading state:** `loading={true}` renders the full card skeleton — use during initial data fetch.
@@ -63,6 +69,10 @@
 - `sparkline` needs at least 2 data points to render
 
 ## Changes
+### v0.43.0
+- **BREAKING** Removed `accent` (colored left-rail). Use `accentStyle` (`"icon"` | `"tint"`) or rely on `delta` for trend colour.
+- **Added** `surface`, `accentStyle`, `iconFill`, `flash`, `flashSpeed`. New standalone `StatFlash` primitive. Base no longer stacks border + shadow.
+
 ### v0.2.0
 - **Added** `icon` prop now accepts `React.ComponentType` (e.g., `icon={IconBolt}`) in addition to `ReactNode`
 

--- a/packages/core/docs/components/ui/stat-flash.md
+++ b/packages/core/docs/components/ui/stat-flash.md
@@ -1,0 +1,44 @@
+# StatFlash
+
+- Import: @devalok/shilp-sutra/ui/stat-flash
+- Server-safe: No
+- Category: ui
+
+## Props
+    icon: ReactNode | ComponentType<{ className?: string }> (REQUIRED — settled identity glyph)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (REQUIRED — the entrance state)
+    fill: "soft" | "solid" (resting chip style; default soft)
+    speed: "fast" | "normal" | "slow" (coarse motion preset; default normal)
+    holdMs: number (override how long the flash holds before settling)
+    settleTransition: Transition (override the icon scale-in transition)
+    flashTransition: Transition (override the flash enter/exit fade)
+
+## Defaults
+    fill="soft", speed="normal"
+
+## Example
+```jsx
+// Preset: green up-arrow flashes, then settles to the folder icon
+<StatFlash icon={<IconFolder />} flash="up" />
+
+// Explicit tone + glyph
+<StatFlash icon={<IconActivity />} flash={{ tone: "info", icon: <IconBolt /> }} fill="solid" />
+
+// Composable speed: coarse preset + fine override
+<StatFlash icon={<IconFolder />} flash="up" speed="fast" holdMs={300} />
+```
+
+## Composability
+- **State → identity primitive:** the chip mounts showing a transient *state* (a toned glyph — up-arrow on green, check, alert…) then settles into the stable *identity* icon. Used by `StatCard`'s `flash` prop, but standalone too (list rows, badges, toasts).
+- **Tone slot:** six named presets (`up`/`down`/`goal`/`record`/`alert`/`live`) map to DS semantic tones (success/error/warning/info/accent) + a glyph. Pass `{ tone, icon }` for anything else.
+- **Composable motion:** `speed` is a coarse preset built from the DS motion tokens; `holdMs` / `settleTransition` / `flashTransition` each override one slice and fall back to the preset.
+- **Accessible by default:** honors `prefers-reduced-motion` — renders the settled identity directly, no flash. The chip is `aria-hidden` (decorative; the metric's text carries meaning).
+
+## Gotchas
+- `flash` and `icon` are both required — the flash settles *to* the icon.
+- Fine overrides win over `speed`.
+- Decorative only — never the sole carrier of meaning (it's `aria-hidden`).
+
+## Changes
+### v0.43.0
+- **Added** Initial release. Powers `StatCard`'s `flash` prop.

--- a/packages/core/llms-full.txt
+++ b/packages/core/llms-full.txt
@@ -4046,7 +4046,11 @@ import { SplitButton } from '@devalok/shilp-sutra'
     comparisonLabel: string (shown after delta, e.g. "vs last month")
     secondaryLabel: string (below main value, e.g. "of $50,000 target")
     progress: number (0-100, renders thin progress bar below value)
-    accent: "default" | "success" | "warning" | "error" | "info" (left border color)
+    surface: "raised" | "flat" (raised = ring-in-shadow, no border [default]; flat = border, no shadow)
+    accentStyle: "none" | "icon" | "tint" (none [default]; icon = accent chip around icon; tint = accent surface wash + accent value)
+    iconFill: "soft" | "solid" (chip style when accentStyle="icon"; default soft)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (opt-in entrance flash; requires icon)
+    flashSpeed: "fast" | "normal" | "slow" (default normal)
     sparkline: number[] (renders mini SVG line chart)
     onClick: () => void (makes card clickable with hover state)
     href: string (makes card a link via LinkContext)
@@ -4064,7 +4068,8 @@ import { SplitButton } from '@devalok/shilp-sutra'
   delta={{ value: "+12%", direction: "up" }}
   comparisonLabel="vs last month"
   icon={<IconCurrencyDollar />}
-  accent="success"
+  accentStyle="icon"
+  flash="up"
 />
 
 <StatCard
@@ -4081,7 +4086,8 @@ import { SplitButton } from '@devalok/shilp-sutra'
 - **High-density metric card** — optimized for dashboards. Everything optional except `value`. Mix and match features (delta, sparkline, progress, secondary label, footer) per metric's needs.
 - **Router integration via href:** Internally uses `LinkContext` to resolve framework-specific Link components (Next.js, react-router). Set `href` in a LinkProvider-wrapped tree to get seamless client-side navigation without custom asChild wiring.
 - **Interactive modes:** `onClick` makes the entire card a button; `href` makes it a link. Mutually exclusive — href wins if both are set.
-- **Accent bar semantic:** Use `accent` to signal metric health at a glance (success for positive, warning for at-risk, error for over-target). Combine with delta.direction for layered emphasis.
+- **Accent (composable, opt-in):** `accentStyle="icon"` wraps `icon` in an accent chip (`iconFill="soft" | "solid"`); `accentStyle="tint"` applies a subtle accent surface wash + accent value. `surface` picks edge-vs-elevation. No colored rail — the DS never stacks a border + drop shadow (make-kit rule #6). Trend health reads from `delta.direction` (up=green, down=red).
+- **Flash motion (opt-in):** `flash` mounts a toned state glyph (`up`/`down`/`goal`/`record`/`alert`/`live`, or `{ tone, icon }`) that settles to `icon`; `flashSpeed` tunes timing. Reuses the standalone `StatFlash` primitive. Honors `prefers-reduced-motion`.
 - **Sparkline:** Pure SVG, lightweight — no chart library. For rich charts use Chart components. Minimum 2 data points.
 - **Icon auto-sizing:** Accepts `ComponentType<{ className }>` OR `ReactNode`. The component prop (e.g. `icon={IconBolt}`) is preferred — icon is rendered at a consistent size.
 - **Loading state:** `loading={true}` renders the full card skeleton — use during initial data fetch.
@@ -4093,11 +4099,59 @@ import { SplitButton } from '@devalok/shilp-sutra'
 - `sparkline` needs at least 2 data points to render
 
 ## Changes
+### v0.43.0
+- **BREAKING** Removed `accent` (colored left-rail). Use `accentStyle` (`"icon"` | `"tint"`) or rely on `delta` for trend colour.
+- **Added** `surface`, `accentStyle`, `iconFill`, `flash`, `flashSpeed`. New standalone `StatFlash` primitive. Base no longer stacks border + shadow.
+
 ### v0.2.0
 - **Added** `icon` prop now accepts `React.ComponentType` (e.g., `icon={IconBolt}`) in addition to `ReactNode`
 
 ### v0.1.0
 - **Added** Initial release
+# StatFlash
+
+- Import: @devalok/shilp-sutra/ui/stat-flash
+- Server-safe: No
+- Category: ui
+
+## Props
+    icon: ReactNode | ComponentType<{ className?: string }> (REQUIRED — settled identity glyph)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (REQUIRED — the entrance state)
+    fill: "soft" | "solid" (resting chip style; default soft)
+    speed: "fast" | "normal" | "slow" (coarse motion preset; default normal)
+    holdMs: number (override how long the flash holds before settling)
+    settleTransition: Transition (override the icon scale-in transition)
+    flashTransition: Transition (override the flash enter/exit fade)
+
+## Defaults
+    fill="soft", speed="normal"
+
+## Example
+```jsx
+// Preset: green up-arrow flashes, then settles to the folder icon
+<StatFlash icon={<IconFolder />} flash="up" />
+
+// Explicit tone + glyph
+<StatFlash icon={<IconActivity />} flash={{ tone: "info", icon: <IconBolt /> }} fill="solid" />
+
+// Composable speed: coarse preset + fine override
+<StatFlash icon={<IconFolder />} flash="up" speed="fast" holdMs={300} />
+```
+
+## Composability
+- **State → identity primitive:** the chip mounts showing a transient *state* (a toned glyph — up-arrow on green, check, alert…) then settles into the stable *identity* icon. Used by `StatCard`'s `flash` prop, but standalone too (list rows, badges, toasts).
+- **Tone slot:** six named presets (`up`/`down`/`goal`/`record`/`alert`/`live`) map to DS semantic tones (success/error/warning/info/accent) + a glyph. Pass `{ tone, icon }` for anything else.
+- **Composable motion:** `speed` is a coarse preset built from the DS motion tokens; `holdMs` / `settleTransition` / `flashTransition` each override one slice and fall back to the preset.
+- **Accessible by default:** honors `prefers-reduced-motion` — renders the settled identity directly, no flash. The chip is `aria-hidden` (decorative; the metric's text carries meaning).
+
+## Gotchas
+- `flash` and `icon` are both required — the flash settles *to* the icon.
+- Fine overrides win over `speed`.
+- Decorative only — never the sole carrier of meaning (it's `aria-hidden`).
+
+## Changes
+### v0.43.0
+- **Added** Initial release. Powers `StatCard`'s `flash` prop.
 # StatusDot
 
 - Import: @devalok/shilp-sutra/ui/status-dot

--- a/packages/core/src/ai/command-bar.tsx
+++ b/packages/core/src/ai/command-bar.tsx
@@ -828,7 +828,7 @@ const CommandBar = React.forwardRef<HTMLDivElement, CommandBarProps>(
             {...props}
             className={cn(
               'fixed left-1/2 top-[20%] z-modal w-full max-w-[560px] -translate-x-1/2',
-              'overflow-hidden rounded-overlay-lg border border-surface-border-strong bg-surface-overlay shadow-overlay',
+              'overflow-hidden rounded-overlay-lg bg-surface-overlay shadow-overlay',
               'duration-moderate-02 data-[state=open]:animate-in data-[state=closed]:animate-out',
               'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
               'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',

--- a/packages/core/src/composed/bulk-action-bar.tsx
+++ b/packages/core/src/composed/bulk-action-bar.tsx
@@ -177,7 +177,7 @@ function BulkActionBar({
           transition={springs.snappy}
           className={cn(
             'fixed bottom-ds-06 left-1/2 z-sticky -translate-x-1/2',
-            'flex items-center gap-ds-04 rounded-surface border border-surface-border bg-surface-overlay px-ds-05 py-ds-03 shadow-floating',
+            'flex items-center gap-ds-04 rounded-surface bg-surface-overlay px-ds-05 py-ds-03 shadow-floating',
             className,
           )}
           role="toolbar"

--- a/packages/core/src/composed/command-palette.tsx
+++ b/packages/core/src/composed/command-palette.tsx
@@ -330,7 +330,7 @@ const CommandPalette = React.forwardRef<HTMLDivElement, CommandPaletteProps>(
           {...props}
           className={cn(
             'fixed left-1/2 top-[20%] z-modal w-full max-w-[560px] -translate-x-1/2',
-            'overflow-hidden rounded-overlay-lg border border-surface-border-strong bg-surface-overlay shadow-overlay',
+            'overflow-hidden rounded-overlay-lg bg-surface-overlay shadow-overlay',
             'duration-moderate-02 data-[state=open]:animate-in data-[state=closed]:animate-out',
             'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
             'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',

--- a/packages/core/src/composed/content-card.tsx
+++ b/packages/core/src/composed/content-card.tsx
@@ -10,7 +10,7 @@ const contentCardVariants = cva(
     variants: {
       variant: {
         default:
-          'border border-surface-border-strong bg-surface-raised shadow-raised hover:shadow-raised-hover',
+          'bg-surface-raised shadow-raised hover:shadow-raised-hover',
         outline:
           'border border-surface-border bg-transparent hover:border-surface-border-strong',
         ghost:

--- a/packages/core/src/composed/error-boundary.tsx
+++ b/packages/core/src/composed/error-boundary.tsx
@@ -111,7 +111,7 @@ const ErrorDisplay = React.forwardRef<HTMLDivElement, ErrorDisplayProps>(
   return (
     <div ref={ref} {...props} className={cn("flex min-h-[60vh] items-center justify-center p-ds-05", className)}>
       <div
-        className="flex w-full max-w-lg flex-col items-center gap-ds-06 rounded-overlay-lg border border-surface-border-strong bg-surface-raised p-ds-07 text-center shadow-raised"
+        className="flex w-full max-w-lg flex-col items-center gap-ds-06 rounded-overlay-lg bg-surface-raised p-ds-07 text-center shadow-raised"
       >
         {/* Error Icon */}
         <div

--- a/packages/core/src/composed/extensions/emoji-suggestion.tsx
+++ b/packages/core/src/composed/extensions/emoji-suggestion.tsx
@@ -67,7 +67,7 @@ const EmojiList = React.forwardRef<EmojiListRef, EmojiListProps>(
     if (!items.length) return null
 
     return (
-      <div role="listbox" aria-label="Emoji suggestions" className="z-popover max-h-[200px] overflow-x-hidden overflow-y-auto rounded-control border border-surface-border-strong bg-surface-overlay shadow-raised-hover">
+      <div role="listbox" aria-label="Emoji suggestions" className="z-popover max-h-[200px] overflow-x-hidden overflow-y-auto rounded-control bg-surface-overlay shadow-raised-hover">
         {items.map((item, index) => (
           <button
             key={item.id}

--- a/packages/core/src/composed/extensions/mention-suggestion.tsx
+++ b/packages/core/src/composed/extensions/mention-suggestion.tsx
@@ -41,7 +41,7 @@ const MentionList = React.forwardRef<MentionListRef, MentionListProps>(
     if (!items.length) return null
 
     return (
-      <div role="listbox" aria-label="Mention suggestions" className="z-popover overflow-hidden rounded-control border border-surface-border-strong bg-surface-overlay shadow-raised-hover">
+      <div role="listbox" aria-label="Mention suggestions" className="z-popover overflow-hidden rounded-control bg-surface-overlay shadow-raised-hover">
         {items.map((item, index) => (
           <button
             key={item.id}

--- a/packages/core/src/composed/extensions/slash-command.tsx
+++ b/packages/core/src/composed/extensions/slash-command.tsx
@@ -100,7 +100,7 @@ const SlashCommandList = React.forwardRef<SlashCommandListRef, SlashCommandListP
       <div
         role="listbox"
         aria-label="Slash commands"
-        className="z-popover max-h-[320px] min-w-[220px] overflow-x-hidden overflow-y-auto rounded-surface border border-surface-border-strong bg-surface-overlay p-ds-02 shadow-floating"
+        className="z-popover max-h-[320px] min-w-[220px] overflow-x-hidden overflow-y-auto rounded-surface bg-surface-overlay p-ds-02 shadow-floating"
       >
         {renderedGroups.map((group, gi) => (
           <div key={group.label} role="group" aria-label={group.label}>

--- a/packages/core/src/composed/file-preview/audio-preview.tsx
+++ b/packages/core/src/composed/file-preview/audio-preview.tsx
@@ -92,7 +92,7 @@ export default function AudioPreview({ url, fileName, onError }: { url: string; 
   if (error) return <ErrorFallback message="Could not load audio" url={url} />
 
   return (
-    <div ref={containerRef} className="rounded-surface border border-surface-border bg-surface-raised shadow-raised overflow-hidden" tabIndex={-1}>
+    <div ref={containerRef} className="rounded-surface bg-surface-raised shadow-raised overflow-hidden" tabIndex={-1}>
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio
         ref={audioRef}

--- a/packages/core/src/composed/file-preview/shared.tsx
+++ b/packages/core/src/composed/file-preview/shared.tsx
@@ -44,7 +44,7 @@ export function Toolbar({ children, className }: { children: React.ReactNode; cl
       animate={{ opacity: 1, y: 0 }}
       transition={tweens.fade}
       className={cn(
-        'flex items-center gap-ds-01 rounded-control border border-surface-border bg-surface-overlay/95 px-ds-02 py-ds-01 shadow-floating backdrop-blur-xs',
+        'flex items-center gap-ds-01 rounded-control bg-surface-overlay/95 px-ds-02 py-ds-01 shadow-floating backdrop-blur-xs',
         className,
       )}
     >

--- a/packages/core/src/composed/rich-chat-input.tsx
+++ b/packages/core/src/composed/rich-chat-input.tsx
@@ -192,7 +192,7 @@ function SplitSendDropdown({ options }: { options: Array<{ label: string; icon?:
       </button>
       {/* min-w-[200px]: component-specific dropdown width — no design token equivalent */}
       {open && (
-        <div className="absolute bottom-full right-0 mb-ds-02 min-w-[200px] rounded-surface border border-surface-border-strong bg-surface-overlay p-ds-02 shadow-floating z-popover">
+        <div className="absolute bottom-full right-0 mb-ds-02 min-w-[200px] rounded-surface bg-surface-overlay p-ds-02 shadow-floating z-popover">
           <p className="px-ds-03 py-ds-01 text-ds-xs font-medium text-surface-fg-subtle">Send options</p>
           {options.map((opt, i) => (
             <button
@@ -242,13 +242,13 @@ function EmojiPickerPopover({ set = 'native', onSelect, onClose }: { set?: strin
   }, [onClose])
 
   const fallback = (
-    <div className="flex h-[350px] w-[352px] items-center justify-center rounded-surface border border-surface-border-strong bg-surface-overlay shadow-floating">
+    <div className="flex h-[350px] w-[352px] items-center justify-center rounded-surface bg-surface-overlay shadow-floating">
       <span className="text-ds-sm text-surface-fg-subtle">Loading...</span>
     </div>
   )
 
   return (
-    <div ref={ref} className="rounded-surface border border-surface-border-strong bg-surface-overlay shadow-floating overflow-hidden">
+    <div ref={ref} className="rounded-surface bg-surface-overlay shadow-floating overflow-hidden">
       {!data ? fallback : (
         <React.Suspense fallback={fallback}>
           <LazyEmojiPicker
@@ -315,7 +315,7 @@ function ChatBubbleMenu({ editor }: { editor: Editor }) {
   return (
     <BubbleMenu
       editor={editor}
-      className="flex gap-ds-01 rounded-surface border border-surface-border-strong bg-surface-overlay p-ds-02 shadow-floating"
+      className="flex gap-ds-01 rounded-surface bg-surface-overlay p-ds-02 shadow-floating"
     >
       <BubbleBtn onClick={() => editor.chain().focus().toggleBold().run()} isActive={state.isBold} title="Bold">
         <Icon icon={IconBold} size="xs" />

--- a/packages/core/src/composed/rich-text-editor.tsx
+++ b/packages/core/src/composed/rich-text-editor.tsx
@@ -147,7 +147,7 @@ function LinkButton({ editor }: { editor: Editor }) {
         <form
           onSubmit={handleSubmit}
           aria-label="Edit link URL"
-          className="absolute left-0 top-full z-popover mt-ds-01 flex items-center gap-ds-02 rounded-control border border-surface-border-strong bg-surface-overlay p-ds-02 shadow-raised-hover"
+          className="absolute left-0 top-full z-popover mt-ds-01 flex items-center gap-ds-02 rounded-control bg-surface-overlay p-ds-02 shadow-raised-hover"
         >
           <input
             ref={inputRef}
@@ -361,7 +361,7 @@ function EmojiPickerLazy({ set = 'native', onSelect }: { set?: string; onSelect:
     loadEmojiData(set).then((d) => setData(d))
   }, [set])
 
-  const fallback = <div className="flex h-[350px] w-[352px] items-center justify-center rounded-surface border border-surface-border-strong bg-surface-overlay shadow-raised-hover"><span className="text-ds-sm text-surface-fg-subtle">Loading...</span></div>
+  const fallback = <div className="flex h-[350px] w-[352px] items-center justify-center rounded-surface bg-surface-overlay shadow-raised-hover"><span className="text-ds-sm text-surface-fg-subtle">Loading...</span></div>
 
   if (!data) return fallback
 

--- a/packages/core/src/shell/notification-center.tsx
+++ b/packages/core/src/shell/notification-center.tsx
@@ -504,7 +504,7 @@ const NotificationCenter = React.forwardRef<HTMLButtonElement, NotificationCente
 
       <PopoverContent
         className={cn(
-          'w-[380px] rounded-overlay-lg border border-surface-border-strong bg-surface-overlay p-0 shadow-floating',
+          'w-[380px] rounded-overlay-lg bg-surface-overlay p-0 shadow-floating',
           popoverClassName,
         )}
         sideOffset={8}

--- a/packages/core/src/shell/sidebar.tsx
+++ b/packages/core/src/shell/sidebar.tsx
@@ -130,6 +130,12 @@ export interface AppSidebarProps
   renderItem?: (item: NavItem, defaultRender: () => React.ReactNode) => React.ReactNode | null
   /** Additional className for the root sidebar element */
   className?: string
+  /**
+   * Corner radius of nav items (composable). @default 'md' (control radius, ~6px).
+   * `'lg'` restores the previous rounder look; `'sm'` is tighter; `'pill'` is fully rounded.
+   * Sets the `--ds-sidebar-item-radius` CSS var, so you can also override it via `className`/`style`.
+   */
+  navItemRadius?: 'sm' | 'md' | 'lg' | 'pill'
 }
 
 // -----------------------------------------------------------------------
@@ -179,9 +185,19 @@ function CloseIcon({ className }: { className?: string }) {
 // Shared styles
 // -----------------------------------------------------------------------
 
-const navItemBase = 'relative gap-ds-04 rounded-surface px-ds-04 py-ds-03 transition-colors duration-fast-02'
-const navItemActive =
-  "bg-accent-2 text-accent-11 after:absolute after:right-0 after:top-0 after:h-full after:w-ds-01 after:rounded-l-pill after:bg-accent-9 after:content-['']"
+// Radius is composable via the `navItemRadius` prop (sets --ds-sidebar-item-radius).
+// Default is the control radius (~6px) — surface (10px) read as over-rounded blobs.
+const navItemBase =
+  'relative gap-ds-04 rounded-[var(--ds-sidebar-item-radius,var(--radius-control))] px-ds-04 py-ds-03 transition-colors duration-fast-02'
+const NAV_ITEM_RADIUS = {
+  sm: 'var(--radius-control-inner)',
+  md: 'var(--radius-control)',
+  lg: 'var(--radius-surface)',
+  pill: 'var(--radius-pill)',
+} as const
+// Active = tinted surface + accent text + weight. No accent rail — the tint and
+// colour already signal "you are here"; a stripe on top is doubled accent (AI tell).
+const navItemActive = 'bg-accent-2 text-accent-11 font-medium'
 const navItemInactive = 'text-surface-fg-subtle hover:bg-surface-raised-hover hover:text-surface-fg'
 
 // -----------------------------------------------------------------------
@@ -323,6 +339,8 @@ const AppSidebar = React.forwardRef<HTMLDivElement, AppSidebarProps>(
       footer,
       renderItem,
       className,
+      navItemRadius,
+      style,
       ...props
     },
     ref,
@@ -340,6 +358,11 @@ const AppSidebar = React.forwardRef<HTMLDivElement, AppSidebarProps>(
         {...props}
         ref={ref}
         aria-label="Main navigation"
+        style={
+          navItemRadius
+            ? ({ '--ds-sidebar-item-radius': NAV_ITEM_RADIUS[navItemRadius], ...style } as React.CSSProperties)
+            : style
+        }
         className={cn(
           'z-raised hidden h-full flex-col border-r border-surface-border-strong bg-surface-raised md:flex',
           className,
@@ -442,7 +465,7 @@ const AppSidebar = React.forwardRef<HTMLDivElement, AppSidebarProps>(
 
             {/* Promo banner */}
             {footer.promo && (
-              <div className="relative rounded-surface border border-surface-border bg-surface-raised p-ds-04 shadow-raised">
+              <div className="relative rounded-surface bg-surface-raised p-ds-04 shadow-raised">
                 {footer.promo.onDismiss && (
                   <button
                     onClick={footer.promo.onDismiss}

--- a/packages/core/src/shell/top-bar.tsx
+++ b/packages/core/src/shell/top-bar.tsx
@@ -289,7 +289,7 @@ const TopBarUserMenu = React.forwardRef<HTMLButtonElement, TopBarUserMenuProps>(
         </Tooltip>
 
         <DropdownMenuContent
-          className="w-[200px] rounded-overlay-lg border border-surface-border-strong bg-surface-overlay p-0 shadow-floating"
+          className="w-[200px] rounded-overlay-lg bg-surface-overlay p-0 shadow-floating"
           sideOffset={8}
           align="end"
         >

--- a/packages/core/src/tokens/semantic.css
+++ b/packages/core/src/tokens/semantic.css
@@ -493,14 +493,18 @@
     0 2px 4px -1.5px oklch(var(--shadow-color) / calc(0.045 * var(--shadow-strength))),
     0 6px 12px -3px oklch(var(--shadow-color) / calc(0.035 * var(--shadow-strength))),
     0 14px 28px -8px oklch(var(--shadow-color) / calc(0.025 * var(--shadow-strength)));
+  /* Hairline edge ring — the shadow's own 1px border-substitute (make-kit rule #6:
+     shadow already carries the ring, so components never add an explicit border).
+     Light: cool tint. Dark: a light ring, since drop shadows barely read on dark. */
+  --shadow-edge-ring: 0 0 0 1px oklch(var(--shadow-color) / calc(0.09 * var(--shadow-strength)));
   --shadow-md-internal:
-    0 0 0 1px oklch(var(--shadow-color) / calc(0.04 * var(--shadow-strength))),
+    var(--shadow-edge-ring),
     0 1px 2px -1px oklch(var(--shadow-color) / calc(0.05 * var(--shadow-strength))),
     0 4px 8px -2px oklch(var(--shadow-color) / calc(0.04 * var(--shadow-strength))),
     0 10px 20px -5px oklch(var(--shadow-color) / calc(0.035 * var(--shadow-strength))),
     0 24px 44px -12px oklch(var(--shadow-color) / calc(0.025 * var(--shadow-strength)));
   --shadow-lg-internal:
-    0 0 0 1px oklch(var(--shadow-color) / calc(0.04 * var(--shadow-strength))),
+    var(--shadow-edge-ring),
     0 1px 2px -1px oklch(var(--shadow-color) / calc(0.05 * var(--shadow-strength))),
     0 3px 6px -2px oklch(var(--shadow-color) / calc(0.045 * var(--shadow-strength))),
     0 8px 16px -4px oklch(var(--shadow-color) / calc(0.04 * var(--shadow-strength))),
@@ -603,6 +607,8 @@
   /* Shadows (heavier in dark mode) — brand-reactive via color-mix on
      --color-accent-9 so they follow consumer brand swaps. */
   --shadow-strength: 2.5;
+  /* Light ring on dark — a dark-tinted ring would vanish against dark surfaces. */
+  --shadow-edge-ring: 0 0 0 1px oklch(1 0 0 / 0.12);
   --shadow-brand:    0 2px 8px color-mix(in oklch, var(--color-accent-9) 30%, transparent), 0 6px 20px color-mix(in oklch, var(--color-accent-9) 20%, transparent);
   --shadow-glow:     0 0 0 1.5px color-mix(in oklch, var(--color-accent-9) 35%, transparent), 0 0 10px color-mix(in oklch, var(--color-accent-9) 20%, transparent);
   --shadow-ring:     0 0 0 2px color-mix(in oklch, var(--color-accent-9) 45%, transparent);

--- a/packages/core/src/ui/alert-dialog.tsx
+++ b/packages/core/src/ui/alert-dialog.tsx
@@ -104,8 +104,8 @@ const AlertDialogContent = React.forwardRef<
               className={cn(
                 'fixed z-modal grid w-full gap-ds-05 bg-surface-overlay p-ds-06',
                 responsive !== false
-                  ? 'inset-0 md:inset-auto md:left-[50%] md:top-[50%] md:max-w-lg md:rounded-overlay-lg md:border md:border-surface-border-strong md:shadow-overlay'
-                  : 'left-[50%] top-[50%] max-w-lg rounded-overlay-lg border border-surface-border-strong shadow-overlay',
+                  ? 'inset-0 md:inset-auto md:left-[50%] md:top-[50%] md:max-w-lg md:rounded-overlay-lg md:shadow-overlay'
+                  : 'left-[50%] top-[50%] max-w-lg rounded-overlay-lg shadow-overlay',
                 className,
               )}
             >

--- a/packages/core/src/ui/autocomplete.tsx
+++ b/packages/core/src/ui/autocomplete.tsx
@@ -257,7 +257,7 @@ const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
                   variants={listVariants}
                   style={floatingStyles}
                   className={cn(
-                    'z-popover overflow-auto rounded-overlay border border-surface-border-strong bg-surface-overlay shadow-raised-hover',
+                    'z-popover overflow-auto rounded-overlay bg-surface-overlay shadow-raised-hover',
                   )}
                 >
                   {filtered.length === 0 ? (

--- a/packages/core/src/ui/card.tsx
+++ b/packages/core/src/ui/card.tsx
@@ -16,8 +16,12 @@ const cardVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-surface-raised border border-surface-border shadow-raised',
-        elevated: 'bg-surface-raised border border-surface-border shadow-raised-hover',
+        // Elevation-led: the shadow's own ring is the edge (make-kit rule #6 — no
+        // border+shadow double-edge). border-transparent keeps the `color` prop able to
+        // paint a deliberate colored edge without a grey one by default.
+        default: 'bg-surface-raised border border-transparent shadow-raised',
+        elevated: 'bg-surface-raised border border-transparent shadow-raised-hover',
+        // Border-led: a visible edge, no shadow.
         outline: 'bg-transparent border border-surface-border-strong shadow-none',
         flat: 'bg-surface-raised border-none shadow-none',
       },
@@ -44,8 +48,10 @@ const cardVariants = cva(
  * Props for Card — a general-purpose content container with 4 elevation/style variants and
  * an optional interactive hover state.
  *
- * **Variants:** `default` (subtle border + shadow-raised) | `elevated` (stronger shadow-raised-hover) |
- * `outline` (2px solid border, no shadow) | `flat` (filled background, no shadow)
+ * **Variants (elevation-led vs border-led — never both):** `default` (ring-in-shadow, no border) |
+ * `elevated` (stronger shadow-raised-hover, no border) | `outline` (visible border, no shadow) |
+ * `flat` (filled background, no edge). The shadow tokens carry their own 1px ring, so elevated
+ * variants need no explicit border (make-kit rule #6).
  *
  * **Composition:** Use sub-components `<CardHeader>`, `<CardTitle>`, `<CardDescription>`,
  * `<CardContent>`, and `<CardFooter>` for consistent internal spacing.
@@ -139,7 +145,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
     const classes = cn(
       cardVariants({ variant, color, size }),
       accent && 'relative overflow-hidden',
-      interactive && 'hover:shadow-raised-hover hover:border-surface-border-strong cursor-pointer transition-shadow duration-fast-02 ease-productive-standard',
+      interactive && 'hover:shadow-raised-hover cursor-pointer transition-shadow duration-fast-02 ease-productive-standard',
       className,
     )
 

--- a/packages/core/src/ui/chat/message.tsx
+++ b/packages/core/src/ui/chat/message.tsx
@@ -427,7 +427,7 @@ function MessageActions({ children, delay = 100 }: MessageActionsProps) {
     <div
       className={cn(
         'absolute -top-2 right-0 z-10',
-        'flex items-center gap-ds-01 rounded-control border border-surface-border bg-surface-raised px-ds-01 py-ds-01 shadow-raised',
+        'flex items-center gap-ds-01 rounded-control bg-surface-raised px-ds-01 py-ds-01 shadow-raised',
         'opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 transition-opacity duration-150',
       )}
       style={{ transitionDelay: `${delay}ms` }}

--- a/packages/core/src/ui/color-input.tsx
+++ b/packages/core/src/ui/color-input.tsx
@@ -353,7 +353,7 @@ const ColorInput = React.forwardRef<HTMLDivElement, ColorInputProps>(
             aria-label="Color picker"
             align={align}
             sideOffset={8}
-            className="w-[272px] rounded-overlay-lg border border-surface-border-strong bg-surface-overlay p-0 shadow-floating"
+            className="w-[272px] rounded-overlay-lg bg-surface-overlay p-0 shadow-floating"
           >
             <div className="flex flex-col">
               {/* Interactive picker */}

--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -449,7 +449,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
               animate={{ opacity: 1, scale: 1 }}
               transition={{ ...springs.snappy, opacity: tweens.fade }}
               className={cn(
-                'z-popover w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-overlay border border-surface-border bg-surface-overlay shadow-floating',
+                'z-popover w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-overlay bg-surface-overlay shadow-floating',
               )}
             >
                   {/* Search input */}

--- a/packages/core/src/ui/context-menu.tsx
+++ b/packages/core/src/ui/context-menu.tsx
@@ -112,7 +112,7 @@ const ContextMenuSubContent = React.forwardRef<
             exit={{ opacity: 0, scale: 0.95 }}
             transition={{ ...springs.snappy, opacity: tweens.fade }}
             className={cn(
-              "z-popover min-w-[8rem] overflow-hidden rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating",
+              "z-popover min-w-[8rem] overflow-hidden rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating",
               className
             )}
           >
@@ -147,7 +147,7 @@ const ContextMenuContent = React.forwardRef<
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ ...springs.snappy, opacity: tweens.fade }}
               className={cn(
-                "z-popover rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating",
+                "z-popover rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating",
                 className
               )}
             >

--- a/packages/core/src/ui/data-table-bulk-actions.tsx
+++ b/packages/core/src/ui/data-table-bulk-actions.tsx
@@ -34,7 +34,7 @@ export function DataTableBulkActions<TData>({
       className={cn(
         'fixed bottom-6 left-1/2 -translate-x-1/2 z-sticky',
         'flex items-center gap-ds-04 px-ds-05 py-ds-03',
-        'rounded-overlay border border-surface-border-strong bg-surface-overlay shadow-floating',
+        'rounded-overlay bg-surface-overlay shadow-floating',
         'animate-in slide-in-from-bottom-2',
       )}
       role="toolbar"

--- a/packages/core/src/ui/dialog.tsx
+++ b/packages/core/src/ui/dialog.tsx
@@ -156,8 +156,8 @@ const DialogContent = React.forwardRef<
               className={cn(
                 'fixed z-modal grid w-full gap-ds-05 bg-surface-overlay p-ds-06',
                 responsive !== false
-                  ? 'inset-0 md:inset-auto md:left-[50%] md:top-[50%] md:max-w-lg md:rounded-overlay-lg md:border md:border-surface-border-strong md:shadow-overlay'
-                  : 'left-[50%] top-[50%] max-w-lg rounded-overlay-lg border border-surface-border-strong shadow-overlay',
+                  ? 'inset-0 md:inset-auto md:left-[50%] md:top-[50%] md:max-w-lg md:rounded-overlay-lg md:shadow-overlay'
+                  : 'left-[50%] top-[50%] max-w-lg rounded-overlay-lg shadow-overlay',
                 className,
               )}
             >

--- a/packages/core/src/ui/dropdown-menu.tsx
+++ b/packages/core/src/ui/dropdown-menu.tsx
@@ -177,7 +177,7 @@ const DropdownMenuSubContent = React.forwardRef<
             exit={{ opacity: 0, scale: 0.95 }}
             transition={{ ...springs.snappy, opacity: tweens.fade }}
             className={cn(
-              'z-popover min-w-[8rem] overflow-hidden rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
+              'z-popover min-w-[8rem] overflow-hidden rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
               className,
             )}
           >
@@ -214,7 +214,7 @@ const DropdownMenuContent = React.forwardRef<
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ ...springs.snappy, opacity: tweens.fade }}
               className={cn(
-                'z-popover min-w-[8rem] rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
+                'z-popover min-w-[8rem] rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
                 className,
               )}
             >

--- a/packages/core/src/ui/hover-card.tsx
+++ b/packages/core/src/ui/hover-card.tsx
@@ -70,7 +70,7 @@ const HoverCardContent = React.forwardRef<
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ ...springs.snappy, opacity: tweens.fade }}
               className={cn(
-                'z-popover w-64 rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-05 shadow-floating outline-hidden',
+                'z-popover w-64 rounded-overlay bg-surface-overlay p-ds-05 shadow-floating outline-hidden',
                 className,
               )}
             >

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -168,6 +168,14 @@ export {
   skeletonVariants,
 } from './skeleton'
 export { StatCard, type StatCardProps } from './stat-card'
+export {
+  type FlashPreset,
+  type FlashSpec,
+  type FlashSpeed,
+  type FlashTone,
+  StatFlash,
+  type StatFlashProps,
+} from './stat-flash'
 export { StatusDot, type StatusDotProps, type StatusDotStatus } from './status-dot'
 export { Table, TableBody, TableCaption, TableCell, type TableCellProps,TableFooter, TableHead, TableHeader, type TableProps, TableRow, type TableRowProps } from './table'
 

--- a/packages/core/src/ui/input-otp.tsx
+++ b/packages/core/src/ui/input-otp.tsx
@@ -74,7 +74,7 @@ const InputOTPSlot = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        'relative flex items-center justify-center border-y border-r border-surface-border-strong shadow-raised transition-[box-shadow,border-color] first:rounded-l-control first:border-l last:rounded-r-control',
+        'relative flex items-center justify-center border-y border-r border-surface-border-strong transition-[box-shadow,border-color] first:rounded-l-control first:border-l last:rounded-r-control',
         slotSizeClasses[size],
         'group-[.is-error]/otp:border-error-7',
         isActive && 'z-raised ring-2 ring-accent-9',

--- a/packages/core/src/ui/menubar.tsx
+++ b/packages/core/src/ui/menubar.tsx
@@ -70,7 +70,7 @@ const Menubar = React.forwardRef<
   <MenubarPrimitive.Root
     ref={ref}
     className={cn(
-      'flex h-ds-sm-plus items-center space-x-ds-02 rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 shadow-raised',
+      'flex h-ds-sm-plus items-center space-x-ds-02 rounded-overlay bg-surface-overlay p-ds-02 shadow-raised',
       className,
     )}
     {...props}
@@ -135,7 +135,7 @@ const MenubarSubContent = React.forwardRef<
             exit={{ opacity: 0, scale: 0.95 }}
             transition={{ ...springs.snappy, opacity: tweens.fade }}
             className={cn(
-              'z-popover min-w-[8rem] overflow-hidden rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
+              'z-popover min-w-[8rem] overflow-hidden rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
               className,
             )}
           >
@@ -177,7 +177,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'z-popover min-w-[12rem] rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
+          'z-popover min-w-[12rem] rounded-overlay bg-surface-overlay p-ds-02 text-surface-fg shadow-floating',
           'data-[state=open]:animate-popover-in data-[state=closed]:animate-popover-out',
           className,
         )}

--- a/packages/core/src/ui/navigation-menu.tsx
+++ b/packages/core/src/ui/navigation-menu.tsx
@@ -186,7 +186,7 @@ const NavigationMenuViewport = React.forwardRef<
     <div className={cn('absolute left-0 top-full flex justify-center')}>
       <NavigationMenuPrimitive.Viewport
         className={cn(
-          'origin-top-center relative mt-ds-02b h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-overlay border border-surface-border-strong bg-surface-overlay shadow-floating md:w-[var(--radix-navigation-menu-viewport-width)]',
+          'origin-top-center relative mt-ds-02b h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-overlay bg-surface-overlay shadow-floating md:w-[var(--radix-navigation-menu-viewport-width)]',
           className,
         )}
         ref={composedRef}

--- a/packages/core/src/ui/popover.tsx
+++ b/packages/core/src/ui/popover.tsx
@@ -86,7 +86,7 @@ const PopoverContent = React.forwardRef<
               exit={{ opacity: 0, scale: 0.95 }}
               transition={{ ...springs.snappy, opacity: tweens.fade }}
               className={cn(
-                'z-popover w-72 rounded-overlay border border-surface-border-strong bg-surface-overlay p-ds-05 text-surface-fg shadow-floating outline-hidden',
+                'z-popover w-72 rounded-overlay bg-surface-overlay p-ds-05 text-surface-fg shadow-floating outline-hidden',
                 className,
               )}
             >

--- a/packages/core/src/ui/select.tsx
+++ b/packages/core/src/ui/select.tsx
@@ -159,7 +159,7 @@ const SelectContent = React.forwardRef<
         animate={{ opacity: 1, scale: 1 }}
         transition={{ ...springs.snappy, opacity: tweens.fade }}
         className={cn(
-          'relative z-popover max-h-96 min-w-[8rem] overflow-hidden rounded-overlay border border-surface-border-strong bg-surface-overlay text-surface-fg shadow-floating',
+          'relative z-popover max-h-96 min-w-[8rem] overflow-hidden rounded-overlay bg-surface-overlay text-surface-fg shadow-floating',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,

--- a/packages/core/src/ui/sidebar.tsx
+++ b/packages/core/src/ui/sidebar.tsx
@@ -316,7 +316,7 @@ const Sidebar = forwardRef<
           <aside
             aria-label="Sidebar"
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-surface-raised group-data-[variant=floating]:rounded-surface group-data-[variant=floating]:border group-data-[variant=floating]:border-surface-border group-data-[variant=floating]:shadow-raised"
+            className="flex h-full w-full flex-col bg-surface-raised group-data-[variant=floating]:rounded-surface group-data-[variant=floating]:shadow-raised"
           >
             {children}
           </aside>

--- a/packages/core/src/ui/split-button.tsx
+++ b/packages/core/src/ui/split-button.tsx
@@ -344,7 +344,7 @@ const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ duration: durations.moderate01 }}
-                className="rounded-overlay border border-surface-border-strong bg-surface-overlay shadow-floating"
+                className="rounded-overlay bg-surface-overlay shadow-floating"
               >
                 {dropdownContent}
               </motion.div>

--- a/packages/core/src/ui/stat-card.stories.tsx
+++ b/packages/core/src/ui/stat-card.stories.tsx
@@ -9,9 +9,17 @@ const meta: Meta<typeof StatCard> = {
     label: { control: 'text' },
     value: { control: 'text' },
     loading: { control: 'boolean' },
-    accent: {
+    accentStyle: {
       control: 'select',
-      options: ['default', 'success', 'warning', 'error', 'info'],
+      options: ['none', 'icon', 'tint'],
+    },
+    surface: {
+      control: 'inline-radio',
+      options: ['raised', 'flat'],
+    },
+    iconFill: {
+      control: 'inline-radio',
+      options: ['soft', 'solid'],
     },
     progress: { control: { type: 'range', min: 0, max: 100 } },
   },
@@ -122,12 +130,46 @@ export const WithProgress: Story = {
   decorators: [(Story) => <div className="w-[320px]"><Story /></div>],
 }
 
-export const WithAccent: Story = {
+export const AccentTint: Story = {
   args: {
-    label: 'Error Rate',
-    value: '2.4%',
-    delta: { value: '+0.8%', direction: 'up' },
-    accent: 'error',
+    label: 'Monthly Revenue',
+    value: '$48,200',
+    delta: { value: '+12%', direction: 'up' },
+    accentStyle: 'tint',
+  },
+  decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
+}
+
+export const AccentIcon: Story = {
+  args: {
+    label: 'Active Projects',
+    value: 128,
+    delta: { value: '+12%', direction: 'up' },
+    icon: <span>P</span>,
+    accentStyle: 'icon',
+    iconFill: 'soft',
+  },
+  decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
+}
+
+export const AccentIconSolid: Story = {
+  args: {
+    label: 'Active Projects',
+    value: 128,
+    delta: { value: '+12%', direction: 'up' },
+    icon: <span>P</span>,
+    accentStyle: 'icon',
+    iconFill: 'solid',
+  },
+  decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
+}
+
+export const SurfaceFlat: Story = {
+  args: {
+    label: 'Active Projects',
+    value: 128,
+    delta: { value: '+12%', direction: 'up' },
+    surface: 'flat',
   },
   decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
 }
@@ -160,7 +202,7 @@ export const FullFeatured: Story = {
     comparisonLabel: 'vs last month',
     secondaryLabel: 'of $50,000 target',
     progress: 96,
-    accent: 'success',
+    accentStyle: 'tint',
     sparkline: [22, 28, 25, 31, 27, 35, 33, 40, 38, 42, 45, 48],
     onClick: () => alert('View revenue details'),
   },
@@ -176,7 +218,6 @@ export const DashboardGrid: Story = {
         prefix="$"
         delta={{ value: '+12%', direction: 'up' }}
         comparisonLabel="vs last month"
-        accent="success"
         sparkline={[22, 28, 25, 31, 27, 35, 33, 40, 38, 42, 45, 48]}
         onClick={() => {}}
       />
@@ -185,7 +226,6 @@ export const DashboardGrid: Story = {
         value="1,842"
         delta={{ value: '+8%', direction: 'up' }}
         comparisonLabel="vs last week"
-        accent="info"
         sparkline={[150, 162, 158, 170, 165, 175, 180, 184]}
       />
       <StatCard
@@ -193,7 +233,6 @@ export const DashboardGrid: Story = {
         value="3.2%"
         delta={{ value: '-0.4%', direction: 'down' }}
         comparisonLabel="vs last month"
-        accent="warning"
         secondaryLabel="target: 4.0%"
         progress={72}
       />
@@ -201,7 +240,6 @@ export const DashboardGrid: Story = {
         label="Error Rate"
         value="0.12%"
         delta={{ value: '+0.02%', direction: 'up' }}
-        accent="error"
         sparkline={[0.08, 0.09, 0.1, 0.11, 0.09, 0.1, 0.12]}
       />
     </div>
@@ -223,14 +261,12 @@ export const ProgressEdgeCases: Story = {
         label="Complete"
         value="100%"
         progress={100}
-        accent="success"
         secondaryLabel="target reached"
       />
       <StatCard
         label="Overflow (clamped)"
         value="142%"
         progress={142}
-        accent="warning"
         secondaryLabel="over target — clamped to 100"
       />
     </div>
@@ -291,12 +327,12 @@ export const ClickableWithHref: Story = {
   decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
 }
 
-export const LoadingWithAccent: Story = {
+export const LoadingFlat: Story = {
   args: {
     label: 'Revenue',
     value: 0,
     loading: true,
-    accent: 'success',
+    surface: 'flat',
   },
   decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
 }

--- a/packages/core/src/ui/stat-card.test.tsx
+++ b/packages/core/src/ui/stat-card.test.tsx
@@ -150,4 +150,34 @@ describe('StatCard', () => {
     expect(screen.getByText('View details')).toBeInTheDocument()
   })
 
+  // ── Accent style + surface + flash (anti-convergence rework) ────────────────
+  it('renders accentStyle="icon" with the provided icon', () => {
+    const { container } = render(
+      <StatCard
+        label="Projects"
+        value={128}
+        icon={<svg data-testid="ic" />}
+        accentStyle="icon"
+      />,
+    )
+    expect(container.querySelector('[data-testid="ic"]')).toBeInTheDocument()
+  })
+
+  it('renders accentStyle="tint" value', () => {
+    render(<StatCard label="Revenue" value="$48,200" accentStyle="tint" />)
+    expect(screen.getByText('$48,200')).toBeInTheDocument()
+  })
+
+  it('renders surface="flat" without crashing', () => {
+    render(<StatCard label="Projects" value={128} surface="flat" />)
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+  })
+
+  it('renders an entrance flash when flash is set', () => {
+    const { container } = render(
+      <StatCard label="Projects" value={128} icon={<svg data-testid="ic" />} flash="up" />,
+    )
+    expect(container.querySelector('[data-testid="ic"]')).toBeInTheDocument()
+  })
+
 })

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -11,10 +11,18 @@ import { useLink } from './lib/link-context'
 import { springs, tweens } from './lib/motion'
 import { normalizeIcon } from './lib/normalize-icon'
 import { cn } from './lib/utils'
+import { StatFlash, type FlashPreset, type FlashSpec, type FlashSpeed } from './stat-flash'
 
 /**
  * Props for StatCard — a dashboard metric tile displaying a label, a large numeric value,
  * an optional trend delta (with directional arrow icon), and an optional header icon.
+ *
+ * **Surface:** `surface="raised"` (default) is elevation-led — the shadow's own 1px ring is the
+ * edge, no border (make-kit rule #6). `surface="flat"` is border-led, no shadow.
+ *
+ * **Accent:** `accentStyle="none"` (default) is neutral; `"icon"` wraps `icon` in an accent chip
+ * (`iconFill="soft" | "solid"`); `"tint"` applies a subtle accent surface wash + accent value.
+ * (Replaces the removed `accent` left-rail prop — see CHANGELOG migration.)
  *
  * **Delta direction:** `'up'` renders a green trending-up arrow, `'down'` renders a red
  * trending-down arrow, `'neutral'` renders a grey dash. The `delta.value` is a formatted
@@ -74,8 +82,20 @@ export interface StatCardProps extends React.HTMLAttributes<HTMLDivElement> {
   secondaryLabel?: string
   /** Progress toward a target (0-100). Renders a thin progress bar below the value. */
   progress?: number
-  /** Color accent for the left border decoration */
-  accent?: 'default' | 'success' | 'warning' | 'error' | 'info'
+  /** Surface treatment: `raised` (ring-in-shadow, no border — default) or `flat` (border, no shadow). */
+  surface?: 'raised' | 'flat'
+  /** How the brand accent reads: `none` (neutral — default), `icon` (accent chip around `icon`), or `tint` (subtle accent surface wash + accent value). */
+  accentStyle?: 'none' | 'icon' | 'tint'
+  /** When `accentStyle="icon"`: `soft` (tinted chip) or `solid` (filled accent chip). @default 'soft' */
+  iconFill?: 'soft' | 'solid'
+  /**
+   * Opt-in entrance flash: the icon chip mounts showing a transient state (e.g. a green up-arrow)
+   * then settles to `icon`. A preset (`'up' | 'down' | 'goal' | 'record' | 'alert' | 'live'`) or an
+   * explicit `{ tone, icon }`. Requires `icon`; implies the icon chip. Off by default.
+   */
+  flash?: FlashPreset | FlashSpec
+  /** Speed of the entrance flash: `fast` | `normal` | `slow`. @default 'normal' */
+  flashSpeed?: FlashSpeed
   /** Sparkline data points. Renders a mini SVG line chart in the card. */
   sparkline?: number[]
   /** Make the card clickable with hover state */
@@ -84,14 +104,6 @@ export interface StatCardProps extends React.HTMLAttributes<HTMLDivElement> {
   href?: string
   /** Footer content rendered below the card body, e.g. "View details →" */
   footer?: React.ReactNode
-}
-
-const accentBorderMap: Record<NonNullable<StatCardProps['accent']>, string> = {
-  default: 'border-l-accent-9',
-  success: 'border-l-success-9',
-  warning: 'border-l-warning-9',
-  error: 'border-l-error-9',
-  info: 'border-l-info-9',
 }
 
 function buildSparklinePath(raw: number[], width: number, height: number): string {
@@ -202,7 +214,11 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       comparisonLabel,
       secondaryLabel,
       progress,
-      accent,
+      surface = 'raised',
+      accentStyle = 'none',
+      iconFill = 'soft',
+      flash,
+      flashSpeed,
       sparkline,
       onClick,
       href,
@@ -222,8 +238,8 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
         <div
           ref={ref}
           className={cn(
-            'rounded-surface border border-surface-border bg-surface-raised shadow-raised p-ds-05b',
-            accent && `border-l-[3px] ${accentBorderMap[accent]}`,
+            'rounded-surface bg-surface-raised p-ds-05b',
+            surface === 'flat' ? 'border border-surface-border' : 'shadow-raised',
             className,
           )}
           {...props}
@@ -271,22 +287,44 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
             {sparkline && sparkline.length >= 2 && (
               <Sparkline data={sparkline} colorClass={sparklineColor} />
             )}
-            {icon && (
-              <motion.span
-                className="text-surface-fg-muted"
-                initial={{ opacity: 0, scale: 0.96 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={springs.snappy}
-                aria-hidden="true"
-              >
-                <IconProvider size="lg">{normalizeIcon(icon, 'lg')}</IconProvider>
-              </motion.span>
-            )}
+            {icon && flash ? (
+              <StatFlash icon={icon} flash={flash} fill={iconFill} speed={flashSpeed} />
+            ) : icon ? (
+              accentStyle === 'icon' ? (
+                <motion.span
+                  className={cn(
+                    'inline-flex items-center justify-center rounded-control p-ds-02',
+                    iconFill === 'solid'
+                      ? 'bg-accent-9 text-accent-fg'
+                      : 'bg-accent-3 text-accent-11',
+                  )}
+                  initial={{ opacity: 0, scale: 0.96 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={springs.snappy}
+                  aria-hidden="true"
+                >
+                  <IconProvider size="md">{normalizeIcon(icon, 'md')}</IconProvider>
+                </motion.span>
+              ) : (
+                <motion.span
+                  className="text-surface-fg-muted"
+                  initial={{ opacity: 0, scale: 0.96 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={springs.snappy}
+                  aria-hidden="true"
+                >
+                  <IconProvider size="lg">{normalizeIcon(icon, 'lg')}</IconProvider>
+                </motion.span>
+              )
+            ) : null}
           </div>
         </div>
         <div className="overflow-hidden">
           <motion.p
-            className="inline-block text-ds-3xl font-semibold text-surface-fg"
+            className={cn(
+              'inline-block text-ds-3xl font-semibold',
+              accentStyle === 'tint' ? 'text-accent-11' : 'text-surface-fg',
+            )}
             initial={{ opacity: 0, y: '100%' }}
             animate={{ opacity: 1, y: 0 }}
             transition={springs.smooth}
@@ -357,10 +395,13 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
     )
 
     const cardClasses = cn(
-      'rounded-surface border border-surface-border bg-surface-raised shadow-raised p-ds-05b',
-      accent && `border-l-[3px] ${accentBorderMap[accent]}`,
+      'rounded-surface p-ds-05b',
+      accentStyle === 'tint'
+        ? 'bg-linear-to-t from-accent-2 to-surface-raised'
+        : 'bg-surface-raised',
+      surface === 'flat' ? 'border border-surface-border' : 'shadow-raised',
       isClickable &&
-        'cursor-pointer hover:shadow-raised-hover hover:border-surface-border-strong transition-[box-shadow,border-color] duration-fast-02 ease-productive-standard group',
+        'cursor-pointer hover:shadow-raised-hover transition-[box-shadow] duration-fast-02 ease-productive-standard group',
       className,
     )
 

--- a/packages/core/src/ui/stat-flash.stories.tsx
+++ b/packages/core/src/ui/stat-flash.stories.tsx
@@ -1,0 +1,57 @@
+import { IconActivity, IconCurrencyDollar, IconServer, IconUsers } from '@tabler/icons-react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { StatFlash } from './stat-flash'
+
+const meta: Meta<typeof StatFlash> = {
+  title: 'Components/Data Display/StatFlash',
+  component: StatFlash,
+  tags: ['autodocs', 'stable'],
+  argTypes: {
+    flash: {
+      control: 'select',
+      options: ['up', 'down', 'goal', 'record', 'alert', 'live'],
+    },
+    fill: { control: 'inline-radio', options: ['soft', 'solid'] },
+    speed: { control: 'inline-radio', options: ['fast', 'normal', 'slow'] },
+  },
+}
+export default meta
+type Story = StoryObj<typeof StatFlash>
+
+export const TrendUp: Story = {
+  args: { icon: <IconActivity />, flash: 'up' },
+}
+
+export const TrendDown: Story = {
+  args: { icon: <IconCurrencyDollar />, flash: 'down' },
+}
+
+export const Solid: Story = {
+  args: { icon: <IconUsers />, flash: 'record', fill: 'solid' },
+}
+
+export const Slow: Story = {
+  args: { icon: <IconServer />, flash: 'alert', speed: 'slow' },
+}
+
+export const CustomSpec: Story = {
+  args: {
+    icon: <IconActivity />,
+    flash: { tone: 'info', icon: <IconServer /> },
+  },
+}
+
+/** All six presets side by side. Hit refresh to replay the entrance. */
+export const AllPresets: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-ds-04">
+      <StatFlash icon={<IconActivity />} flash="up" />
+      <StatFlash icon={<IconCurrencyDollar />} flash="down" />
+      <StatFlash icon={<IconActivity />} flash="goal" />
+      <StatFlash icon={<IconUsers />} flash="record" />
+      <StatFlash icon={<IconServer />} flash="alert" />
+      <StatFlash icon={<IconActivity />} flash="live" />
+    </div>
+  ),
+}

--- a/packages/core/src/ui/stat-flash.test.tsx
+++ b/packages/core/src/ui/stat-flash.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { StatFlash } from './stat-flash'
+
+describe('StatFlash', () => {
+  it('renders a preset flash without crashing', () => {
+    const { container } = render(<StatFlash icon={<svg data-testid="identity" />} flash="up" />)
+    // Renders the chip wrapper (decorative).
+    expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument()
+    // Identity icon is in the DOM (even mid-animation).
+    expect(container.querySelector('[data-testid="identity"]')).toBeInTheDocument()
+  })
+
+  it('accepts an explicit { tone, icon } spec', () => {
+    const { container } = render(
+      <StatFlash
+        icon={<svg data-testid="identity" />}
+        flash={{ tone: 'info', icon: <svg data-testid="flash-glyph" /> }}
+      />,
+    )
+    expect(container.querySelector('[data-testid="identity"]')).toBeInTheDocument()
+  })
+
+  it('renders solid fill variant', () => {
+    const { container } = render(
+      <StatFlash icon={<svg />} flash="record" fill="solid" />,
+    )
+    expect(container.firstChild).toHaveClass('bg-accent-9')
+  })
+
+  it('renders soft fill by default', () => {
+    const { container } = render(<StatFlash icon={<svg />} flash="alert" />)
+    expect(container.firstChild).toHaveClass('bg-accent-3')
+  })
+})

--- a/packages/core/src/ui/stat-flash.tsx
+++ b/packages/core/src/ui/stat-flash.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import {
+  IconAlertTriangle,
+  IconArrowDown,
+  IconArrowUp,
+  IconBolt,
+  IconCheck,
+  IconStar,
+} from '@tabler/icons-react'
+import { AnimatePresence, motion, type Transition, useReducedMotion } from 'framer-motion'
+import * as React from 'react'
+
+import { IconProvider } from './icon-context'
+import type { IconInput } from './lib/icon-input'
+import { springs, tweens } from './lib/motion'
+import { normalizeIcon } from './lib/normalize-icon'
+import { cn } from './lib/utils'
+
+export type FlashTone = 'success' | 'error' | 'warning' | 'info' | 'accent'
+
+/** Named entrance states. Each maps to a tone + glyph. */
+export type FlashPreset = 'up' | 'down' | 'goal' | 'record' | 'alert' | 'live'
+
+/** Explicit flash: any tone + any glyph. */
+export interface FlashSpec {
+  tone: FlashTone
+  icon: IconInput
+}
+
+const FLASH_PRESETS: Record<FlashPreset, { tone: FlashTone; Glyph: React.ComponentType }> = {
+  up: { tone: 'success', Glyph: IconArrowUp },
+  down: { tone: 'error', Glyph: IconArrowDown },
+  goal: { tone: 'success', Glyph: IconCheck },
+  record: { tone: 'accent', Glyph: IconStar },
+  alert: { tone: 'warning', Glyph: IconAlertTriangle },
+  live: { tone: 'info', Glyph: IconBolt },
+}
+
+const toneBg: Record<FlashTone, string> = {
+  success: 'bg-success-9',
+  error: 'bg-error-9',
+  warning: 'bg-warning-9',
+  info: 'bg-info-9',
+  accent: 'bg-accent-9',
+}
+
+const toneFg: Record<FlashTone, string> = {
+  success: 'text-success-fg',
+  error: 'text-error-fg',
+  warning: 'text-warning-fg',
+  info: 'text-info-fg',
+  accent: 'text-accent-fg',
+}
+
+/** Composable speed — coarse presets built from the DS motion tokens. */
+export type FlashSpeed = 'fast' | 'normal' | 'slow'
+
+const SPEEDS: Record<FlashSpeed, { holdMs: number; settle: Transition; fade: Transition }> = {
+  fast: { holdMs: 450, settle: springs.snappy, fade: tweens.fade },
+  normal: { holdMs: 650, settle: springs.snappy, fade: tweens.fade },
+  slow: { holdMs: 950, settle: springs.gentle, fade: tweens.elegant },
+}
+
+export interface StatFlashProps {
+  /** Settled identity glyph, shown after the flash resolves. */
+  icon: IconInput
+  /** The entrance flash — a named preset or an explicit `{ tone, icon }`. */
+  flash: FlashPreset | FlashSpec
+  /** Resting chip style once settled. @default 'soft' */
+  fill?: 'soft' | 'solid'
+  /** Coarse speed preset (hold + settle + fade), built from DS motion tokens. @default 'normal' */
+  speed?: FlashSpeed
+  /** Override how long the flash holds before settling, in ms. Wins over `speed`. */
+  holdMs?: number
+  /** Override the settle (icon scale-in) transition. Wins over `speed`. */
+  settleTransition?: Transition
+  /** Override the flash enter/exit fade transition. Wins over `speed`. */
+  flashTransition?: Transition
+}
+
+/**
+ * StatFlash — a chip that mounts showing a transient **state** (a toned glyph: an up-arrow on
+ * green, a check, an alert…) then settles into the metric's stable **identity** icon. The pattern
+ * is *state → identity*: communicate what just happened, then resolve to what the metric is.
+ *
+ * Used by `StatCard` via its `flash` prop, but standalone too (list rows, badges, toasts).
+ * Honors `prefers-reduced-motion` — renders the settled identity directly, no flash.
+ *
+ * @example
+ * <StatFlash icon={<IconFolder />} flash="up" />          // green up-arrow → folder
+ * <StatFlash icon={<IconBolt />} flash={{ tone: 'info', icon: <IconActivity /> }} />
+ */
+export function StatFlash({
+  icon,
+  flash,
+  fill = 'soft',
+  speed = 'normal',
+  holdMs,
+  settleTransition,
+  flashTransition,
+}: StatFlashProps) {
+  const prefersReduced = useReducedMotion()
+  const preset = SPEEDS[speed]
+  const hold = holdMs ?? preset.holdMs
+  const settleT = settleTransition ?? preset.settle
+  const fadeT = flashTransition ?? preset.fade
+
+  const resolved =
+    typeof flash === 'string'
+      ? { tone: FLASH_PRESETS[flash].tone, icon: <FlashPresetGlyph preset={flash} /> }
+      : flash
+
+  const [settled, setSettled] = React.useState(false)
+
+  React.useEffect(() => {
+    if (prefersReduced) {
+      setSettled(true)
+      return
+    }
+    const t = setTimeout(() => setSettled(true), hold)
+    return () => clearTimeout(t)
+  }, [prefersReduced, hold])
+
+  return (
+    <span
+      className={cn(
+        'relative inline-flex items-center justify-center overflow-hidden rounded-control p-ds-02',
+        fill === 'solid' ? 'bg-accent-9 text-accent-fg' : 'bg-accent-3 text-accent-11',
+      )}
+      aria-hidden="true"
+    >
+      <motion.span
+        className="inline-flex"
+        initial={prefersReduced ? false : { opacity: 0, scale: 0.55 }}
+        animate={{ opacity: settled ? 1 : 0, scale: settled ? 1 : 0.55 }}
+        transition={settleT}
+      >
+        <IconProvider size="md">{normalizeIcon(icon, 'md')}</IconProvider>
+      </motion.span>
+      <AnimatePresence>
+        {!settled && (
+          <motion.span
+            className={cn(
+              'absolute inset-0 inline-flex items-center justify-center',
+              toneBg[resolved.tone],
+              toneFg[resolved.tone],
+            )}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={fadeT}
+          >
+            <IconProvider size="md">{normalizeIcon(resolved.icon, 'md')}</IconProvider>
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </span>
+  )
+}
+
+function FlashPresetGlyph({ preset }: { preset: FlashPreset }) {
+  const { Glyph } = FLASH_PRESETS[preset]
+  return <Glyph />
+}
+
+StatFlash.displayName = 'StatFlash'

--- a/packages/core/src/ui/toast.tsx
+++ b/packages/core/src/ui/toast.tsx
@@ -181,7 +181,7 @@ function ToastContent({
       role={isUrgent ? 'alert' : 'status'}
       aria-live={isUrgent ? 'assertive' : 'polite'}
       aria-atomic="true"
-      className="group relative flex w-full overflow-hidden rounded-overlay-sm border border-surface-border-strong bg-surface-overlay shadow-floating"
+      className="group relative flex w-full overflow-hidden rounded-overlay-sm bg-surface-overlay shadow-floating"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onFocusCapture={() => setFocused(true)}
@@ -522,7 +522,7 @@ function UploadToastContent({
       role={uploadUrgent ? 'alert' : 'status'}
       aria-live={uploadUrgent ? 'assertive' : 'polite'}
       aria-label="File uploads"
-      className="group relative flex w-full overflow-hidden rounded-overlay-sm border border-surface-border-strong bg-surface-overlay shadow-floating"
+      className="group relative flex w-full overflow-hidden rounded-overlay-sm bg-surface-overlay shadow-floating"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onFocusCapture={() => setFocused(true)}

--- a/skills/shilp-sutra/references/components-full.md
+++ b/skills/shilp-sutra/references/components-full.md
@@ -4048,7 +4048,11 @@ import { SplitButton } from '@devalok/shilp-sutra'
     comparisonLabel: string (shown after delta, e.g. "vs last month")
     secondaryLabel: string (below main value, e.g. "of $50,000 target")
     progress: number (0-100, renders thin progress bar below value)
-    accent: "default" | "success" | "warning" | "error" | "info" (left border color)
+    surface: "raised" | "flat" (raised = ring-in-shadow, no border [default]; flat = border, no shadow)
+    accentStyle: "none" | "icon" | "tint" (none [default]; icon = accent chip around icon; tint = accent surface wash + accent value)
+    iconFill: "soft" | "solid" (chip style when accentStyle="icon"; default soft)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (opt-in entrance flash; requires icon)
+    flashSpeed: "fast" | "normal" | "slow" (default normal)
     sparkline: number[] (renders mini SVG line chart)
     onClick: () => void (makes card clickable with hover state)
     href: string (makes card a link via LinkContext)
@@ -4066,7 +4070,8 @@ import { SplitButton } from '@devalok/shilp-sutra'
   delta={{ value: "+12%", direction: "up" }}
   comparisonLabel="vs last month"
   icon={<IconCurrencyDollar />}
-  accent="success"
+  accentStyle="icon"
+  flash="up"
 />
 
 <StatCard
@@ -4083,7 +4088,8 @@ import { SplitButton } from '@devalok/shilp-sutra'
 - **High-density metric card** — optimized for dashboards. Everything optional except `value`. Mix and match features (delta, sparkline, progress, secondary label, footer) per metric's needs.
 - **Router integration via href:** Internally uses `LinkContext` to resolve framework-specific Link components (Next.js, react-router). Set `href` in a LinkProvider-wrapped tree to get seamless client-side navigation without custom asChild wiring.
 - **Interactive modes:** `onClick` makes the entire card a button; `href` makes it a link. Mutually exclusive — href wins if both are set.
-- **Accent bar semantic:** Use `accent` to signal metric health at a glance (success for positive, warning for at-risk, error for over-target). Combine with delta.direction for layered emphasis.
+- **Accent (composable, opt-in):** `accentStyle="icon"` wraps `icon` in an accent chip (`iconFill="soft" | "solid"`); `accentStyle="tint"` applies a subtle accent surface wash + accent value. `surface` picks edge-vs-elevation. No colored rail — the DS never stacks a border + drop shadow (make-kit rule #6). Trend health reads from `delta.direction` (up=green, down=red).
+- **Flash motion (opt-in):** `flash` mounts a toned state glyph (`up`/`down`/`goal`/`record`/`alert`/`live`, or `{ tone, icon }`) that settles to `icon`; `flashSpeed` tunes timing. Reuses the standalone `StatFlash` primitive. Honors `prefers-reduced-motion`.
 - **Sparkline:** Pure SVG, lightweight — no chart library. For rich charts use Chart components. Minimum 2 data points.
 - **Icon auto-sizing:** Accepts `ComponentType<{ className }>` OR `ReactNode`. The component prop (e.g. `icon={IconBolt}`) is preferred — icon is rendered at a consistent size.
 - **Loading state:** `loading={true}` renders the full card skeleton — use during initial data fetch.
@@ -4095,11 +4101,59 @@ import { SplitButton } from '@devalok/shilp-sutra'
 - `sparkline` needs at least 2 data points to render
 
 ## Changes
+### v0.43.0
+- **BREAKING** Removed `accent` (colored left-rail). Use `accentStyle` (`"icon"` | `"tint"`) or rely on `delta` for trend colour.
+- **Added** `surface`, `accentStyle`, `iconFill`, `flash`, `flashSpeed`. New standalone `StatFlash` primitive. Base no longer stacks border + shadow.
+
 ### v0.2.0
 - **Added** `icon` prop now accepts `React.ComponentType` (e.g., `icon={IconBolt}`) in addition to `ReactNode`
 
 ### v0.1.0
 - **Added** Initial release
+# StatFlash
+
+- Import: @devalok/shilp-sutra/ui/stat-flash
+- Server-safe: No
+- Category: ui
+
+## Props
+    icon: ReactNode | ComponentType<{ className?: string }> (REQUIRED — settled identity glyph)
+    flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (REQUIRED — the entrance state)
+    fill: "soft" | "solid" (resting chip style; default soft)
+    speed: "fast" | "normal" | "slow" (coarse motion preset; default normal)
+    holdMs: number (override how long the flash holds before settling)
+    settleTransition: Transition (override the icon scale-in transition)
+    flashTransition: Transition (override the flash enter/exit fade)
+
+## Defaults
+    fill="soft", speed="normal"
+
+## Example
+```jsx
+// Preset: green up-arrow flashes, then settles to the folder icon
+<StatFlash icon={<IconFolder />} flash="up" />
+
+// Explicit tone + glyph
+<StatFlash icon={<IconActivity />} flash={{ tone: "info", icon: <IconBolt /> }} fill="solid" />
+
+// Composable speed: coarse preset + fine override
+<StatFlash icon={<IconFolder />} flash="up" speed="fast" holdMs={300} />
+```
+
+## Composability
+- **State → identity primitive:** the chip mounts showing a transient *state* (a toned glyph — up-arrow on green, check, alert…) then settles into the stable *identity* icon. Used by `StatCard`'s `flash` prop, but standalone too (list rows, badges, toasts).
+- **Tone slot:** six named presets (`up`/`down`/`goal`/`record`/`alert`/`live`) map to DS semantic tones (success/error/warning/info/accent) + a glyph. Pass `{ tone, icon }` for anything else.
+- **Composable motion:** `speed` is a coarse preset built from the DS motion tokens; `holdMs` / `settleTransition` / `flashTransition` each override one slice and fall back to the preset.
+- **Accessible by default:** honors `prefers-reduced-motion` — renders the settled identity directly, no flash. The chip is `aria-hidden` (decorative; the metric's text carries meaning).
+
+## Gotchas
+- `flash` and `icon` are both required — the flash settles *to* the icon.
+- Fine overrides win over `speed`.
+- Decorative only — never the sole carrier of meaning (it's `aria-hidden`).
+
+## Changes
+### v0.43.0
+- **Added** Initial release. Powers `StatCard`'s `flash` prop.
 # StatusDot
 
 - Import: @devalok/shilp-sutra/ui/status-dot


### PR DESCRIPTION
## Why

Setu's anti-convergence ruleset (and our own make-kit **Guidelines rule #6**) forbids stacking a visible **border + drop shadow** on the same element — the shadow tokens already carry a 1px ring. An audit found the library broke its own rule in **~30 places**, including the flagship `Card`, and the single most recognizable AI tell: an accent rail on a rounded, shadowed card (`StatCard`, the sidebar active item). This makes the library honor the rule its Make kit teaches AI agents.

## What

**Edge XOR elevation, by surface role** (visual, non-breaking unless noted):
- **Overlays** (Dialog, AlertDialog, Popover, HoverCard, Dropdown/Context/Menubar, Select, Combobox, Autocomplete, NavigationMenu, Toast, ColorInput, SplitButton, DataTable bulk actions, command-bar/palette, suggestion popovers, rich-chat-input/editor menus, notification-center, top-bar, file-preview toolbars, floating Sidebar) — dropped the explicit border; the shadow's ring carries the edge. `--shadow-floating`/`--shadow-overlay` ring 0.04→0.09; new `--shadow-edge-ring` gives **dark mode a light ring**.
- **Cards** — `Card` `default`/`elevated` are ring-in-shadow (no border); `outline` = border-led. `content-card`, `audio-preview`, `error-boundary`, chat toolbar, sidebar promo card de-stacked.
- **InputOTP** cells border-led (dropped redundant shadow).

**Sidebar**
- Active nav item: removed the accent `::after` **rail** (doubled-accent tell) → tint + accent text + weight.
- **Composable** nav-item radius: new `navItemRadius` prop + `--ds-sidebar-item-radius`; default control (~6px), was over-rounded 10px.

**StatCard**
- ⚠️ **BREAKING:** removed the `accent` colored left-rail prop. Migrate → `accentStyle="icon" | "tint"`, or rely on `delta` for trend colour.
- New, all composable + opt-in: `surface` (raised|flat), `accentStyle` (none|icon|tint), `iconFill`, `flash` + `flashSpeed`.
- New **`StatFlash`** primitive — a state→identity entrance (up/down/goal/record/alert/live or `{tone,icon}`), composable speed, `prefers-reduced-motion` gated.

## Gates (local)
typecheck ✓ · lint 0 errors ✓ · build ✓ · SSR smoke 146/146 ✓ · tests **2161 pass** ✓ · docs + skill refs regenerated ✓ · double-edge **eliminated library-wide** (0 residual).

> Note for reviewer: the local `pre-publish-audit` flags `SKILL.md` frontmatter — a **Windows CRLF false-positive** (the regex is LF-only; the committed blob is LF, so CI passes). Chromatic will show **broad diffs across overlays/cards — expected**, that's the verification.

## Follow-ups (not in this PR)
- **Karm DS notice** for the StatCard `accent` removal (`/send-karm-notice`).
- **PR4 (site):** `built-with.tsx` uses dead `bg-gradient-to-br` (renders nothing in TW4) + colored-border+shadow+gradient stacking; eyebrow-kicker on every heading; emoji glyphs → DS icons; "Three pillars"/4-cards copy bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgkWTThT6PjVL8vPqTHRB