### PR TITLE
fix(core): export ./ui/truncated-text subpath + v0.44.0 follow-ups (0.44.1)

### DIFF
--- a/.changeset/fix-truncated-text-export.md
+++ b/.changeset/fix-truncated-text-export.md
@@ -1,0 +1,22 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Add the missing `./ui/truncated-text` subpath export.
+
+0.44.0 shipped the new `TruncatedText` primitive in `dist/` and re-exported it
+from the package root (`@devalok/shilp-sutra` and `@devalok/shilp-sutra/ui`), but
+the granular subpath was never added to `package.json#exports`. As a result:
+
+```ts
+import { TruncatedText } from "@devalok/shilp-sutra/ui/truncated-text";
+// -> Module not found, before 0.44.1
+```
+
+Root-barrel imports were unaffected and continue to work. This patch restores
+parity with every other `./ui/*` component.
+
+To prevent recurrence, `pre-publish-audit.mjs` now gates on every flat
+`src/ui/*.tsx` component having a matching `./ui/<name>` subpath export (or an
+explicit barrel-only allowlist entry). The SSR smoke test iterates the exports
+map, so it now also imports `truncated-text` — closing the gap that let this slip.

--- a/docs/audit/2026-06-30-v0.44.0-followups.md
+++ b/docs/audit/2026-06-30-v0.44.0-followups.md
@@ -1,0 +1,24 @@
+# v0.44.0 follow-ups — deferred / pending work
+
+**Context:** 0.44.0 shipped the card-system overhaul + anti-convergence + truncation (see `MIGRATION.md` § v0.44.0, PRs #87/#88). This file tracks what was deliberately deferred or closed, so it isn't lost. Source audits: `2026-06-30-SITREP.md`, `2026-06-30-primitive-bypass-audit.md`, `2026-06-30-truncation-audit.md`.
+
+## Pending — immediate (post-publish protocol)
+
+- [ ] **Karm DS notice.** 0.44.0 ships 3 breaking changes; file a `[DS Notice]` on `devalok-design/karm` (label `shilp-sutra-ai-agent-feedback`) so consumers migrate. Use `/send-karm-notice`. Breaking set:
+  - `Card`: removed `accent` / `accentColor` → use `<CardAction>` or `color`.
+  - `StatCard`: `surface` → `variant` (`raised`→`default`, `flat`→`outline`).
+  - `ContentCard` deprecated → compose `Card` + slots.
+
+## Deferred — candidates for 0.45.0 (all additive / non-breaking)
+
+- [ ] **A3 — DataTableCards compose `Card variant="outline"`** (`primitive-bypass-audit` A3). Hand-rolls a card surface instead of composing `<Card>`. Deferred: porting onto the new gap-model padding/gap shifted the dense table-card layout more than the SSOT win justified at the time. Revisit with explicit before/after on the table-card spacing.
+- [ ] **E remainder — round the `text-[13px]` / `text-[11px]` magic values** to existing tokens. ~7 sites: `chat/message.tsx` (×5), `badge-indicator`, and any others from the bypass audit's E list. The 9px → `--text-ds-2xs` part shipped in 0.44.0; 13/11 were left because rounding (down to 12/10 vs up to 14/12) changes rendered size and is a per-site taste call. Decide direction, then sweep.
+- [ ] **F guard (optional tooling)** — add a `pre-publish-audit.mjs` check that flags primitive-bypass: a hand-rolled Button/Card/Input signature in a component that should compose the primitive. Prevents the bypass class from recurring. Lower priority than shipping features.
+
+## Closed — decided won't-do
+
+- **C2 — `schedule-send.tsx` compose `Select` / `Input`.** Left native. The DS primitives didn't fit the compact inline date/time picker; native controls give better UX in that dense toolbar. Not a bug.
+
+## Done in 0.44.0 (for cross-reference)
+
+A1 (StatCard composes Card), A2 (ContentCard deprecated), Class B (12 button bypasses → `<Button>`), C1 (chat edit → `<Textarea>`), D1 (oauth corner-pill comment), E-core (`--text-ds-2xs` 9px), full truncation PR (`<TruncatedText>` + ~25 M/B1/B2/W sites), Phase 3 (`<CardAction>` corner slots + StatCard `deltaPlacement="inline"`).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -432,6 +432,11 @@
       "import": "./dist/ui/tooltip.js",
       "default": "./dist/ui/tooltip.js"
     },
+    "./ui/truncated-text": {
+      "types": "./dist/ui/truncated-text.d.ts",
+      "import": "./dist/ui/truncated-text.js",
+      "default": "./dist/ui/truncated-text.js"
+    },
     "./ui/visually-hidden": {
       "types": "./dist/ui/visually-hidden.d.ts",
       "import": "./dist/ui/visually-hidden.js",

--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -14,7 +14,7 @@
 
 import { execSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
-import { join, resolve } from 'path'
+import { join, resolve, basename } from 'path'
 import { globSync } from 'node:fs'
 import { validate as validateBreakingManifest } from './validate-breaking-manifest.mjs'
 
@@ -537,6 +537,46 @@ gate('exports types-first ordering (every subpath)', () => {
   walk(corePkg.exports, '')
   if (violations.length > 0) {
     return `Exports with wrong conditional ordering:\n${violations.map((v) => `      ${v}`).join('\n')}`
+  }
+  return true
+})
+
+// Gate: every flat src/ui/*.tsx component has a "./ui/<name>" subpath export
+// (or is explicitly allowlisted as barrel-only / internal). 0.44.0 shipped
+// TruncatedText in dist/ but never added "./ui/truncated-text" to the exports
+// map — so `import { TruncatedText } from "@devalok/shilp-sutra/ui/truncated-text"`
+// failed to resolve, and the SSR smoke test (which iterates the exports map)
+// never caught it. This gate closes that loop: a new component without a
+// subpath export now forces an explicit decision — export it or allowlist it.
+const SUBPATH_EXEMPT = new Set([
+  // Internal sub-parts consumed only through their parent's barrel/subpath:
+  'button-processing', // SplitButton/Button loading-state helper
+  'stat-flash', // sub-part of StatCard
+  // DataTable internals — DataTable itself is barrel-isolated (./ui/data-table):
+  'data-table-body',
+  'data-table-bulk-actions',
+  'data-table-card',
+  'data-table-context',
+  'data-table-header',
+  'data-table-pagination',
+])
+gate('Every flat src/ui component has a ./ui/<name> subpath export', () => {
+  const subpaths = new Set(
+    Object.keys(corePkg.exports)
+      .filter((k) => /^\.\/ui\/[^/]+$/.test(k))
+      .map((k) => k.replace('./ui/', ''))
+  )
+  const missing = globSync('packages/core/src/ui/*.tsx', { cwd: ROOT })
+    .map((f) => basename(f, '.tsx'))
+    .filter((name) => !/\.(test|stories)$/.test(name))
+    .filter((name) => !subpaths.has(name) && !SUBPATH_EXEMPT.has(name))
+    .sort()
+  if (missing.length > 0) {
+    return (
+      `flat src/ui components with no "./ui/<name>" export:\n${missing
+        .map((m) => `      ${m} — add "./ui/${m}" to packages/core/package.json#exports`)
+        .join('\n')}\n      (or add it to SUBPATH_EXEMPT in scripts/pre-publish-audit.mjs if it is barrel-only/internal)`
+    )
   }
   return true
 })


### PR DESCRIPTION
Tracks what 0.44.0 deferred or closed so the audit items don't get lost post-release.

**Pending:** Karm DS notice (3 breaking changes).
**Deferred → 0.45.0 candidates:** A3 (DataTableCards→Card outline), E remainder (13/11px rounding), F guard (bypass detector).
**Closed:** C2 (schedule-send left native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BgkWTThT6PjVL8vPqTHRB