### PR TITLE
ci: skip library pipelines on site-only changes

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -3,6 +3,10 @@ name: Deploy Storybook to GitHub Pages
 on:
   push:
     branches: [main]
+    # Storybook documents the component library, not the marketing site.
+    # Site-only changes (apps/site/**) don't change any story — skip the redeploy.
+    paths-ignore:
+      - 'apps/site/**'
 
   # Allow manual trigger from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 on:
   push:
     branches: [main]
+    # Site-only changes (apps/site/**) deploy via Railway and never touch the
+    # published npm packages — skip the release pipeline for them.
+    paths-ignore:
+      - 'apps/site/**'
   # Allow manual re-runs from the Actions UI / gh CLI without needing a new commit.
   # Useful when a prior publish failed on a transient issue (auth, registry outage,
   # token expiry) and we want to retry with the fix in place — as happened after

--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -3,8 +3,14 @@ name: Visual Review (Chromatic)
 on:
   push:
     branches: [main]
+    # Chromatic snapshots Storybook (the component library). Site-only changes
+    # (apps/site/**) touch no story — skip to save snapshot quota.
+    paths-ignore:
+      - 'apps/site/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'apps/site/**'
   workflow_dispatch:
     inputs:
       auto_accept:


### PR DESCRIPTION
Stops site-only commits from dragging the **component-library** pipeline.

`apps/site` deploys on its own via **Railway** (it has a `Dockerfile`; no GH deploy workflow). It never affects the published npm packages or Storybook — yet today every site commit fires **Release**, **Deploy Storybook**, and **Chromatic**. That's wasteful and, for Release, risks the flaky `changeset get-github-info` fetch on a push that has nothing to publish.

### Change
`paths-ignore: ['apps/site/**']` on the push (and Chromatic PR) triggers of:
- `release.yml`
- `deploy-storybook.yml`
- `visual-review.yml`

`ci.yml` is intentionally **left running on all PRs** — it builds library + site together, so it's the gate that validates the site still consumes the workspace package.

### Safety
The `Protect main` ruleset has **no required status checks** (only PR-review + deletion + non-fast-forward), so path-filtering can't deadlock a merge (the classic "skipped required check stays pending" trap doesn't apply here). Mixed PRs (library + site) still trigger everything — `paths-ignore` only skips when *all* changed files are under `apps/site/`.

### Out of scope (FYI, your call)
- **Chromatic plan is exhausted** ("Update your plan to resume") — the UI Review/Tests checks are stuck for *all* PRs, not just site ones. Not blocking (not required), but worth topping up or they stay perma-pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgkWTThT6PjVL8vPqTHRB