### PR TITLE
fix(site): anti-convergence cleanup + dead TW4 gradient bug

### DIFF
--- a/apps/site/app/figma-make/page.tsx
+++ b/apps/site/app/figma-make/page.tsx
@@ -236,7 +236,7 @@ export default function FigmaMakePage() {
               </Text>
             </header>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-ds-04">
-              <Card color="warning" accent="left" accentColor="warning">
+              <Card variant="outline" color="warning">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-ds-03">
                     <IconClockExclamation size={18} className="text-warning-11" />

--- a/apps/site/components/brand-switcher.tsx
+++ b/apps/site/components/brand-switcher.tsx
@@ -80,7 +80,7 @@ export function BrandSwitcher({ align = 'end' }: BrandSwitcherProps = {}) {
           aria-label="Brand presets"
           className={[
             'absolute mt-ds-02 w-72 max-w-[calc(100vw-2rem)] rounded-control',
-            'border border-surface-border bg-surface-overlay shadow-overlay z-popover overflow-hidden',
+            'bg-surface-overlay shadow-overlay z-popover overflow-hidden',
             align === 'start' ? 'left-0' : 'right-0',
           ].join(' ')}
         >

--- a/apps/site/components/built-with.tsx
+++ b/apps/site/components/built-with.tsx
@@ -277,7 +277,7 @@ function FeaturedCard({ consumer }: { consumer: Consumer }) {
   return (
     <article
       style={style}
-      className="relative overflow-hidden rounded-surface border border-accent-7 shadow-raised bg-gradient-to-br from-accent-2 via-accent-3 to-accent-2"
+      className="relative overflow-hidden rounded-surface border border-accent-7 bg-linear-to-br from-accent-2 via-accent-3 to-accent-2"
     >
       {/* Decorative brand glow in the corner — purely atmospheric. Sized
           smaller on mobile so it doesn't dominate the layout. */}
@@ -361,7 +361,7 @@ function FeaturedCard({ consumer }: { consumer: Consumer }) {
 
           {/* Mock product chrome — proves the brand on a real-feeling
               artifact. Hidden below sm to avoid cramping a phone viewport. */}
-          <div className="hidden sm:flex rounded-control border border-accent-7 bg-surface-base shadow-overlay p-ds-04 flex-col gap-ds-03">
+          <div className="hidden sm:flex rounded-control bg-surface-base shadow-overlay p-ds-04 flex-col gap-ds-03">
             <div className="flex items-center gap-ds-02 min-w-0">
               <span aria-hidden className="w-2 h-2 rounded-pill bg-error-9 shrink-0" />
               <span aria-hidden className="w-2 h-2 rounded-pill bg-warning-9 shrink-0" />
@@ -407,7 +407,7 @@ function SecondaryCard({ consumer }: { consumer: Consumer }) {
 
   const body = (
     <article style={style} className={cardClass}>
-      <div className="relative h-16 bg-gradient-to-br from-accent-3 to-accent-2 border-b border-surface-border-subtle overflow-hidden shrink-0">
+      <div className="relative h-16 bg-linear-to-br from-accent-3 to-accent-2 border-b border-surface-border-subtle overflow-hidden shrink-0">
         <span
           aria-hidden
           className="pointer-events-none absolute -top-10 -right-10 w-32 h-32 rounded-pill opacity-40 blur-2xl"

--- a/apps/site/components/featured-components.tsx
+++ b/apps/site/components/featured-components.tsx
@@ -66,7 +66,7 @@ function FeatureCard({
   children: React.ReactNode
 }) {
   return (
-    <article className="group flex flex-col gap-ds-04 p-ds-05b rounded-surface bg-surface-raised border border-transparent shadow-raised transition-[box-shadow,border-color,translate] duration-fast-02 ease-productive-standard hover:border-surface-border-strong hover:shadow-raised-hover hover:-translate-y-px">
+    <article className="group flex flex-col gap-ds-04 p-ds-05b rounded-surface bg-surface-raised shadow-raised transition-[box-shadow,translate] duration-fast-02 ease-productive-standard hover:shadow-raised-hover hover:-translate-y-px">
       <header className="flex flex-col">
         <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">{slug}</span>
         <h3 className="text-ds-md text-surface-fg font-semibold mt-ds-01">{title}</h3>

--- a/apps/site/components/landing-surface.tsx
+++ b/apps/site/components/landing-surface.tsx
@@ -151,7 +151,7 @@ export function LandingSurface() {
                         className={[
                           'flex items-start gap-ds-03 px-ds-03 -mx-ds-03 py-ds-03 rounded-control border-b border-surface-border-subtle last:border-b-0',
                           'hover:bg-surface-raised-hover transition-colors duration-fast-02 ease-productive-standard',
-                          a.isNew && 'border-l-2 border-l-accent-9 pl-ds-03 bg-accent-2',
+                          a.isNew && 'bg-accent-2',
                         ]
                           .filter(Boolean)
                           .join(' ')}

--- a/apps/site/components/themer/AgentPromptHero.tsx
+++ b/apps/site/components/themer/AgentPromptHero.tsx
@@ -46,7 +46,7 @@ export function AgentPromptHero({ prompt }: AgentPromptHeroProps) {
             onClick={copy}
             className="inline-flex items-center gap-ds-02 rounded-control bg-accent-9 px-ds-06 py-ds-04 text-ds-md font-semibold text-accent-fg shadow-raised hover:bg-accent-10 transition-colors"
           >
-            {copied ? '✓ Copied' : 'Copy prompt'}
+            {copied ? 'Copied' : 'Copy prompt'}
           </button>
           <button
             type="button"

--- a/apps/site/components/themer/ResultActions.tsx
+++ b/apps/site/components/themer/ResultActions.tsx
@@ -38,14 +38,14 @@ export function ResultActions({ css }: ResultActionsProps) {
           onClick={() => copy(css, setCssState)}
           className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-strong bg-surface-2 px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg hover:bg-surface-3"
         >
-          {cssState === 'copied' ? '✓ Copied' : 'Copy CSS'}
+          {cssState === 'copied' ? 'Copied' : 'Copy CSS'}
         </button>
         <button
           type="button"
           onClick={() => copy(window.location.href, setShareState)}
           className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-subtle bg-surface-2 px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg-muted hover:text-surface-fg hover:bg-surface-3"
         >
-          {shareState === 'copied' ? '✓ Share URL copied' : 'Copy share URL'}
+          {shareState === 'copied' ? 'Share URL copied' : 'Copy share URL'}
         </button>
       </div>
       <CodeBlock code={css} language="css" />


### PR DESCRIPTION
PR4 of the anti-convergence work — the marketing site (`apps/site`). Surgical: 7 files, 10 edits. Typecheck ✓, lint ✓ (0), `next build` ✓.

## Real bug
- **`built-with.tsx` used `bg-gradient-to-br`** — dead in Tailwind 4 (`bg-gradient-*` was renamed to `bg-linear-*`), so those gradients were rendering **nothing**. Fixed → `bg-linear-to-br`.

## Anti-convergence (visual-effect lens, not just borders)
- **figma-make `/page.tsx`:** the update-cadence `Card` stacked `color="warning"` + `accent="left"` + shadow — the full triple "AI tell" — on a brand-new page. → `variant="outline" color="warning"` (border-led, no rail, no shadow).
- **Double-edges stripped:** `built-with` featured card + mock chrome (border + shadow + gradient → drop border/shadow, keep one); `brand-switcher` overlay popover (border → shadow ring); `featured-components` hover (dropped hover border, kept shadow lift).
- **Accent rail removed:** `landing-surface` "new" activity items lost the `border-l-accent-9` stripe (kept the `bg-accent-2` tint).
- **Emoji:** removed the `✓` glyph from themer copy buttons — the label change ("Copied") already confirms the action.

## Deliberately left (defensible, with reasoning)
- **Eyebrow kickers:** 27 across the site, but almost all are **one-per-page or categorize a real section** (the rule permits that). Stripping them is a per-page rhythm call that's yours, not a mechanical violation. Flagging for your eye rather than gutting.
- **Footer 🧡** ("Made in Bharat with 🧡") — aria-labeled brand signature, single instance = deliberate brand voice (rule-exempt).
- **AuroraBloom / built-with `blur-3xl` glows** — contained, atmospheric, inside the brand-demo (deliberate).
- **`feature-grid` "Three pillars. One promise."** — NOT a count bug: 3 pillar cards + 1 promise card = 4, exactly as worded.
- Arrow glyphs (←/→/↓) in links — legit text affordances, not emoji-as-icons.

No changeset — `apps/site` isn't published to npm; it deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgkWTThT6PjVL8vPqTHRB