### PR TITLE
fix(release): retry changeset version to survive get-github-info flake

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:storybook": "vitest --project storybook",
     "test:storybook:ci": "vitest run --project storybook",
     "changeset": "changeset",
-    "version-packages": "changeset version && node scripts/prepend-breaking-summary.mjs && node scripts/sync-skill-version.mjs && node packages/core/scripts/build-component-docs.mjs && node scripts/build-skill.mjs",
+    "version-packages": "node scripts/changeset-version-retry.mjs && node scripts/prepend-breaking-summary.mjs && node scripts/sync-skill-version.mjs && node packages/core/scripts/build-component-docs.mjs && node scripts/build-skill.mjs",
     "release": "pnpm build && changeset publish"
   },
   "devDependencies": {

--- a/scripts/changeset-version-retry.mjs
+++ b/scripts/changeset-version-retry.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Runs `changeset version` with retry + backoff.
+ *
+ * Why: our changelog generator (`@changesets/changelog-github`) calls
+ * `@changesets/get-github-info`, which fetches the GitHub GraphQL API to enrich
+ * each entry with PR/author links. That fetch intermittently dies with
+ * `Invalid response body ... api.github.com/graphql: Premature close` (an undici
+ * stream drop on the runner→GitHub path) — it killed the 0.43.0 release 3× while
+ * succeeding locally. `get-github-info@0.8.0` is already the latest, so there's
+ * no upstream fix to upgrade into; retrying is the robust mitigation.
+ *
+ * `changeset version` is atomic on failure ("no files should have been affected"),
+ * so re-running from a clean state is safe. If every attempt fails we exit
+ * non-zero so the release fails loudly rather than shipping a stale changelog.
+ *
+ * Override attempts with CHANGESET_VERSION_RETRIES (default 4).
+ */
+import { spawnSync } from 'node:child_process'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+const MAX = Math.max(1, Number(process.env.CHANGESET_VERSION_RETRIES) || 4)
+const BASE_DELAY_MS = 5000
+
+for (let attempt = 1; attempt <= MAX; attempt++) {
+  // `pnpm exec` resolves the local `changeset` bin cross-platform (Windows + CI).
+  const result = spawnSync('pnpm', ['exec', 'changeset', 'version'], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  })
+
+  if (result.status === 0) {
+    if (attempt > 1) console.log(`[changeset-version] succeeded on attempt ${attempt}/${MAX}.`)
+    process.exit(0)
+  }
+
+  if (attempt === MAX) {
+    console.error(
+      `\n[changeset-version] failed after ${MAX} attempts. If this is the recurring ` +
+        `@changesets/get-github-info "Premature close", run \`pnpm version-packages\` locally ` +
+        `and push the result as the Version Packages PR (see MIGRATION/release runbook).`,
+    )
+    process.exit(result.status ?? 1)
+  }
+
+  const delayMs = BASE_DELAY_MS * attempt
+  console.warn(
+    `\n[changeset-version] attempt ${attempt}/${MAX} failed ` +
+      `(likely a transient GitHub API "Premature close"). Retrying in ${delayMs / 1000}s…`,
+  )
+  await sleep(delayMs)
+}


### PR DESCRIPTION
## The issue (root cause)
The 0.43.0 release failed **3×** on:
```
🦋 error Failed to parse data from GitHub
🦋 error Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
```
`changeset version` uses `@changesets/changelog-github` → `@changesets/get-github-info@0.8.0`, which fetches the GitHub **GraphQL API** to enrich each changelog entry with PR/author links. That fetch hit an **undici "Premature close"** (response stream dropped) on the GitHub-hosted runner — while the **identical command succeeded locally**. GitHub status was all-green; only ~2 commits in range (not a size/auth problem). `get-github-info@0.8.0` is already the latest published version, so there's nothing to upgrade into.

Net: one transient network blip on a single fetch = the entire release dead, with no retry. We had to hand-generate the bump locally to ship 0.43.0.

## The fix
Wrap `changeset version` in retry + backoff (`scripts/changeset-version-retry.mjs`):
- 4 attempts, `5s × attempt` backoff (overridable via `CHANGESET_VERSION_RETRIES`).
- Cross-platform (`pnpm exec changeset version`; shell only on win32).
- `changeset version` is **atomic on failure** ("no files should have been affected"), so re-running from a clean state is safe.
- If every attempt fails → **exit non-zero** so the release fails loudly (never ships a stale/missing changelog).

`version-packages` now calls the wrapper instead of `changeset version` directly. Verified locally (no-op when no changesets present; bin resolves on Windows).

## Why retry (not switch generators)
Keeps the rich GitHub changelog (PR/author links). Switching to `@changesets/changelog-git` would drop that. Retry is the minimal durable mitigation for a transient fetch.

No changeset — this is release tooling, not a change to any published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgkWTThT6PjVL8vPqTHRB