### PR TITLE
feat: card --card-spacing variable model + CardBleed + table border/hover/density fix

### DIFF
--- a/.changeset/card-spacing-variable.md
+++ b/.changeset/card-spacing-variable.md
@@ -1,0 +1,21 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Card spacing becomes one CSS variable; CardBleed + horizontal cards; StatCard size axis; padding-fight cleanups
+
+**Card (`ui/card`):**
+
+- The `size` axis now assigns `--card-spacing` / `--card-gap` CSS variables; the container, all slots, `CardAction` corner insets, and the new `CardBleed` negations read the same pair. Rendered spacing is unchanged (sm 16/8, md 20/12, lg 24/16). `CardSizeContext` and the per-size class lookup maps are gone — slots work by CSS inheritance. Retune any card with a single override: `className="[--card-spacing:var(--spacing-ds-07)]"`.
+- **Added `<CardBleed side>`** (`x` | `top` | `bottom` | `y` | `all`) — full-bleed escape hatch that negates `--card-spacing`, the shilp-sutra equivalent of Radix Themes' `Inset` / Polaris `Bleed`. `top`/`bottom` inherit the card radius for cover media; `x` escapes a slot's inset for edge-to-edge bands. Direct children of Card are already full-width — don't use `x`/`all` there.
+- **Added `orientation="horizontal"` + `<CardSection>`** — sanctioned horizontal media card: the root becomes a padding-less row, the media pane owns the left edge, and `CardSection` re-establishes the py/gap rhythm from the same variables.
+- **Added** dev-only warning when Card receives bare text or textual elements (`<p>`, `<span>`, headings…) as direct children — the #1 "card padding looks broken" footgun (direct children get no horizontal inset by design).
+
+Compat: rendered pixels are identical; consumer `className` overrides on slots keep winning via tw-merge. Only CSS targeting the old literal classes (`px-ds-05b` on slots, `top-ds-05b` on CardAction) needs to move to the variables.
+
+**StatCard (`ui/stat-card`):**
+
+- **Added `size` prop** (`sm | md | lg`, delegated to Card). `sm` tightens padding to 16px and steps the value down to `text-ds-2xl` — for dense KPI rows and narrow stat grids.
+- Internal rhythm is now flex gap instead of stacked margins; `footer` renders behind a full-width rule instead of an inset `border-t`; loading skeleton gets `aria-busy`.
+
+**Padding-fight cleanups:** `NotificationPreferences` header no longer double-gaps (stale `pb-ds-04` removed); `DataTableCards` mobile rows compose `<Card size="sm">` instead of a hand-rolled 12px bordered box; Card stories/JSDoc and the make-kit spacing/surfaces guides no longer model `p-*` overrides on Card.

--- a/.changeset/table-density-borders.md
+++ b/.changeset/table-density-borders.md
@@ -1,0 +1,17 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Table: restore row separators, fix invisible hover, variable-driven density, card-edge alignment
+
+The original shadcn port had lost TableRow's `border-b` (rows rendered as an unseparated slab) and mis-mapped `hover:bg-muted/50` to `hover:bg-surface-raised` — the card background, so row hover was invisible on any table inside a Card. Fixed, plus a density pass benchmarked against Radix Themes / Carbon / Polaris / Mantine / MUI:
+
+- **Rows** regain a hairline separator (`border-surface-border-subtle`); hover is `surface-raised-hover`; selected stays `accent-3`.
+- **`density` prop on Table** (`compact | standard | comfortable`) sets `--table-py` → rows ≈ 29 / 37 / 45px (was 29 / 53 / 85 via DataTable's per-cell classes). Header height tracks density instead of a fixed 40px. DataTable forwards its existing `density` state; per-cell `cellPadding` context threading is gone.
+- **Edge alignment:** cells are `px-ds-04` interior; first/last cells read `--table-edge`, which inherits `--card-spacing` inside a Card — table columns line up with the card's header/footer slots. Standalone tables fall back to 12px.
+- **Header** drops to `text-ds-sm` medium muted — quieter than the data, per the cross-system consensus.
+- **`striped` prop** — opt-in zebra (faintest surface step); hairlines remain the default.
+- **Sweep:** sort-button + expander hover tokens fixed; expanded row is a `surface-base` recess; sticky header bg is `surface-raised`; raw `h-24` empty states replaced with `py-ds-07`.
+- **DataTableCards** (mobile) now `variant="outline"` — a phone screen of stacked shadow cards accumulates lift (make-kit dense-list rule).
+
+Visible default change: standard rows tighten from ~53px to ~37px.

--- a/.changeset/table-footer-selected-hover.md
+++ b/.changeset/table-footer-selected-hover.md
@@ -1,0 +1,9 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Table: footer + selected-hover fixes, rich-cell recipes
+
+- **TableFooter** background was `color-mix(surface-raised 50%)` — invisible on cards (same mis-mapped shadcn `muted/50` family as the row-hover bug). Now a `surface-base` band with a top hairline.
+- **Selected+hover** rows get an explicit step (`data-[state=selected]:hover:bg-accent-4`) — previously the hover and selected classes tied on specificity and stylesheet order decided.
+- **Cell recipes** documented in `table.md` + new `RichCells` / `SelectedRows` stories: user cell (avatar + truncating two-line identity — comfortable density only, per the industry two-line rule), tag group with `+N` overflow, money cells (consistent decimals; negatives never color-only), qualitative-numbers-stay-left, muted em-dash for empty values. Density→avatar mapping: compact = text only, standard = `xs`, comfortable = `xs`/`sm`.

--- a/.changeset/table-row-features.md
+++ b/.changeset/table-row-features.md
@@ -1,0 +1,10 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Table structural features: TableRowLink, TableRowActions, numeric cells, animated + accessible row expansion
+
+- **`TableRowLink`** (`ui/table-row-link`) — whole-row navigation as a **real anchor**: cmd/ctrl+click, middle-click, and "open in new tab" work, and screen readers announce a link — none of which `onClick`-on-row gives. Stretch pseudo-element is anchored to the cell (Safari ignores `position:relative` on `<tr>`) and clipped by the table root's new `overflow-x-clip`. Keyboard focus draws a row-level ring (`has-[[data-slot=row-link]:focus-visible]` on TableRow). `stretch={false}` = title-only link that keeps row text selectable.
+- **`TableRowActions`** — action cluster revealed on row hover with the full a11y contract: opacity reveal (never `display:none`) so buttons stay permanently tabbable, `:focus-within` reveals on keyboard entry, always visible on touch (`pointer-coarse`), and a `persist` prop for always-visible mode. Reveal animates with `duration-fast-01 ease-productive-standard`.
+- **`numeric`** boolean on `TableCell`/`TableHead` — right-align + tabular figures in one prop.
+- **Row expansion (DataTable)** — `aria-expanded` now on the toggle button (was missing), visually-hidden header for the expand column, chevron rotation on motion tokens, and the expanded row animates open/closed (height + opacity, `springs.smooth`) with a `useReducedMotion` self-guard; virtualized tables keep the instant reveal.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,29 @@ This page indexes all breaking changes across `@devalok/shilp-sutra` versions. F
 
 > **Upgrading from &lt; 0.36?** Start here, then read each intermediate version section. Breaking changes stack — skipping versions means stacking migrations.
 
+## v0.45.0 — Card spacing variable + table overhaul (no breaking API changes)
+
+Nothing breaks at the TypeScript level. Two things are worth checking after upgrade:
+
+### Visual: table rows tighten
+
+Standard density rows go from ~53px to ~37px (comfortable ~85px → ~45px) — the density map was re-benchmarked against Carbon/Radix/Polaris. If a screen depended on the old airy rows, pass `density="comfortable"`. Rows also regain their hairline separators (they had been silently lost) and row hover is now actually visible on cards.
+
+### CSS selectors targeting Card/Table internals
+
+Card's per-size literal classes (`px-ds-05b` on slots, `top-ds-05b` on CardAction) are gone — spacing now flows through `--card-spacing`/`--card-gap` CSS variables. Consumer `className` overrides via tw-merge keep working; only hand-written CSS selectors targeting the old class names need to move to the variables:
+
+```diff
+- .my-card .px-ds-05b { … }
++ .my-card { --card-spacing: 24px; }
+```
+
+Table cells similarly moved from `py-ds-03 px-ds-03` literals to `py-(--table-py) px-ds-04` + `--table-edge` on first/last cells.
+
+### New APIs (additive)
+
+`CardBleed`, `CardSection`, `Card orientation="horizontal"`, `StatCard size`, `Table density/striped`, `TableCell/TableHead numeric`, `TableRowActions`, `TableRowLink` (`ui/table-row-link`). StatCard's `footer` now renders behind a full-width rule instead of an inset border — purely visual.
+
 ## v0.44.0 — Card system: gap-model, corner slots, truncation primitive
 
 Three breaking changes (`Card` `accent`/`accentColor` removed, `StatCard` `surface` → `variant`, `ContentCard` deprecated). Everything else is additive.

--- a/packages/core/docs/components/composed/content-card.md
+++ b/packages/core/docs/components/composed/content-card.md
@@ -1,5 +1,7 @@
 # ContentCard
 
+> **DEPRECATED (v0.44.0)** — will be removed in the next major. Compose `Card` + `CardHeader`/`CardTitle`/`CardAction`/`CardContent`/`CardFooter` instead (they cover every ContentCard feature on the gap model). Migration: `headerTitle` → `<CardTitle>`, `headerActions` → `<CardAction>`, `padding` → Card `size`, `footer` → `<CardFooter>`. See MIGRATION.md → v0.44.0.
+
 - Import: @devalok/shilp-sutra/composed/content-card
 - Server-safe: Yes
 - Category: composed

--- a/packages/core/docs/components/ui/card.md
+++ b/packages/core/docs/components/ui/card.md
@@ -7,24 +7,30 @@
 ## Props
     variant: "default" | "elevated" | "outline" | "flat"
     color: "default" | "accent" | "error" | "success" | "warning" | "info" | "neutral" (border accent color)
-    size: "sm" | "md" | "lg" (padding — propagated to CardHeader/CardContent/CardFooter via context)
+    size: "sm" | "md" | "lg" (sets --card-spacing / --card-gap once; container + slots + CardAction + CardBleed all read the pair)
+    orientation: "vertical" (default) | "horizontal" (row layout — media pane + <CardSection> column)
     interactive: boolean (enables hover shadow lift + pointer cursor)
 
 ### CardAction
     placement: "top-right" (default) | "top-left" | "bottom-right" | "bottom-left"
     tuck: boolean (pull a step toward the corner so an icon button's glyph aligns to the content edge)
 
+### CardBleed
+    side: "x" (default) | "top" | "bottom" | "y" | "all" (which card padding to negate; top/bottom/y for direct children — inherit the card radius; x/all for content inside a slot)
+
 ## Compound Components
-    Card (root)
-      CardAction      ← absolutely-positioned corner slot (badge, icon button, menu)
-      CardHeader      ← inherits size from Card context
+    Card (root)         ← owns py + gap via --card-spacing / --card-gap
+      CardBleed         ← escape hatch from the padding (full-bleed media, edge bands)
+      CardAction        ← absolutely-positioned corner slot (badge, icon button, menu)
+      CardHeader        ← px-(--card-spacing) only
         CardTitle
         CardDescription
-      CardContent     ← inherits size from Card context
-      CardFooter      ← inherits size from Card context
+      CardContent       ← px-(--card-spacing) only
+      CardFooter        ← px-(--card-spacing) only
+      CardSection       ← vertical column that re-establishes py + gap (horizontal cards)
 
 ## Defaults
-    variant="default", color="default", size="md"
+    variant="default", color="default", size="md", orientation="vertical"
 
 ## Example
 ```jsx
@@ -38,7 +44,10 @@
 ```
 
 ## Composability
-- **Size cascades through context** — Card's `size` prop sets padding on CardHeader, CardContent, and CardFooter via `CardSizeContext`. Don't set padding classes on sub-components directly; override via `className` if needed.
+- **Size is one CSS variable** — Card's `size` prop assigns `--card-spacing`/`--card-gap`; slots, CardAction corners, and CardBleed negations all read the same pair (no React context). Retune a card with a single override: `className="[--card-spacing:var(--spacing-ds-07)]"`. Never add `p-*` classes to Card or a slot.
+- **Direct children are full-width** — only slots are inset, so a `<Separator />` or tinted band between slots is edge-to-edge for free. Text must live inside a slot; dev builds warn on bare text/`<p>` children.
+- **Full-bleed via `<CardBleed>`** — negates the same variable the padding reads (Radix `Inset` / Polaris `Bleed` equivalent). `side="top"/"bottom"` for cover media as direct children; `side="x"` to escape a slot's inset. Never `x`/`all` on a direct child (overflows).
+- **Horizontal cards** — `orientation="horizontal"` makes the root a padding-less row; wrap the text column in `<CardSection>` to restore the py/gap rhythm; the media pane owns the left edge (`rounded-l-surface overflow-hidden`).
 - **Not a compound state machine** — Card, CardHeader, CardTitle, etc. are purely structural. No open/close state.
 - **Corner slots via `CardAction`:** Pin a badge, icon button, or menu to any corner (`placement`), inset to match the card's content padding. `tuck` pulls an icon button so its glyph (not its padding box) aligns to the content edge. Replaces the removed `accent` decorative bar — composition, not a bespoke prop. Card is `relative` to anchor it.
 - **`color` paints the border, never a stacked rail:** `color` tints the 1px edge (semantic accent/error/success/…). The DS never stacks a border + drop shadow or a colored rail on top (make-kit rule #6 — that reads as an AI tell).
@@ -47,9 +56,16 @@
 
 ## Gotchas
 - Use `interactive` prop for clickable cards — adds hover lift and pointer cursor
-- Don't override CardHeader/CardContent/CardFooter padding via className if you want the size cascade to work — set size on Card instead
+- Don't add padding classes to Card or its slots — override `--card-spacing` instead
+- Bare text as a direct child of Card gets no horizontal inset (wrap it in CardContent); dev builds warn
 
 ## Changes
+### v0.45.0
+- **Changed** Size axis now assigns `--card-spacing`/`--card-gap` CSS variables instead of per-size literal classes; `CardSizeContext` and the per-size slot/corner lookup maps are gone. Rendered spacing is identical (sm 16/8, md 20/12, lg 24/16). Consumer `className` padding overrides on slots keep working via tw-merge; anything targeting the old literal classes (`px-ds-05b` etc.) in CSS selectors must switch to the variables.
+- **Added** `<CardBleed side>` — full-bleed escape hatch that negates `--card-spacing` (cover images, edge bands, in-slot breakouts).
+- **Added** `orientation="horizontal"` + `<CardSection>` — sanctioned horizontal media card layout.
+- **Added** Dev-only warning when Card receives bare text / textual elements as direct children.
+
 ### v0.44.0
 - **BREAKING** Removed `accent` / `accentColor` (the colored edge-bar / left-rail). Use `<CardAction>` for corner content, or `color` for a tinted border. The DS no longer ships a stacked rail (make-kit rule #6).
 - **Added** `<CardAction>` compound — composable corner slot (4 placements, `tuck`).

--- a/packages/core/docs/components/ui/data-table.md
+++ b/packages/core/docs/components/ui/data-table.md
@@ -77,7 +77,7 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 
 **Virtualization:** `virtualRows={true}` enables row virtualization via `@tanstack/react-virtual`. Turn it on for 1000+ row datasets; the scroll container must have a bounded height.
 
-**Density integration:** `defaultDensity="compact"` is the Karm-style dense mode (h-9 rows). DataTableToolbar's density switcher updates this at runtime; the prop sets the initial state only.
+**Density integration:** density is forwarded to `Table`'s `density` prop, which sets `--table-py` (compact 4 / standard 8 / comfortable 12px → rows ≈ 29 / 37 / 45px; header tracks it). DataTableToolbar's density switcher updates this at runtime; the prop sets the initial state only.
 
 ## Gotchas
 - Barrel-isolated since v0.5.0 — must use `@devalok/shilp-sutra/ui/data-table`, NOT the `ui` barrel
@@ -90,6 +90,11 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 - `virtualRows={true}` requires a bounded scroll container — unbounded height silently disables virtualization
 
 ## Changes
+### v0.45.0
+- **Changed** Density now drives Table's `--table-py` variable (rows ≈ 29 / 37 / 45px; was 29 / 53 / 85). Per-cell `cellPadding` threading removed from context.
+- **Fixed** Hover/selected states visible on cards: row/sort-button/expander hover use `surface-raised-hover` (was the invisible `surface-raised`); expanded row is a `surface-base` recess; sticky header bg is `surface-raised`; empty state uses `py-ds-07` (was raw `h-24`).
+- **Changed** Mobile card view composes `<Card size="sm" variant="outline">` (was a hand-rolled 12px bordered box).
+
 ### v0.29.0
 - **Fixed** Controlled selection infinite re-render loop — inline `getRowId` callback caused `onSelectionChange` effect to fire every render, creating a setState cycle with `selectedIds`. Now uses a stable ref for `getRowId`.
 

--- a/packages/core/docs/components/ui/data-table.md
+++ b/packages/core/docs/components/ui/data-table.md
@@ -91,6 +91,8 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 
 ## Changes
 ### v0.45.0
+- **Fixed** Expander a11y per the expando-row spec: `aria-expanded` on the toggle button, visually-hidden "Expand rows" column header; chevron rotation uses `duration-fast-02 ease-productive-standard`.
+- **Added** Expanded-row content animates open/closed (height + opacity via framer, `springs.smooth`), self-guarded with `useReducedMotion` — instant swap for reduced-motion users. Virtualized tables keep the instant reveal (a height animation would fight the virtualizer's measurements).
 - **Changed** Density now drives Table's `--table-py` variable (rows ≈ 29 / 37 / 45px; was 29 / 53 / 85). Per-cell `cellPadding` threading removed from context.
 - **Fixed** Hover/selected states visible on cards: row/sort-button/expander hover use `surface-raised-hover` (was the invisible `surface-raised`); expanded row is a `surface-base` recess; sticky header bg is `surface-raised`; empty state uses `py-ds-07` (was raw `h-24`).
 - **Changed** Mobile card view composes `<Card size="sm" variant="outline">` (was a hand-rolled 12px bordered box).

--- a/packages/core/docs/components/ui/stat-card.md
+++ b/packages/core/docs/components/ui/stat-card.md
@@ -18,6 +18,7 @@
     secondaryLabel: string (below main value, e.g. "of $50,000 target")
     progress: number (0-100, renders thin progress bar below value)
     variant: "default" | "elevated" | "outline" | "flat" (default = ring-in-shadow, no border; elevated = stronger shadow; outline = border, no shadow; flat = filled, no edge) — delegated to Card
+    size: "sm" | "md" (default) | "lg" — delegated to Card's size axis; sm tightens padding to 16px and steps the value down to text-ds-2xl (use for dense KPI rows / narrow stat grids)
     accentStyle: "none" | "icon" | "tint" (none [default]; icon = accent chip around icon; tint = accent surface wash + accent value)
     iconFill: "soft" | "solid" (chip style when accentStyle="icon"; default soft)
     flash: "up" | "down" | "goal" | "record" | "alert" | "live" | { tone, icon } (opt-in entrance flash; requires icon)
@@ -28,7 +29,7 @@
     footer: ReactNode (below card body, e.g. "View details →")
 
 ## Defaults
-    none (all props are optional except value)
+    size="md"; all other props optional except value
 
 ## Example
 ```jsx
@@ -70,6 +71,11 @@
 - `sparkline` needs at least 2 data points to render
 
 ## Changes
+### v0.45.0
+- **Added** `size` prop (`sm | md | lg`, delegated to Card) — `sm` tightens padding and steps the value to `text-ds-2xl` for dense KPI grids.
+- **Changed** Internal rhythm is now flex gap (no margin stacking); `footer` renders behind a full-width rule (divider + CardFooter as direct Card children) instead of an inset `border-t`.
+- **Added** `aria-busy="true"` on the loading skeleton card.
+
 ### v0.44.0
 - **BREAKING** Renamed `surface` → `variant`, widened to a 4-way scale (`default` | `elevated` | `outline` | `flat`). StatCard now composes `<Card>`, so surface, gap-model padding, and elevation all live in one place. Migration: `surface="raised"` → `variant="default"`, `surface="flat"` → `variant="outline"`.
 - **Added** `deltaPlacement` (`"block"` [default] | `"inline"`) — inline rides the value's baseline for compact dashboards.

--- a/packages/core/docs/components/ui/table-row-link.md
+++ b/packages/core/docs/components/ui/table-row-link.md
@@ -1,0 +1,41 @@
+# TableRowLink
+
+- Import: @devalok/shilp-sutra/ui/table-row-link
+- Server-safe: No (uses LinkContext)
+- Category: ui
+
+## Props
+    href: string (required) — navigation target; rendered through the LinkContext Link component (framework router aware)
+    stretch: boolean (default true) — stretch the click target across the whole row via a pseudo-element; pass false for a title-only link that keeps row text selectable
+    ...AnchorHTMLAttributes — target, rel, onClick, aria-label, etc.
+
+## Example
+```jsx
+<TableRow>
+  <TableCell className="relative">
+    <TableRowLink href={`/projects/${id}`}>{name}</TableRowLink>
+  </TableCell>
+  <TableCell><Badge color="success">Active</Badge></TableCell>
+  <TableCell>
+    <TableRowActions>
+      <IconButton className="relative z-[1]" size="xs" variant="ghost" aria-label={`Actions for ${name}`} icon={<IconDots />} />
+    </TableRowActions>
+  </TableCell>
+</TableRow>
+```
+
+## Composability
+- **A real anchor, not a click handler** — cmd/ctrl+click, middle-click, right-click "open in new tab", and screen-reader link announcement all work. Never put `onClick` on a `<tr>` and never add `role="grid"` just for clickable rows.
+- **Placement contract:** lives inside the row's *primary* cell, which must be `className="relative"` — the stretch pseudo-element is anchored to the cell (Safari ignores `position: relative` on `<tr>`) and spans `100vw`; the Table root's `overflow-x-clip` contains it.
+- **Focus:** keyboard focus draws a row-level ring via TableRow's `has-[[data-slot=row-link]:focus-visible]` rule; the anchor suppresses its own outline (stretch mode). `stretch={false}` uses a normal anchor focus ring.
+- **Other interactive elements** in the row (menu buttons, checkboxes, TableRowActions children) must sit above the stretch: `className="relative z-[1]"`.
+- Routes through `LinkContext` — Next.js/React Router consumers get client-side navigation automatically.
+
+## Gotchas
+- The stretched overlay blocks text selection inside the row — use `stretch={false}` (GitHub-style title link) when row text must stay selectable
+- Don't combine with DataTable's `onRowClick` on the same row — one navigation owner per row
+- If a secondary link/button in the row seems unclickable, it's missing `relative z-[1]`
+
+## Changes
+### v0.45.0
+- **Added** Initial release

--- a/packages/core/docs/components/ui/table.md
+++ b/packages/core/docs/components/ui/table.md
@@ -8,6 +8,17 @@
     density: "compact" | "standard" (default) | "comfortable" — sets --table-py (4 / 8 / 12px vertical cell padding → rows ≈ 29 / 37 / 45px); header height tracks it
     striped: boolean (opt-in zebra — even body rows get the faintest surface step; hairline separators remain the default row cue)
 
+### TableCell / TableHead
+    numeric: boolean (right-align + tabular figures; header follows the column. Identifier-numbers — dates, phones, IDs — stay left)
+
+### TableRowActions
+    persist: boolean (always show instead of hover/focus reveal)
+    Reveal is opacity-based: buttons stay in the tab order permanently, appear on row hover AND :focus-within, and are always visible on touch (pointer-coarse). Give the column a visually-hidden header.
+
+### TableRowLink (separate import: ui/table-row-link — client component)
+    href: string (required); stretch: boolean (default true)
+    A real anchor placed in the row's primary cell (`<TableCell className="relative">`), stretched across the row via a pseudo-element — cmd/ctrl+click, middle-click, and context menu work, unlike onClick-on-row. Keyboard focus draws a row-level ring. Other interactive elements in the row need `className="relative z-[1]"`. `stretch={false}` = title-only link (keeps row text selectable).
+
 ## Compound Components
     Table (root <table>)
       TableHeader (<thead>)
@@ -91,6 +102,9 @@ See the `RichCells` story for all of these live.
 
 ## Changes
 ### v0.45.0
+- **Added** `TableRowLink` (ui/table-row-link) — real-anchor whole-row navigation with pseudo-element stretch (Safari-safe: anchored to the cell, clipped by the table's `overflow-x-clip`), row-level focus ring, `stretch={false}` title-only mode.
+- **Added** `TableRowActions` — hover/focus-revealed action cluster (opacity reveal, permanently tabbable, `:focus-within` + touch fallbacks, `persist` mode).
+- **Added** `numeric` prop on TableCell/TableHead — right-align + tabular figures.
 - **Fixed** TableFooter background was `color-mix(surface-raised 50%)` — invisible on cards (same mis-mapped shadcn `muted/50` family as the row hover). Now a `surface-base` band with a top hairline.
 - **Fixed** Selected+hover tie: selected rows get an explicit `hover:bg-accent-4` step (hover and selected previously tied on specificity).
 - **Added** Cell recipes section (user cell, tag overflow, money, empty-dash) + density→avatar mapping; `RichCells` / `SelectedRows` stories.

--- a/packages/core/docs/components/ui/table.md
+++ b/packages/core/docs/components/ui/table.md
@@ -4,6 +4,10 @@
 - Server-safe: Yes
 - Category: ui
 
+## Props
+    density: "compact" | "standard" (default) | "comfortable" — sets --table-py (4 / 8 / 12px vertical cell padding → rows ≈ 29 / 37 / 45px); header height tracks it
+    striped: boolean (opt-in zebra — even body rows get the faintest surface step; hairline separators remain the default row cue)
+
 ## Compound Components
     Table (root <table>)
       TableHeader (<thead>)
@@ -43,8 +47,17 @@
 ## Gotchas
 - Table headers automatically have scope="col" for screen reader navigation
 - For anything beyond trivial display, prefer DataTable — don't rebuild sorting/pagination/selection on top of bare Table
+- Inside a Card, first/last cells inherit `--card-spacing` so edge columns align with the card's slots; standalone tables fall back to 12px edges
+- Numeric columns: add `text-right tabular-nums` (DataTable does this via column meta `align: 'right'`)
 
 ## Changes
+### v0.45.0
+- **Added** `density` prop (`compact | standard | comfortable`) via `--table-py`; header height tracks density instead of a fixed 40px
+- **Added** `striped` prop — opt-in zebra
+- **Changed** Rows regain their hairline separator (`border-b border-surface-border-subtle` — lost in the original port) and hover becomes visible on cards (`hover:bg-surface-raised-hover`, was the invisible `surface-raised`)
+- **Changed** Cells: `px-ds-04` interior, first/last cells read `--table-edge` (= `--card-spacing` inside a Card); header drops to `text-ds-sm` muted
+- **Changed** Default vertical rhythm tightens: standard rows ~53px → ~37px
+
 ### v0.18.0
 - **Added** `TableProps`, `TableRowProps`, `TableCellProps` type exports
 

--- a/packages/core/docs/components/ui/table.md
+++ b/packages/core/docs/components/ui/table.md
@@ -44,6 +44,45 @@
 - **Composes with UI primitives inside cells:** Badge for status pills, Avatar for user cells, IconButton for row actions, StatusDot for state indicators. All server-safe if the table is server-rendered.
 - **TableCaption** renders as HTML `<caption>` — useful for a summary description that screen readers announce before the table content.
 
+## Cell recipes
+
+**Density → content mapping.** Rows grow silently when cell content is taller than the text line; pick content size by density:
+
+| Density | Row target | Avatar | Badge | Notes |
+|---|---|---|---|---|
+| compact | ~29px | none — text only | `xs` | identity = text, no chrome |
+| standard | ~37px | `xs` (24px) | `xs` | **single-line** identity only; an `sm` avatar grows rows to ~49px — don't |
+| comfortable | ~45px | `xs` or `sm` | `xs`/`sm` | the only density for **two-line** identity (name + email) — industry rule (Carbon): two-line content belongs in the tallest rows only |
+
+Rule of thumb (matches Carbon/Setproduct): avatar ≈ row height − 16px of breathing room.
+
+**User cell** (avatar + two-line identity, both lines truncate — use `density="comfortable"`):
+```jsx
+<TableCell>
+  <div className="flex items-center gap-ds-03 min-w-0">
+    <Avatar size="xs"><AvatarFallback>GK</AvatarFallback></Avatar>
+    <div className="min-w-0 leading-ds-tight">
+      <TruncatedText as="p" className="font-medium">Goutham Krishnan</TruncatedText>
+      <TruncatedText as="p" mode="middle" className="text-ds-sm text-surface-fg-muted">goutham@devalok.in</TruncatedText>
+    </div>
+  </div>
+</TableCell>
+```
+
+**Tag group with overflow** — cap visible badges, spill to a muted `+N`; never let badges wrap:
+```jsx
+<div className="flex items-center gap-ds-02">
+  {tags.slice(0, 2).map((t) => <Badge key={t} color="neutral" size="xs">{t}</Badge>)}
+  {tags.length > 2 && <span className="text-ds-sm text-surface-fg-subtle">+{tags.length - 2}</span>}
+</div>
+```
+
+**Money cell** — `text-right tabular-nums` (DataTable: column meta `align: 'right'`). Keep a consistent number of decimal places per column — that's what actually aligns decimals. Negatives: never color alone — pair red with a minus sign or accounting parentheses `(1,500)`.
+**Qualitative numbers stay left** — dates, phone numbers, zip codes, IDs are identifiers, not quantities; only true quantities right-align.
+**Empty value** — muted em-dash, with an accessible label: `<span className="text-surface-fg-subtle" aria-label="No value">—</span>`. Don't leave cells blank.
+
+See the `RichCells` story for all of these live.
+
 ## Gotchas
 - Table headers automatically have scope="col" for screen reader navigation
 - For anything beyond trivial display, prefer DataTable — don't rebuild sorting/pagination/selection on top of bare Table
@@ -52,6 +91,9 @@
 
 ## Changes
 ### v0.45.0
+- **Fixed** TableFooter background was `color-mix(surface-raised 50%)` — invisible on cards (same mis-mapped shadcn `muted/50` family as the row hover). Now a `surface-base` band with a top hairline.
+- **Fixed** Selected+hover tie: selected rows get an explicit `hover:bg-accent-4` step (hover and selected previously tied on specificity).
+- **Added** Cell recipes section (user cell, tag overflow, money, empty-dash) + density→avatar mapping; `RichCells` / `SelectedRows` stories.
 - **Added** `density` prop (`compact | standard | comfortable`) via `--table-py`; header height tracks density instead of a fixed 40px
 - **Added** `striped` prop — opt-in zebra
 - **Changed** Rows regain their hairline separator (`border-b border-surface-border-subtle` — lost in the original port) and hover becomes visible on cards (`hover:bg-surface-raised-hover`, was the invisible `surface-raised`)

--- a/packages/core/llms-quick.txt
+++ b/packages/core/llms-quick.txt
@@ -186,10 +186,11 @@ Components with the two-axis system: **Button, Badge, Alert, Banner, Progress, S
 - **Text**: variant(heading-2xl..xs, body-lg..xs, label-lg..xs, caption, overline, code). Polymorphic `as` prop.
 - **Stack**: direction(vertical|horizontal) gap(SpacingToken) align/justify/wrap.
 - **Container**, **Separator**.
-- **Card**: variant(default|elevated|outline|flat) accent(left|top|right|bottom). Compound: CardHeader > CardTitle, CardDescription; CardContent; CardFooter.
+- **Card**: variant(default|elevated|outline|flat) color size(sm|md|lg — one CSS var pair: --card-spacing/--card-gap) orientation(vertical|horizontal) interactive. Compound: CardBleed(side — full-bleed), CardAction(corner slot), CardHeader > CardTitle, CardDescription; CardContent; CardFooter; CardSection(horizontal). Text must live in a slot; never p-* on Card. (accent/accentColor removed 0.44.)
+- **Table**: density(compact|standard|comfortable) striped + TableHead/TableCell `numeric`; TableRowActions(hover/focus-revealed row actions); TableRowLink(real-anchor row navigation, import ui/table-row-link). Rows have hairline separators; inside Card place Table as direct child (edge cells align with slots).
 - **Badge**: variant(subtle|solid|outline|soft) color(default|accent|error|success|warning|info|neutral + 7 categories + custom) size(xs|sm|md|lg) + onClick, onDismiss, dot, startIcon, endIcon, truncate. Compound: Badge.Indicator, Badge.Group.
 - **Avatar**: size(xs|sm|md|lg|xl) shape(circle|square|rounded) status, ring, badge.
-- **Spinner**, **Progress** (autoColor!), **Skeleton**, **StatCard**, **StatusDot**, **ColorSwatch**.
+- **Spinner**, **Progress** (autoColor!), **Skeleton**, **StatCard** (size sm|md|lg for density; variant delegated to Card), **StatusDot**, **ColorSwatch**.
 - **Alert**: variant(subtle|solid|outline) color(info|success|warning|error|neutral) + title, onDismiss. Single component, not compound.
 - **Banner**: color(...) + actions, onDismiss. Mobile-responsive.
 - **Toast**: imperative `toast.success('msg')` / `.error/.warning/.info/.loading/.message/.promise/.upload/.custom`. Requires `<Toaster />`.

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -41,6 +41,28 @@ Paste the snippet *after* `@import "@devalok/shilp-sutra/css";` in the global st
 
 The repo URL for these files is `https://github.com/devalok-design/shilp-sutra/tree/main/packages/core/docs/recipes`. Consumer projects should also have an `AGENTS.md` at their root with the rules above pre-loaded — read that first if it exists.
 
+## NEW (v0.45.0)
+
+- **Card spacing = one CSS variable.** `size` assigns `--card-spacing`/`--card-gap`; container, slots, CardAction corners, and CardBleed all read the pair. Rendered spacing unchanged (sm 16/8, md 20/12, lg 24/16). Retune any card with one class: `[--card-spacing:var(--spacing-ds-07)]`. `CardSizeContext` is gone — slots work by CSS inheritance.
+- **`<CardBleed side>`** (`x | top | bottom | y | all`) — full-bleed escape hatch (Radix Inset / Polaris Bleed equivalent). `top`/`bottom` inherit the card radius for cover media; `x` escapes a slot's inset. Direct children of Card are already full-width — never `x`/`all` there.
+- **`<Card orientation="horizontal">` + `<CardSection>`** — horizontal media cards: media pane owns the left edge, CardSection restores py/gap rhythm.
+- **StatCard `size`** (`sm|md|lg`) — `sm` = 16px padding + 2xl value for dense KPI grids; internal rhythm now flex-gap; `footer` renders behind a full-width rule.
+- **Table overhaul.** Rows regained hairline separators (`border-b border-surface-border-subtle` — lost in the original port); hover fixed to `surface-raised-hover` (was the invisible `surface-raised` — same for sort button, expander, expanded row, TableFooter); `density` prop (rows ≈29/37/45px, header tracks it); `striped` opt-in zebra; first/last cells read `--table-edge` = `--card-spacing` inside a Card (columns align with card slots); header quieter (`text-ds-sm` muted); explicit selected+hover step (accent-4).
+- **`<TableRowLink href stretch?>`** (`ui/table-row-link`, client) — real-anchor whole-row navigation: cmd+click / middle-click / context menu / SR link semantics work. Primary cell needs `className="relative"`; other row controls need `relative z-[1]`; `stretch={false}` = title-only link. Never `onClick` on a row.
+- **`<TableRowActions persist?>`** — hover/focus-revealed action cluster: opacity reveal (permanently tabbable), `:focus-within` reveal, always visible on touch. Visually-hidden column header required.
+- **`numeric`** on TableCell/TableHead — right + tabular figures. Identifier-numbers (dates, IDs, phones) stay left; negatives never color-only.
+- **Row expansion** — `aria-expanded` on the toggle button, animated open/close (height+opacity, reduced-motion self-guarded).
+- **DataTableCards** (mobile) compose `<Card size="sm" variant="outline">`.
+- **Cell recipes** in `docs/components/ui/table.md` — user cell (two-line identity = `comfortable` density only; avatar ≈ row height − 16px), tag `+N` overflow, money conventions, em-dash empties.
+
+## CHANGES (v0.44.0) — backfilled; this file previously missed the 0.44 entry
+
+- **BREAKING: Card `accent`/`accentColor` removed** — use `color` (tinted 1px border) or `<CardAction>` (corner badge/menu slot, 4 placements + `tuck`). See MIGRATION.md → v0.44.0.
+- **BREAKING: StatCard `surface` → `variant`** — StatCard composes Card; surface is Card's 4-way `variant`.
+- **Card gap model** — container owns vertical padding + inter-slot gap; slots own horizontal inset only. Adding/removing a slot can't unbalance the bottom edge. Never add `p-*`/`pt-*` to Card or slots.
+- **ContentCard deprecated** — compose Card slots; removal next major.
+- **`<TruncatedText>`** (`ui/truncated-text`) — `mode: end|clamp|middle`, tooltip-on-truncation, accessible full name.
+
 ## NEW (v0.42.0)
 
 - **Figma Make kit.** 26 guideline files at `node_modules/@devalok/shilp-sutra/make-kit/` (top-level `Guidelines.md` + `setup.md`, eight `foundations/*.md`, sixteen `components/*.md`). Subpath exports `@devalok/shilp-sutra/make-kit` → `Guidelines.md`, `/make-kit/*` → individual files. Used by Figma Make to generate apps + prototypes against the DS. Setup walkthrough: https://shilp-sutra.devalok.in/figma-make. Public npm registry; cross-org sharing not supported by Figma — each consumer org self-registers. Pin to a specific npm version; no auto-update flow yet. Make kits need Organization / Enterprise Figma plan; Free + Pro can still install the package directly in React projects.
@@ -313,7 +335,7 @@ Same pattern for `border-surface-*`, `text-surface-*`, `ring-surface-*`.
 
 ## CHANGES (v0.16.0)
 - **DataTable server-side features**: `onSort` callback (manual sorting), `pagination` prop (server-side pagination with page/total/onPageChange), `selectedIds` + `selectableFilter` (controlled selection), `loading` shimmer, `emptyState` ReactNode, `singleExpand`, `stickyHeader`, `onRowClick`, `bulkActions` floating bar
-- **DataTable display**: `density?: 'compact' | 'standard' | 'comfortable'` (compact=4px padding, standard=16px, comfortable=32px). `toolbar?: boolean` (column visibility + density + export controls). Column `meta: { align: 'right' }` for numeric columns (auto-applies text-right tabular-nums). Column `meta: { hideBelow: 'md' }` for responsive column hiding (hidden below breakpoint). `selectableFilter?: (row) => boolean` to disable selection on certain rows (e.g. only PENDING rows selectable).
+- **DataTable display**: `density?: 'compact' | 'standard' | 'comfortable'` (vertical cell padding 4/8/12px → rows ≈29/37/45px; forwarded to Table's `--table-py`, header height tracks it). `toolbar?: boolean` (column visibility + density + export controls). Column `meta: { align: 'right' }` for numeric columns (auto-applies text-right tabular-nums). Column `meta: { hideBelow: 'md' }` for responsive column hiding (hidden below breakpoint). `selectableFilter?: (row) => boolean` to disable selection on certain rows (e.g. only PENDING rows selectable).
 - **ActivityFeed**: New composed component — `@devalok/shilp-sutra/composed/activity-feed` — vertical timeline with colored dots, actor avatars, expandable detail, compact mode, load more
 - EmptyState: `iconSize?: 'sm' | 'md' | 'lg'` prop for icon dimension control
 - BottomNavbar: `badge?: number` on BottomNavItem for notification counts (99+ cap)
@@ -624,12 +646,12 @@ NOTIFICATION SELECTION GUIDE:
 - Badge: variant(subtle|solid|outline|soft) color(default|accent|error|success|warning|info|neutral + 7 category colors + custom) size(xs|sm|md|lg) + onClick, onDismiss, selected, disabled, dot, startIcon, endIcon, maxWidth, circle, asChild. Compound: Badge.Indicator(count, max, dot, color, invisible, showZero, placement, children), Badge.Group(max, gap, size, onOverflowClick, children). Custom colors: color="custom" + style={{'--badge-color':'#hex'}}. Grain-ready (has relative/overflow-hidden/isolate).
 - Chip: DEPRECATED — Use `<Badge onClick={...}>` instead. Chip wrapper maps label prop to children for backward compat.
 - Avatar: size(xs|sm|md|lg|xl) shape(circle|square|rounded) status?(AvatarStatus) ring?('lead'|'admin'|'client') badge?(number|'dot'|ReactNode) loading?(boolean) > AvatarImage + AvatarFallback(colorSeed?). Types: AvatarStatus = 'online'|'offline'|'busy'|'away', AvatarRing = 'none'|'lead'|'admin'|'client'. Fallback colors are deterministic from name hash (8 categorical). Online dot pulses. Badge pops in with MotionPop.
-- Card: variant(default|elevated|outline|flat) interactive(boolean) accent?(left|top|right|bottom) accentColor?(default|secondary|error|success|warning|info) > CardHeader > CardTitle, CardDescription; CardContent; CardFooter
-- Table > TableHeader > TableRow > TableHead; TableBody > TableRow > TableCell; TableFooter; TableCaption
+- Card: variant(default|elevated|outline|flat) color(default|accent|error|success|warning|info|neutral) size(sm|md|lg — assigns --card-spacing/--card-gap CSS vars; retune with className="[--card-spacing:var(--spacing-ds-07)]") orientation(vertical|horizontal) interactive(boolean) > CardBleed(side: x|top|bottom|y|all — full-bleed escape hatch; x only INSIDE slots), CardAction(placement, tuck — corner overlay), CardHeader > CardTitle, CardDescription; CardContent; CardFooter; CardSection (rhythm column for horizontal cards). Direct children span full width (dividers/bands free) — text MUST live in a slot (dev warning otherwise). NEVER p-* on Card/slots. Removed in 0.44: accent/accentColor.
+- Table: density(compact|standard|comfortable — rows ≈29/37/45px via --table-py) striped(boolean, opt-in zebra) > TableHeader > TableRow > TableHead(numeric?); TableBody > TableRow > TableCell(numeric? — right + tabular-nums); TableFooter; TableCaption; TableRowActions(persist? — hover/focus-revealed row actions, permanently tabbable); TableRowLink(href, stretch — SEPARATE import ui/table-row-link, client-only) — real-anchor whole-row navigation (never onClick on a row). Inside a Card, place Table as a direct child: edge cells inherit --card-spacing and align with card slots.
 - Text: variant(TextVariant) as(element). Type: TextVariant = 'heading-2xl' | 'heading-xl' | 'heading-lg' | 'heading-md' | 'heading-sm' | 'heading-xs' | 'body-lg' | 'body-md' | 'body-sm' | 'body-xs' | 'label-lg' | 'label-md' | 'label-sm' | 'label-xs' | 'caption' | 'overline'
 - Code: variant(inline|block)
 - Skeleton: variant(rectangle|circle|text) animation(pulse|shimmer|none)
-- StatCard: title/label, value, delta, icon, prefix, suffix, comparisonLabel, secondaryLabel, progress, sparkline, onClick, href, accent(default|success|warning|error|info), footer
+- StatCard: title/label, value, delta{value,direction}, deltaPlacement(block|inline), icon, prefix, suffix, comparisonLabel, secondaryLabel, progress, sparkline, onClick, href, footer (renders behind a full-width rule), variant(default|elevated|outline|flat — delegated to Card), size(sm|md|lg — sm for dense KPI grids, value steps to 2xl), accentStyle(none|icon|tint), iconFill(soft|solid), flash(up|down|goal|record|alert|live|{tone,icon}), flashSpeed, loading. Removed in 0.43/0.44: accent rail, surface prop.
 - ColorSwatch: color(CSS string) size(sm|md|lg) shape(circle|square|rounded) ring(boolean) — for dynamic runtime colors
 - StatusDot: status(healthy|warning|critical|neutral|inactive) size(sm|md|lg) pulse?(boolean, default true for healthy) label?(string)
 - ProgressRing: value(number) max?(100) size(sm|md|lg) color(default|success|warning|error|info) showValue?(boolean) label?(string). Also: MultiProgressRing for concentric Activity Ring style
@@ -681,7 +703,7 @@ Import: `@devalok/shilp-sutra/ui/chat`
 - PageHeader: title, subtitle, breadcrumbs[], actions(ReactNode)
 - AvatarGroup: users(AvatarUser[]), max?(number), size?(xs|sm|md|lg|xl), showTooltip?, borderColor?('surface-base'|'surface-raised'), onOverflowClick?(), renderAvatar?((user,index)=>ReactNode), expandDirection?('left'|'right'), expandAmount?('compact'|'default'|'wide'). Type: AvatarUser = { name, image?, ring?, indicator?('lead'|'admin'|ReactNode) }. GPU-composited hover expand via translateX. Use expandDirection="left" for right-aligned groups. indicator renders a small dot on avatar: 'lead'=warning-9, 'admin'=accent-9, or custom ReactNode.
 - StatusBadge: DISCRIMINATED UNION — pass status OR color, not both. status(active|pending|approved|rejected|completed|blocked|in-progress|review|cancelled|draft) color(success|warning|error|info|neutral) size(sm|md) onClick?(() => void, renders as button with auto chevron-down icon) icon?(ReactNode, custom trailing icon)
-- ContentCard: variant(default|outline|ghost) padding(default|compact|spacious|none)
+- ContentCard: DEPRECATED (0.44) — use Card + CardHeader/CardContent/CardFooter/CardAction slots. Removed next major.
 - EmptyState: icon(ReactNode or ComponentType), title(required), description, action(ReactNode), compact
 - PriorityIndicator: priority(Priority) display(compact|full). Type: Priority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT' | 'low' | 'medium' | 'high' | 'urgent'
 - SimpleTooltip: wraps Tooltip compound into single component

--- a/packages/core/make-kit/components/card.md
+++ b/packages/core/make-kit/components/card.md
@@ -6,18 +6,20 @@ The default container for any panel-style content that sits **on** the page.
 import {
   Card,
   CardAction,
+  CardBleed,
   CardHeader,
   CardTitle,
   CardDescription,
   CardContent,
   CardFooter,
+  CardSection,
 } from '@devalok/shilp-sutra/ui/card'
 ```
 
 ## When to use
 
 - Any rectangular region that reads as a discrete unit on the page: dashboards widgets, list items, marketing feature blocks.
-- Need built-in header / actions / footer slots? Use `<ContentCard>` (composed wrapper).
+- Header / actions / footer are built in as slots (`CardHeader`, `CardAction`, `CardFooter`) — don't reach for a wrapper. (`<ContentCard>` is deprecated; use Card slots.)
 - Need just a tinted region with no card affordance? Use a `<div className="bg-surface-raised">` (rare; usually Card is right).
 
 Card renders on `surface-raised` with `shadow-raised`. **Never** override its background or border.
@@ -38,27 +40,62 @@ Card renders on `surface-raised` with `shadow-raised`. **Never** override its ba
 | `default` (default) | Standard border. |
 | `accent`, `error`, `success`, `warning`, `info`, `neutral` | Border picks up the semantic color at step-7. Use to signal status without filling the whole card. |
 
-## Sizes (padding cascade)
+## Sizes (one CSS variable)
 
-`size` on Card propagates to `CardHeader`, `CardContent`, `CardFooter` via React context:
+`size` sets `--card-spacing` / `--card-gap` once on the root. The container reads them for its
+vertical padding + inter-slot gap; every slot reads `--card-spacing` for its horizontal inset;
+`CardAction` corners and `CardBleed` negations read the same variable.
 
-| Size | Default padding |
-|---|---|
-| `sm` | `ds-04` (12 px) |
-| `md` (default) | `ds-05` (16 px) |
-| `lg` | `ds-07` (32 px) |
+| Size | `--card-spacing` | `--card-gap` |
+|---|---|---|
+| `sm` | `ds-05` (16 px) | `ds-03` (8 px) |
+| `md` (default) | `ds-05b` (20 px) | `ds-04` (12 px) |
+| `lg` | `ds-06` (24 px) | `ds-05` (16 px) |
 
-Override on a sub-component via `className` only if absolutely necessary — it breaks the cascade.
+To retune a single card, override the variable — never add `p-*`/`pt-*` classes:
+
+```tsx
+<Card className="[--card-spacing:var(--spacing-ds-07)]">…</Card>
+```
 
 ## Compound shape
 
 ```
-Card (root)
-  CardHeader      ← inherits size from Card
+Card (root)              ← owns py + gap (vertical rhythm)
+  CardBleed side="top"   ← optional full-bleed media (negates the card padding)
+  CardHeader             ← owns px only
     CardTitle
     CardDescription
-  CardContent     ← inherits size from Card
-  CardFooter      ← inherits size from Card
+  CardContent            ← owns px only
+  CardFooter             ← owns px only
+  CardAction             ← absolute corner overlay
+```
+
+Direct children of Card span its **full width** (only slots are inset). A `<Separator />` or a
+tinted band placed between slots is edge-to-edge for free. The flip side: **text must live inside
+a slot** — a bare `<p>` as a direct child gets no horizontal inset (dev builds warn).
+
+### CardBleed (escape the padding)
+
+| Prop | Type | Notes |
+|---|---|---|
+| `side` | `'x'` (default) `\| 'top' \| 'bottom' \| 'y' \| 'all'` | Which card padding to negate. `top`/`bottom`/`y` are for **direct children** (cover images, edge bands) and inherit the card radius. `x`/`all` are for content **inside a slot**. Never use `x`/`all` on a direct child — it will overflow. |
+
+### Horizontal cards
+
+`orientation="horizontal"` turns the root into a padding-less row; put the media pane first and
+wrap the text column in `<CardSection>`, which re-establishes py + gap from the same variables:
+
+```tsx
+<Card orientation="horizontal">
+  <div className="w-28 shrink-0 overflow-hidden rounded-l-surface">
+    <img className="h-full w-full object-cover" src={thumb} alt="" />
+  </div>
+  <CardSection>
+    <CardHeader><CardTitle>Title</CardTitle></CardHeader>
+    <CardFooter>meta</CardFooter>
+  </CardSection>
+</Card>
 ```
 
 ## Other props
@@ -152,6 +189,7 @@ Card (root)
 - **Never** `bg-surface-base` on a Card — cards sit on `surface-raised`. The pre-publish audit rejects this.
 - **Never** combine `border-*` + `shadow-*` on a Card. Pick one (Card already does — don't override).
 - **Use `interactive` + `onClick` + `aria-label`** for clickable cards. Don't wrap a Card in a `<button>` — broken nesting.
-- **`size` on Card** drives sub-component padding. Don't set padding on `CardContent` directly.
-- **Don't stack `default` cards inside another `default` card.** The nested one should be `flat` or `outline`.
-- For row-style content (avatar + title + meta + actions), prefer `<ContentCard>` from `/composed/content-card` — it bundles the slots.
+- **`size` on Card** drives all spacing via `--card-spacing`. Never set `p-*` on Card or a slot — override the variable if a one-off is truly needed.
+- **Full-bleed** media/dividers use `<CardBleed>` (or plain direct children for full-width strips) — never negative-margin hacks.
+- **Don't stack `default` cards inside another `default` card.** The nested one should be `flat` or `outline`, or better, a `bg-surface-base` recess.
+- For row-style content (avatar + title + meta + actions), compose Card slots — `<ContentCard>` is deprecated and will be removed next major.

--- a/packages/core/make-kit/components/table.md
+++ b/packages/core/make-kit/components/table.md
@@ -12,7 +12,9 @@ import {
   TableHead,
   TableCell,
   TableCaption,
+  TableRowActions,
 } from '@devalok/shilp-sutra/ui/table'
+import { TableRowLink } from '@devalok/shilp-sutra/ui/table-row-link' // client-only
 ```
 
 ## When to use
@@ -39,7 +41,19 @@ Table (<table>)
       TableCell
 ```
 
-Each component is a thin semantic wrapper — no props beyond standard HTML attributes plus `className`.
+## Props
+
+| Component | Prop | Values | Notes |
+|---|---|---|---|
+| `Table` | `density` | `compact` \| `standard` (default) \| `comfortable` | Rows ≈ 29 / 37 / 45 px via `--table-py`; header height tracks it |
+| `Table` | `striped` | boolean | Opt-in zebra. Hairline separators are the default row cue — stripe only very wide/dense tables |
+| `TableCell` / `TableHead` | `numeric` | boolean | Right-align + tabular figures. Quantities only — dates/phones/IDs stay left |
+| `TableRowActions` | `persist` | boolean | Actions always visible instead of hover/focus reveal |
+| `TableRowLink` | `href`, `stretch` | string, boolean (default true) | Real-anchor whole-row navigation; `stretch={false}` = title-only link |
+
+Everything else is a thin semantic wrapper over standard HTML attributes plus `className`.
+
+**Density → cell content.** Rows grow silently when content is taller than the text line: `compact` = text only, `standard` = `Avatar size="xs"` max + single-line identity, `comfortable` = the only density for two-line identity (name + email).
 
 ## Examples
 
@@ -104,22 +118,23 @@ Each component is a thin semantic wrapper — no props beyond standard HTML attr
 </Table>
 ```
 
-**Row actions (IconButton in last cell):**
+**Row actions (hover/focus-revealed via TableRowActions):**
 ```tsx
 <Table>
   <TableHeader>
     <TableRow>
       <TableHead>File</TableHead>
-      <TableHead>Size</TableHead>
-      <TableHead className="w-12" />
+      <TableHead numeric>Size</TableHead>
+      <TableHead className="w-12"><span className="sr-only">Actions</span></TableHead>
     </TableRow>
   </TableHeader>
   <TableBody>
     {files.map((f) => (
       <TableRow key={f.id}>
         <TableCell>{f.name}</TableCell>
-        <TableCell>{formatFileSize(f.size)}</TableCell>
+        <TableCell numeric>{formatFileSize(f.size)}</TableCell>
         <TableCell>
+          <TableRowActions>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <IconButton icon={<Icon icon={IconDots} />} variant="ghost" size="sm" aria-label="Actions" />
@@ -130,12 +145,32 @@ Each component is a thin semantic wrapper — no props beyond standard HTML attr
               <DropdownMenuItem onSelect={() => remove(f)}>Delete</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          </TableRowActions>
         </TableCell>
       </TableRow>
     ))}
   </TableBody>
 </Table>
 ```
+
+`TableRowActions` reveals on row hover AND keyboard focus (buttons stay permanently tabbable — opacity reveal, never `display:none`); always visible on touch. Pass `persist` to keep actions always visible. Give the column a visually-hidden header.
+
+**Whole-row navigation (TableRowLink — client component):**
+```tsx
+<TableRow>
+  <TableCell className="relative">
+    <TableRowLink href={`/projects/${p.id}`}>{p.name}</TableRowLink>
+  </TableCell>
+  <TableCell><Badge color="success">Active</Badge></TableCell>
+  <TableCell>
+    <TableRowActions>
+      <IconButton className="relative z-[1]" size="xs" variant="ghost" aria-label={`Actions for ${p.name}`} icon={<Icon icon={IconDots} />} />
+    </TableRowActions>
+  </TableCell>
+</TableRow>
+```
+
+A real anchor stretched across the row — cmd/ctrl+click, middle-click, and "open in new tab" work. The primary cell must be `className="relative"`; other interactive elements in the row need `className="relative z-[1]"`. **Never** put `onClick` on a `<TableRow>` for navigation. Trade-off: the stretch blocks text selection — `stretch={false}` gives a title-only link.
 
 **Inside a Card:**
 ```tsx
@@ -164,7 +199,7 @@ Each component is a thin semantic wrapper — no props beyond standard HTML attr
 </Card>
 ```
 
-When inside a `<Card>`, the Table's surrounding padding comes from `CardContent`. Don't add extra padding on the Table.
+Better: for edge-to-edge rows (borders and hover running the full card width), place the Table as a **direct child of Card** instead of inside `CardContent` — first/last cells automatically pad with `var(--card-spacing)` so columns align with the card's header/footer slots. Use `CardContent` wrapping only when the table should stay inset.
 
 **Server-rendered table (RSC):**
 ```tsx
@@ -212,4 +247,7 @@ See `foundations/typography.md` for the body / label variants inside cells, `fou
 - For wide tables on mobile, wrap in an `overflow-x-auto` container. Don't try to make a Table responsive via column stacking — switch to a card list on small viewports.
 - Don't style cell text with raw Tailwind palette utilities. Use `text-fg-muted` from `foundations/color.md`.
 - Compose with Badge for status, Avatar for users, IconButton for row actions. Don't invent new primitives per table.
-- Keep TableCell content single-line where possible — multi-line cells make scanning hard. Use `<Stack>` only when each row genuinely needs two lines.
+- Keep TableCell content single-line where possible — multi-line cells make scanning hard. Two-line identity cells (name + email) require `density="comfortable"`.
+- Quantitative columns get `numeric` (right + tabular figures). Identifier-numbers (dates, phones, IDs) stay left. Negatives: never color alone — pair with a minus sign or parentheses.
+- Row navigation = `<TableRowLink>` (real anchor), never `onClick` on the row. Row actions = `<TableRowActions>` with a visually-hidden column header.
+- Empty cells get a muted em-dash with `aria-label`, never blank: `<span className="text-fg-muted" aria-label="No value">—</span>`.

--- a/packages/core/make-kit/foundations/spacing.md
+++ b/packages/core/make-kit/foundations/spacing.md
@@ -37,7 +37,9 @@ If you need a *fourth* tier (e.g. between heading and body inside one group), us
 
 ```tsx
 // Padding
-<Card className="p-ds-05">…</Card>          // inside-card spacing
+// Card manages its own padding via the size prop — NEVER add p-* to a Card
+// (it fights the gap model). Use size="sm" | "md" | "lg" instead.
+<Card size="sm">…</Card>                    // tighter card
 <div className="px-ds-07 py-ds-09">…</div>  // page region
 
 // Gaps

--- a/packages/core/make-kit/foundations/surfaces.md
+++ b/packages/core/make-kit/foundations/surfaces.md
@@ -97,7 +97,7 @@ In dark mode the kit lightens surfaces with elevation (so `surface-overlay` is *
     …
   </aside>
   <main className="bg-surface-base p-ds-07">
-    <Card className="bg-surface-raised shadow-raised p-ds-05">  {/* Card */}
+    <Card>  {/* Card — brings its own surface, shadow, and padding (never add p-*) */}
       …
       <Dialog>
         <DialogContent className="bg-surface-overlay shadow-overlay">

--- a/packages/core/src/composed/Introduction.mdx
+++ b/packages/core/src/composed/Introduction.mdx
@@ -28,7 +28,7 @@ import { PageHeader, DatePicker, RichTextEditor } from '@devalok/shilp-sutra/com
 
 | Component | Description |
 |-----------|-------------|
-| **ContentCard** | Styled card with outline, elevated, and interactive variants |
+| **ContentCard** | ⚠ Deprecated (0.44) — use `Card` + slots from `ui/card`; removed next major |
 | **EmptyState** | Placeholder with icon, title, description, and action button |
 | **PageHeader** | Page title bar with breadcrumbs and action buttons |
 | **PageSkeletons** | Pre-built full-page skeleton layouts for common page types |

--- a/packages/core/src/shell/notification-preferences.tsx
+++ b/packages/core/src/shell/notification-preferences.tsx
@@ -153,7 +153,7 @@ const NotificationPreferences = React.forwardRef<HTMLDivElement, NotificationPre
   return (
     <>
       <Card ref={ref} className={className} {...(props as Omit<typeof props, 'color'>)}>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-ds-04">
+        <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle className="text-ds-md font-semibold">
             Notification Preferences
           </CardTitle>

--- a/packages/core/src/ui/__tests__/data-table-integration.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-integration.test.tsx
@@ -588,7 +588,10 @@ describe('DataTable — singleExpand', () => {
     const expandButtonsAfter = screen.getAllByLabelText('Expand row')
     await user.click(expandButtonsAfter[0])
     expect(screen.getByTestId('detail-Bob Jones')).toBeInTheDocument()
-    expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument()
+    // collapse is animated (AnimatePresence exit) — wait for unmount
+    await waitFor(() =>
+      expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument(),
+    )
   })
 
   it('collapsing the same row works in singleExpand mode', async () => {
@@ -608,9 +611,11 @@ describe('DataTable — singleExpand', () => {
     await user.click(expandButtons[0])
     expect(screen.getByTestId('detail-Alice Smith')).toBeInTheDocument()
 
-    // Collapse Alice
+    // Collapse Alice — animated exit, wait for unmount
     await user.click(screen.getByLabelText('Collapse row'))
-    expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument(),
+    )
   })
 
   it('multiple rows can expand without singleExpand', async () => {

--- a/packages/core/src/ui/__tests__/data-table-integration.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-integration.test.tsx
@@ -647,7 +647,8 @@ describe('DataTable — stickyHeader', () => {
     expect(thead).toHaveClass('sticky')
     expect(thead).toHaveClass('top-0')
     expect(thead).toHaveClass('z-10')
-    expect(thead).toHaveClass('bg-surface-base')
+    // raised, not base — the sticky bar must match the card surface the table lives on
+    expect(thead).toHaveClass('bg-surface-raised')
   })
 
   it('does not add sticky classes when stickyHeader is false', () => {

--- a/packages/core/src/ui/card.stories.tsx
+++ b/packages/core/src/ui/card.stories.tsx
@@ -2,10 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import {
   Card,
   CardAction,
+  CardBleed,
   CardContent,
   CardDescription,
   CardFooter,
   CardHeader,
+  CardSection,
   CardTitle,
 } from './card'
 import { Badge } from './badge'
@@ -61,7 +63,7 @@ export const Interactive: Story = {
 export const Simple: Story = {
   render: () => (
     <Card className="w-[350px]">
-      <CardContent className="pt-ds-06">
+      <CardContent>
         <p className="text-ds-sm">A simple card with only content, no header or footer.</p>
       </CardContent>
     </Card>
@@ -161,5 +163,79 @@ export const WithCornerAction: Story = {
         </CardAction>
       </Card>
     </div>
+  ),
+}
+
+export const FullBleedMedia: Story = {
+  name: 'CardBleed (full-bleed media + bands)',
+  render: () => (
+    <div className="flex flex-wrap gap-ds-05">
+      <Card className="w-[280px]">
+        <CardBleed side="top">
+          <div className="h-24 bg-linear-to-br from-accent-9 to-accent-11" />
+        </CardBleed>
+        <CardHeader>
+          <CardTitle>Cover image</CardTitle>
+          <CardDescription>side=&quot;top&quot; — touches three edges, inherits the radius.</CardDescription>
+        </CardHeader>
+      </Card>
+
+      <Card className="w-[280px]">
+        <CardHeader>
+          <CardTitle>Storage plan</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CardBleed>
+            <div className="bg-accent-2 px-(--card-spacing) py-ds-03 text-ds-sm text-accent-11">
+              90% of quota used — inline band via side=&quot;x&quot;.
+            </div>
+          </CardBleed>
+        </CardContent>
+        <CardContent>
+          <p className="text-ds-sm text-surface-fg-muted">
+            Note: direct children of Card already span the full width — a divider or band
+            placed between slots needs no bleed at all. side=&quot;x&quot; is only for escaping
+            a slot&apos;s inset.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  ),
+}
+
+export const Horizontal: Story = {
+  name: 'Horizontal (media pane + CardSection)',
+  render: () => (
+    <Card orientation="horizontal" className="w-[420px]">
+      <div className="w-28 shrink-0 overflow-hidden rounded-l-surface">
+        <div className="h-full min-h-24 bg-linear-to-br from-accent-9 to-info-9" />
+      </div>
+      <CardSection>
+        <CardHeader>
+          <CardTitle>Field notes — panchang engine</CardTitle>
+          <CardDescription>Blog draft · 6 min read</CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Badge color="neutral" size="xs">Draft</Badge>
+        </CardFooter>
+      </CardSection>
+    </Card>
+  ),
+}
+
+export const SpacingOverride: Story = {
+  name: 'One-variable spacing override',
+  render: () => (
+    <Card className="w-[350px] [--card-spacing:var(--spacing-ds-07)] [--card-gap:var(--spacing-ds-05)]">
+      <CardHeader>
+        <CardTitle>Hero card</CardTitle>
+        <CardDescription>
+          Padding, slot inset, and CardAction corners all retune from one override.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-ds-sm">className=&quot;[--card-spacing:var(--spacing-ds-07)]&quot;</p>
+      </CardContent>
+    </Card>
   ),
 }

--- a/packages/core/src/ui/card.test.tsx
+++ b/packages/core/src/ui/card.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect,it } from 'vitest'
 
 import { describeConformance } from '../test-utils/conformance'
-import { Card, CardAction, CardContent, CardFooter,CardHeader } from './card'
+import { Card, CardAction, CardBleed, CardContent, CardFooter,CardHeader, CardSection } from './card'
 
 describeConformance('Card', (props) => <Card {...props}>Content</Card>, {
   variants: ['default', 'elevated', 'outline', 'flat'],
@@ -16,7 +16,7 @@ describe('Card', () => {
     expect(screen.getByText('Content')).toBeInTheDocument()
   })
 
-  it('uses the gap model — flex column container owns vertical rhythm, no per-slot py', () => {
+  it('uses the variable gap model — container owns py/gap via --card-spacing/--card-gap', () => {
     const { container } = render(
       <Card>
         <CardHeader>Header</CardHeader>
@@ -24,7 +24,12 @@ describe('Card', () => {
         <CardFooter>Footer</CardFooter>
       </Card>,
     )
-    expect(container.firstChild).toHaveClass('flex', 'flex-col', 'py-ds-05b', 'gap-ds-04')
+    expect(container.firstChild).toHaveClass(
+      'flex',
+      'flex-col',
+      'py-(--card-spacing)',
+      'gap-(--card-gap)',
+    )
   })
 
   it('resets first/last child margins on CardContent (gap-model leak guard)', () => {
@@ -38,7 +43,7 @@ describe('Card', () => {
   })
 
   describe('size', () => {
-    it('defaults to md — px-ds-05b slots, py-ds-05b/gap-ds-04 container', () => {
+    it('defaults to md — assigns the 20px/12px variable pair; slots read the variable', () => {
       const { container } = render(
         <Card>
           <CardHeader>Header</CardHeader>
@@ -46,38 +51,102 @@ describe('Card', () => {
           <CardFooter>Footer</CardFooter>
         </Card>,
       )
-      expect(container.firstChild).toHaveClass('py-ds-05b', 'gap-ds-04')
-      expect(screen.getByText('Header').closest('div')!).toHaveClass('px-ds-05b')
-      expect(screen.getByText('Body').closest('div')!).toHaveClass('px-ds-05b')
-      expect(screen.getByText('Footer').closest('div')!).toHaveClass('px-ds-05b')
+      expect(container.firstChild).toHaveClass(
+        '[--card-spacing:var(--spacing-ds-05b)]',
+        '[--card-gap:var(--spacing-ds-04)]',
+      )
+      expect(screen.getByText('Header').closest('div')!).toHaveClass('px-(--card-spacing)')
+      expect(screen.getByText('Body').closest('div')!).toHaveClass('px-(--card-spacing)')
+      expect(screen.getByText('Footer').closest('div')!).toHaveClass('px-(--card-spacing)')
     })
 
-    it('applies sm — px-ds-05 slots, py-ds-05/gap-ds-03 container', () => {
-      const { container } = render(
-        <Card size="sm">
-          <CardHeader>Header</CardHeader>
-          <CardContent>Body</CardContent>
-          <CardFooter>Footer</CardFooter>
-        </Card>,
+    it('applies sm — 16px/8px variable pair', () => {
+      const { container } = render(<Card size="sm">Content</Card>)
+      expect(container.firstChild).toHaveClass(
+        '[--card-spacing:var(--spacing-ds-05)]',
+        '[--card-gap:var(--spacing-ds-03)]',
       )
-      expect(container.firstChild).toHaveClass('py-ds-05', 'gap-ds-03')
-      expect(screen.getByText('Header').closest('div')!).toHaveClass('px-ds-05')
-      expect(screen.getByText('Body').closest('div')!).toHaveClass('px-ds-05')
-      expect(screen.getByText('Footer').closest('div')!).toHaveClass('px-ds-05')
     })
 
-    it('applies lg — px-ds-06 slots, py-ds-06/gap-ds-05 container', () => {
+    it('applies lg — 24px/16px variable pair', () => {
+      const { container } = render(<Card size="lg">Content</Card>)
+      expect(container.firstChild).toHaveClass(
+        '[--card-spacing:var(--spacing-ds-06)]',
+        '[--card-gap:var(--spacing-ds-05)]',
+      )
+    })
+  })
+
+  describe('orientation', () => {
+    it('horizontal drops the container py/gap and lays out as a row', () => {
       const { container } = render(
-        <Card size="lg">
-          <CardHeader>Header</CardHeader>
-          <CardContent>Body</CardContent>
-          <CardFooter>Footer</CardFooter>
+        <Card orientation="horizontal">
+          <CardSection>
+            <CardHeader>Header</CardHeader>
+          </CardSection>
         </Card>,
       )
-      expect(container.firstChild).toHaveClass('py-ds-06', 'gap-ds-05')
-      expect(screen.getByText('Header').closest('div')!).toHaveClass('px-ds-06')
-      expect(screen.getByText('Body').closest('div')!).toHaveClass('px-ds-06')
-      expect(screen.getByText('Footer').closest('div')!).toHaveClass('px-ds-06')
+      expect(container.firstChild).toHaveClass('flex-row', 'items-stretch')
+      expect(container.firstChild).not.toHaveClass('py-(--card-spacing)', 'gap-(--card-gap)')
+    })
+
+    it('CardSection re-establishes the vertical rhythm from the same variables', () => {
+      render(
+        <Card orientation="horizontal">
+          <CardSection data-testid="section">
+            <CardHeader>Header</CardHeader>
+          </CardSection>
+        </Card>,
+      )
+      expect(screen.getByTestId('section')).toHaveClass(
+        'flex-col',
+        'py-(--card-spacing)',
+        'gap-(--card-gap)',
+        'min-w-0',
+        'flex-1',
+      )
+    })
+  })
+
+  describe('CardBleed', () => {
+    it('defaults to side="x" — negates the slot inset', () => {
+      render(
+        <Card>
+          <CardContent>
+            <CardBleed data-testid="bleed">band</CardBleed>
+          </CardContent>
+        </Card>,
+      )
+      expect(screen.getByTestId('bleed')).toHaveClass('-mx-(--card-spacing)')
+    })
+
+    it('side="top" negates the container edge and inherits the top radius', () => {
+      render(
+        <Card>
+          <CardBleed data-testid="bleed" side="top">
+            media
+          </CardBleed>
+        </Card>,
+      )
+      expect(screen.getByTestId('bleed')).toHaveClass(
+        '-mt-(--card-spacing)',
+        'rounded-t-surface',
+        'overflow-hidden',
+      )
+    })
+
+    it('side="bottom" negates the bottom edge with the bottom radius', () => {
+      render(
+        <Card>
+          <CardBleed data-testid="bleed" side="bottom">
+            band
+          </CardBleed>
+        </Card>,
+      )
+      expect(screen.getByTestId('bleed')).toHaveClass(
+        '-mb-(--card-spacing)',
+        'rounded-b-surface',
+      )
     })
   })
 
@@ -93,16 +162,20 @@ describe('Card', () => {
       expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument()
     })
 
-    it('positions top-right by default with the md inset', () => {
+    it('positions top-right by default with the variable inset', () => {
       render(
         <Card>
           <CardAction data-testid="action">x</CardAction>
         </Card>,
       )
-      expect(screen.getByTestId('action')).toHaveClass('absolute', 'top-ds-05b', 'right-ds-05b')
+      expect(screen.getByTestId('action')).toHaveClass(
+        'absolute',
+        'top-(--card-spacing)',
+        'right-(--card-spacing)',
+      )
     })
 
-    it('honors placement + inherits the card size inset', () => {
+    it('honors placement — inset tracks the variable at every size', () => {
       render(
         <Card size="lg">
           <CardAction data-testid="action" placement="bottom-right">
@@ -110,7 +183,10 @@ describe('Card', () => {
           </CardAction>
         </Card>,
       )
-      expect(screen.getByTestId('action')).toHaveClass('bottom-ds-06', 'right-ds-06')
+      expect(screen.getByTestId('action')).toHaveClass(
+        'bottom-(--card-spacing)',
+        'right-(--card-spacing)',
+      )
     })
 
     it('applies the tuck offset when set', () => {

--- a/packages/core/src/ui/card.tsx
+++ b/packages/core/src/ui/card.tsx
@@ -7,17 +7,22 @@ import * as React from 'react'
 import { motionProps, springs } from './lib/motion'
 import { cn } from './lib/utils'
 
+// Bundlers (Vite, Next.js, webpack) define process.env.NODE_ENV; guard for raw ESM.
+declare const process: { env: { NODE_ENV?: string } } | undefined
+
 type CardSize = 'sm' | 'md' | 'lg'
 
-const CardSizeContext = React.createContext<CardSize>('md')
-
 const cardVariants = cva(
-  // Gap model: the container owns the vertical edge (py) and inter-slot rhythm (gap);
-  // slots own only horizontal padding (px). No per-slot py, no pt-0, no per-element
-  // margins — adding/removing a slot can't unbalance the bottom edge (make-kit rule:
-  // shadow ring is the edge, gap is the rhythm).
+  // Gap model, variable-driven: `size` sets --card-spacing / --card-gap once on the
+  // container; the container reads them for its vertical edge (py) and inter-slot
+  // rhythm (gap), slots read the same variables for their horizontal inset (px), and
+  // CardAction/CardBleed read them for corner offsets / negative margins. One variable
+  // pair is the whole size system — override it with a single arbitrary property
+  // (`[--card-spacing:var(--spacing-ds-07)]`) and every part follows.
+  // No per-slot py, no pt-0, no per-element margins — adding/removing a slot can't
+  // unbalance the bottom edge (make-kit rule: shadow ring is the edge, gap is the rhythm).
   // `relative` establishes the positioning context for <CardAction> corner slots.
-  'relative flex flex-col rounded-surface text-surface-fg transition-shadow duration-fast-02 ease-productive-standard',
+  'relative flex text-surface-fg rounded-surface transition-shadow duration-fast-02 ease-productive-standard',
   {
     variants: {
       variant: {
@@ -39,25 +44,24 @@ const cardVariants = cva(
         info: 'border-info-7',
         neutral: '',
       },
-      // size drives the container's vertical padding + inter-slot gap; slots read
-      // the same size from context for their horizontal padding.
+      // size only assigns the two variables; the orientation axis decides where
+      // they're consumed (container in vertical, <CardSection> in horizontal).
       size: {
-        sm: 'py-ds-05 gap-ds-03',
-        md: 'py-ds-05b gap-ds-04',
-        lg: 'py-ds-06 gap-ds-05',
+        sm: '[--card-spacing:var(--spacing-ds-05)] [--card-gap:var(--spacing-ds-03)]',
+        md: '[--card-spacing:var(--spacing-ds-05b)] [--card-gap:var(--spacing-ds-04)]',
+        lg: '[--card-spacing:var(--spacing-ds-06)] [--card-gap:var(--spacing-ds-05)]',
+      },
+      // vertical: the container owns py + gap (the default gap model).
+      // horizontal: the container is a padding-less row; a <CardSection> child
+      // re-establishes py + gap for the text column while a media pane owns an edge.
+      orientation: {
+        vertical: 'flex-col py-(--card-spacing) gap-(--card-gap)',
+        horizontal: 'flex-row items-stretch',
       },
     },
-    defaultVariants: { variant: 'default', color: 'default', size: 'md' },
+    defaultVariants: { variant: 'default', color: 'default', size: 'md', orientation: 'vertical' },
   },
 )
-
-/** Horizontal padding per size — applied to every slot so full-bleed children
- *  (dividers, media) can opt out, while the container owns the vertical edges. */
-const slotPxClasses: Record<CardSize, string> = {
-  sm: 'px-ds-05',
-  md: 'px-ds-05b',
-  lg: 'px-ds-06',
-}
 
 /**
  * Props for Card — a general-purpose content container with 4 elevation/style variants and
@@ -69,7 +73,13 @@ const slotPxClasses: Record<CardSize, string> = {
  * variants need no explicit border (make-kit rule #6).
  *
  * **Composition:** Use sub-components `<CardHeader>`, `<CardTitle>`, `<CardDescription>`,
- * `<CardContent>`, and `<CardFooter>` for consistent internal spacing.
+ * `<CardContent>`, and `<CardFooter>` for consistent internal spacing. Text content must live
+ * inside a slot — raw text as a direct child gets no horizontal inset (direct children span the
+ * full card width by design, which is what makes full-width dividers and bands free).
+ *
+ * **Spacing:** `size` sets `--card-spacing` / `--card-gap` once; container, slots, `CardAction`,
+ * and `CardBleed` all read the same pair. Retune a card with a single override:
+ * `className="[--card-spacing:var(--spacing-ds-07)]"`.
  *
  * **Interactive:** Pass `interactive` to enable hover shadow lift and pointer cursor —
  * useful for clickable cards in grids.
@@ -87,27 +97,33 @@ const slotPxClasses: Record<CardSize, string> = {
  * </Card>
  *
  * @example
- * // Elevated card for a dashboard stat widget:
- * <Card variant="elevated">
- *   <CardContent>
- *     <StatCard label="Revenue" value="$12,400" delta={{ value: "+8%", direction: "up" }} />
- *   </CardContent>
+ * // Full-bleed cover image + edge-to-edge divider:
+ * <Card>
+ *   <CardBleed side="top"><img src={cover} alt="" /></CardBleed>
+ *   <CardHeader><CardTitle>Muhurat launch site</CardTitle></CardHeader>
+ *   <Separator />
+ *   <CardFooter><Badge color="success">On track</Badge></CardFooter>
  * </Card>
  *
  * @example
- * // Clickable card in a project grid (interactive hover effect):
- * <Card interactive onClick={() => router.push(`/projects/${id}`)}>
- *   <CardHeader>
- *     <CardTitle>{project.name}</CardTitle>
- *   </CardHeader>
+ * // Horizontal media card — media pane owns the left edge, CardSection restores rhythm:
+ * <Card orientation="horizontal">
+ *   <div className="w-32 shrink-0 rounded-l-surface overflow-hidden">
+ *     <img src={thumb} alt="" className="h-full w-full object-cover" />
+ *   </div>
+ *   <CardSection>
+ *     <CardHeader><CardTitle>Field notes</CardTitle></CardHeader>
+ *     <CardFooter>edited yesterday</CardFooter>
+ *   </CardSection>
  * </Card>
  *
  * @example
  * // Flat card for a sidebar panel section (no shadow):
- * <Card variant="flat" className="p-ds-05">
- *   <p className="text-surface-fg-muted text-ds-sm">No recent activity</p>
+ * <Card variant="flat">
+ *   <CardContent>
+ *     <p className="text-surface-fg-muted text-ds-sm">No recent activity</p>
+ *   </CardContent>
  * </Card>
- * // These are just a few ways — feel free to combine props creatively!
  */
 export interface CardProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>,
@@ -118,18 +134,14 @@ export interface CardProps
 export type { CardSize }
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
-  ({ className, variant, color, size, interactive, children, ...props }, ref) => {
-    const resolvedSize: CardSize = size ?? 'md'
+  ({ className, variant, color, size, orientation, interactive, children, ...props }, ref) => {
+    if (typeof process !== 'undefined' && process?.env.NODE_ENV !== 'production') {
+      warnOnUnwrappedTextChildren(children)
+    }
     const classes = cn(
-      cardVariants({ variant, color, size }),
+      cardVariants({ variant, color, size, orientation }),
       interactive && 'hover:shadow-raised-hover cursor-pointer transition-shadow duration-fast-02 ease-productive-standard',
       className,
-    )
-
-    const content = (
-      <CardSizeContext.Provider value={resolvedSize}>
-        {children}
-      </CardSizeContext.Provider>
     )
 
     if (interactive) {
@@ -142,14 +154,14 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
           className={classes}
           {...motionProps(props)}
         >
-          {content}
+          {children}
         </motion.div>
       )
     }
 
     return (
       <div ref={ref} className={classes} {...props}>
-        {content}
+        {children}
       </div>
     )
   },
@@ -159,20 +171,16 @@ Card.displayName = 'Card'
 const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const size = React.useContext(CardSizeContext)
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        'flex flex-col gap-ds-02b [&>:first-child]:mt-0 [&>:last-child]:mb-0',
-        slotPxClasses[size],
-        className,
-      )}
-      {...props}
-    />
-  )
-})
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'flex flex-col gap-ds-02b px-(--card-spacing) [&>:first-child]:mt-0 [&>:last-child]:mb-0',
+      className,
+    )}
+    {...props}
+  />
+))
 CardHeader.displayName = 'CardHeader'
 
 const CardTitle = React.forwardRef<
@@ -202,63 +210,109 @@ CardDescription.displayName = 'CardDescription'
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const size = React.useContext(CardSizeContext)
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        // Reset first/last child margins so a raw <p>/<h*>'s UA margin can't leak
-        // past the slot onto the container's gap-model padding (the bottom-heavy bug).
-        '[&>:first-child]:mt-0 [&>:last-child]:mb-0',
-        slotPxClasses[size],
-        className,
-      )}
-      {...props}
-    />
-  )
-})
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      // Reset first/last child margins so a raw <p>/<h*>'s UA margin can't leak
+      // past the slot onto the container's gap-model padding (the bottom-heavy bug).
+      'px-(--card-spacing) [&>:first-child]:mt-0 [&>:last-child]:mb-0',
+      className,
+    )}
+    {...props}
+  />
+))
 CardContent.displayName = 'CardContent'
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => {
-  const size = React.useContext(CardSizeContext)
-  return (
-    <div
-      ref={ref}
-      className={cn('flex items-center gap-ds-03', slotPxClasses[size], className)}
-      {...props}
-    />
-  )
-})
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center gap-ds-03 px-(--card-spacing)', className)}
+    {...props}
+  />
+))
 CardFooter.displayName = 'CardFooter'
+
+/**
+ * A vertical stack that re-establishes the card's padding + gap rhythm — the text column
+ * of a `<Card orientation="horizontal">`. Reads the same `--card-spacing` / `--card-gap`
+ * variables the container sets, so the horizontal card's content column matches a vertical
+ * card of the same `size` exactly.
+ */
+const CardSection = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex min-w-0 flex-1 flex-col py-(--card-spacing) gap-(--card-gap)', className)}
+    {...props}
+  />
+))
+CardSection.displayName = 'CardSection'
+
+type CardBleedSide = 'x' | 'top' | 'bottom' | 'y' | 'all'
+
+const bleedSideClasses: Record<CardBleedSide, string> = {
+  // Inside a slot: escape the slot's horizontal inset.
+  x: '-mx-(--card-spacing)',
+  // As a direct child: escape the container's vertical edge (direct children are
+  // already full-width — never add `x` bleed to a direct child, it would overflow).
+  top: '-mt-(--card-spacing) rounded-t-surface overflow-hidden',
+  bottom: '-mb-(--card-spacing) rounded-b-surface overflow-hidden',
+  y: '-my-(--card-spacing) rounded-surface overflow-hidden',
+  // Inside a slot, escaping every edge (e.g. an image-only card body).
+  all: '-my-(--card-spacing) -mx-(--card-spacing) rounded-surface overflow-hidden',
+}
+
+export interface CardBleedProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Which card padding to negate. `top`/`bottom`/`y` are for direct children of Card
+   * (full-bleed media, edge bands) and inherit the card's corner radius; `x`/`all` are
+   * for content INSIDE a slot that needs to escape the slot's horizontal inset.
+   * Direct children of Card already span its full width — don't use `x`/`all` there.
+   * @default 'x'
+   */
+  side?: CardBleedSide
+}
+
+/**
+ * Escape hatch from the card's padding — the shilp-sutra equivalent of Radix Themes'
+ * `Inset` / Polaris `Bleed`. Negates the same `--card-spacing` variable the padding
+ * reads, so it stays exact across sizes and overrides.
+ *
+ * @example
+ * // Cover image touching the card's top + side edges:
+ * <Card>
+ *   <CardBleed side="top"><img src={cover} alt="" /></CardBleed>
+ *   <CardHeader><CardTitle>Project</CardTitle></CardHeader>
+ * </Card>
+ *
+ * @example
+ * // A tinted band inside CardContent, running edge-to-edge:
+ * <CardContent>
+ *   <CardBleed><div className="bg-accent-2 px-(--card-spacing) py-ds-03">Heads up…</div></CardBleed>
+ * </CardContent>
+ */
+const CardBleed = React.forwardRef<HTMLDivElement, CardBleedProps>(
+  ({ className, side = 'x', ...props }, ref) => (
+    <div ref={ref} className={cn(bleedSideClasses[side], className)} {...props} />
+  ),
+)
+CardBleed.displayName = 'CardBleed'
 
 type CardActionPlacement = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
 
-// Corner inset matches the slot padding for the card's size, so an action's edge
-// lines up with the content edge. Class names are spelled out literally (not built
-// from the size) so Tailwind's JIT can see them.
-const cornerPositions: Record<CardSize, Record<CardActionPlacement, string>> = {
-  sm: {
-    'top-right': 'top-ds-05 right-ds-05',
-    'top-left': 'top-ds-05 left-ds-05',
-    'bottom-right': 'bottom-ds-05 right-ds-05',
-    'bottom-left': 'bottom-ds-05 left-ds-05',
-  },
-  md: {
-    'top-right': 'top-ds-05b right-ds-05b',
-    'top-left': 'top-ds-05b left-ds-05b',
-    'bottom-right': 'bottom-ds-05b right-ds-05b',
-    'bottom-left': 'bottom-ds-05b left-ds-05b',
-  },
-  lg: {
-    'top-right': 'top-ds-06 right-ds-06',
-    'top-left': 'top-ds-06 left-ds-06',
-    'bottom-right': 'bottom-ds-06 right-ds-06',
-    'bottom-left': 'bottom-ds-06 left-ds-06',
-  },
+// Corner inset reads --card-spacing so an action's edge lines up with the slot
+// content edge at every size.
+const cornerPositions: Record<CardActionPlacement, string> = {
+  'top-right': 'top-(--card-spacing) right-(--card-spacing)',
+  'top-left': 'top-(--card-spacing) left-(--card-spacing)',
+  'bottom-right': 'bottom-(--card-spacing) right-(--card-spacing)',
+  'bottom-left': 'bottom-(--card-spacing) left-(--card-spacing)',
 }
 
 export interface CardActionProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -291,23 +345,43 @@ export interface CardActionProps extends React.HTMLAttributes<HTMLDivElement> {
  * </Card>
  */
 const CardAction = React.forwardRef<HTMLDivElement, CardActionProps>(
-  ({ className, placement = 'top-right', tuck, ...props }, ref) => {
-    const size = React.useContext(CardSizeContext)
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'absolute z-[1] flex items-center gap-ds-02',
-          cornerPositions[size][placement],
-          tuck && '-m-ds-02',
-          className,
-        )}
-        {...props}
-      />
-    )
-  },
+  ({ className, placement = 'top-right', tuck, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'absolute z-[1] flex items-center gap-ds-02',
+        cornerPositions[placement],
+        tuck && '-m-ds-02',
+        className,
+      )}
+      {...props}
+    />
+  ),
 )
 CardAction.displayName = 'CardAction'
 
-export { Card, CardAction, CardContent,CardDescription, CardFooter, CardHeader, CardTitle, cardVariants }
-export type { CardActionPlacement }
+// Text-shaped tags that almost certainly expected a slot's horizontal inset.
+// Structural tags (div, section, img, table, hr…) are legitimate full-width direct
+// children, so they stay silent.
+const TEXTUAL_TAGS = new Set(['p', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'a', 'label', 'small', 'strong', 'em'])
+let warnedUnwrappedText = false
+
+function warnOnUnwrappedTextChildren(children: React.ReactNode): void {
+  if (warnedUnwrappedText) return
+  React.Children.forEach(children, (child) => {
+    const isBareText = typeof child === 'string' && child.trim() !== ''
+    const isTextualTag =
+      React.isValidElement(child) &&
+      typeof child.type === 'string' &&
+      TEXTUAL_TAGS.has(child.type)
+    if (isBareText || isTextualTag) {
+      warnedUnwrappedText = true
+      console.warn(
+        '[shilp-sutra] <Card> received text content as a direct child. Direct children span the full card width and get no horizontal inset — wrap text in <CardContent> (or <CardHeader>/<CardFooter>). See the Card docs, "Composition".',
+      )
+    }
+  })
+}
+
+export { Card, CardAction, CardBleed, CardContent, CardDescription, CardFooter, CardHeader, CardSection, CardTitle, cardVariants }
+export type { CardActionPlacement, CardBleedSide }

--- a/packages/core/src/ui/data-table-body.tsx
+++ b/packages/core/src/ui/data-table-body.tsx
@@ -82,7 +82,6 @@ function DataTableRow<TData>({
 }) {
   const {
     table,
-    cellPadding,
     columnPinningState,
     editable,
     editingCell,
@@ -124,7 +123,6 @@ function DataTableRow<TData>({
           <TableCell
             key={cell.id}
             className={cn(
-              cellPadding,
               pinned.className,
               virtualRows && 'flex-1',
               getColumnMetaClasses(
@@ -183,7 +181,8 @@ function DataTableExpandedRow<TData>({
       <TableCell
         colSpan={allColumns.length}
         className={cn(
-          'bg-surface-raised p-ds-05',
+          // A recess, not a raised layer — surface-raised would vanish on a card.
+          'bg-surface-base p-ds-05',
           virtualRows && 'flex-1',
         )}
       >
@@ -200,7 +199,7 @@ function DataTableSkeletonRows({
 }: {
   rowCount: number
 }) {
-  const { allColumns, cellPadding } = useDataTableContext()
+  const { allColumns } = useDataTableContext()
   const visibleColumnCount = allColumns.length
   const skeletonWidths = ['w-3/4', 'w-1/2', 'w-2/3', 'w-full']
 
@@ -212,10 +211,7 @@ function DataTableSkeletonRows({
             const colId = allColumns[colIdx]?.id ?? allColumns[colIdx]?.header
             const isSelect = colId === '_select'
             return (
-              <TableCell
-                key={`skeleton-${rowIdx}-${colIdx}`}
-                className={cellPadding}
-              >
+              <TableCell key={`skeleton-${rowIdx}-${colIdx}`}>
                 {isSelect ? (
                   <Skeleton
                     variant="text"
@@ -273,7 +269,7 @@ export function DataTableBody<TData>({
           <TableCell
             colSpan={allColumns.length}
             className={cn(
-              'h-24 text-center',
+              'py-ds-07 text-center',
               !emptyState && 'text-surface-fg-subtle',
             )}
           >

--- a/packages/core/src/ui/data-table-body.tsx
+++ b/packages/core/src/ui/data-table-body.tsx
@@ -2,6 +2,7 @@
 
 import { flexRender,type Row } from '@tanstack/react-table'
 import { type VirtualItem } from '@tanstack/react-virtual'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import {
@@ -11,6 +12,7 @@ import {
   isColumnEditable,
   useDataTableContext,
 } from './data-table-context'
+import { springs } from './lib/motion'
 import { cn } from './lib/utils'
 import { Skeleton } from './skeleton'
 import { TableBody, TableCell, TableRow } from './table'
@@ -170,25 +172,56 @@ function DataTableExpandedRow<TData>({
 }) {
   const { allColumns, expandable, renderExpanded, virtualRows } =
     useDataTableContext<TData>()
+  // Self-guarded (StatFlash pattern) — reveal collapses to an instant swap
+  // without relying on a consumer MotionProvider.
+  const prefersReduced = useReducedMotion()
 
-  if (!expandable || !row.getIsExpanded() || !renderExpanded) return null
+  if (!expandable || !renderExpanded) return null
+
+  const expanded = row.getIsExpanded()
+
+  // Virtual rows are absolutely positioned with measured heights — a height
+  // animation would fight the virtualizer, so the reveal is instant there.
+  if (virtualRows) {
+    if (!expanded) return null
+    return (
+      <TableRow style={style} className="absolute w-full flex">
+        <TableCell
+          colSpan={allColumns.length}
+          className="bg-surface-base p-ds-05 flex-1"
+        >
+          {renderExpanded(row.original)}
+        </TableCell>
+      </TableRow>
+    )
+  }
 
   return (
-    <TableRow
-      style={style}
-      className={virtualRows ? 'absolute w-full flex' : undefined}
-    >
-      <TableCell
-        colSpan={allColumns.length}
-        className={cn(
-          // A recess, not a raised layer — surface-raised would vanish on a card.
-          'bg-surface-base p-ds-05',
-          virtualRows && 'flex-1',
-        )}
-      >
-        {renderExpanded(row.original)}
-      </TableCell>
-    </TableRow>
+    <AnimatePresence initial={false}>
+      {expanded && (
+        <TableRow style={style}>
+          <TableCell
+            colSpan={allColumns.length}
+            // A recess, not a raised layer — surface-raised would vanish on a
+            // card. Padding moves to the inner div so the collapsed state has
+            // zero height.
+            className="bg-surface-base p-0"
+          >
+            <motion.div
+              className="overflow-hidden"
+              initial={prefersReduced ? false : { height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={prefersReduced ? undefined : { height: 0, opacity: 0 }}
+              transition={
+                prefersReduced ? { duration: 0 } : { ...springs.smooth }
+              }
+            >
+              <div className="p-ds-05">{renderExpanded(row.original)}</div>
+            </motion.div>
+          </TableCell>
+        </TableRow>
+      )}
+    </AnimatePresence>
   )
 }
 

--- a/packages/core/src/ui/data-table-card.tsx
+++ b/packages/core/src/ui/data-table-card.tsx
@@ -3,6 +3,7 @@
 import { flexRender } from '@tanstack/react-table'
 import React from 'react'
 
+import { Card, CardContent } from './card'
 import { Checkbox } from './checkbox'
 import { useDataTableContext } from './data-table-context'
 import { cn } from './lib/utils'
@@ -32,17 +33,16 @@ export function DataTableCards<TData>({
     return (
       <div className="flex flex-col gap-ds-03">
         {Array.from({ length: skeletonRowCount }, (_, i) => (
-          <div
-            key={`card-skeleton-${i}`}
-            className="rounded-surface border border-surface-border bg-surface-raised p-ds-04"
-          >
-            <Skeleton variant="text" className="mb-ds-03 h-5 w-2/3" animation="pulse" />
-            <div className="flex flex-col gap-ds-02">
-              <Skeleton variant="text" className="h-4 w-full" animation="pulse" />
-              <Skeleton variant="text" className="h-4 w-3/4" animation="pulse" />
-              <Skeleton variant="text" className="h-4 w-1/2" animation="pulse" />
-            </div>
-          </div>
+          <Card key={`card-skeleton-${i}`} size="sm">
+            <CardContent>
+              <Skeleton variant="text" className="mb-ds-03 h-5 w-2/3" animation="pulse" />
+              <div className="flex flex-col gap-ds-02">
+                <Skeleton variant="text" className="h-4 w-full" animation="pulse" />
+                <Skeleton variant="text" className="h-4 w-3/4" animation="pulse" />
+                <Skeleton variant="text" className="h-4 w-1/2" animation="pulse" />
+              </div>
+            </CardContent>
+          </Card>
         ))}
       </div>
     )
@@ -70,16 +70,14 @@ export function DataTableCards<TData>({
         const isSelected = row.getIsSelected()
 
         return (
-          <div
+          <Card
             key={row.id}
             role="listitem"
-            className={cn(
-              'rounded-surface border border-surface-border bg-surface-raised p-ds-04',
-              isSelected && 'ring-2 ring-accent-9',
-            )}
+            size="sm"
+            className={cn(isSelected && 'ring-2 ring-accent-9')}
           >
             {/* Header row: primary field + optional selection checkbox */}
-            <div className="flex items-start justify-between gap-ds-03 mb-ds-02">
+            <CardContent className="flex items-start justify-between gap-ds-03">
               <div className="min-w-0 flex-1 font-medium text-surface-fg">
                 {primaryCell &&
                   flexRender(primaryCell.column.columnDef.cell, primaryCell.getContext())}
@@ -94,11 +92,13 @@ export function DataTableCards<TData>({
                   className="shrink-0"
                 />
               )}
-            </div>
+            </CardContent>
 
-            {/* Label-value pairs for remaining columns */}
+            {/* Label-value pairs for remaining columns, behind a full-width rule */}
             {restCells.length > 0 && (
-              <div className="flex flex-col gap-ds-01 border-t border-surface-border pt-ds-02">
+              <>
+              <div aria-hidden="true" className="h-px w-full bg-surface-border-subtle" />
+              <CardContent className="flex flex-col gap-ds-01">
                 {restCells.map((cell) => {
                   // Respect hideBelow column meta — skip hidden columns
                   const meta = cell.column.columnDef.meta as
@@ -127,9 +127,10 @@ export function DataTableCards<TData>({
                     </div>
                   )
                 })}
-              </div>
+              </CardContent>
+              </>
             )}
-          </div>
+          </Card>
         )
       })}
     </div>

--- a/packages/core/src/ui/data-table-card.tsx
+++ b/packages/core/src/ui/data-table-card.tsx
@@ -33,7 +33,7 @@ export function DataTableCards<TData>({
     return (
       <div className="flex flex-col gap-ds-03">
         {Array.from({ length: skeletonRowCount }, (_, i) => (
-          <Card key={`card-skeleton-${i}`} size="sm">
+          <Card key={`card-skeleton-${i}`} size="sm" variant="outline">
             <CardContent>
               <Skeleton variant="text" className="mb-ds-03 h-5 w-2/3" animation="pulse" />
               <div className="flex flex-col gap-ds-02">
@@ -74,6 +74,9 @@ export function DataTableCards<TData>({
             key={row.id}
             role="listitem"
             size="sm"
+            // outline, not default — a phone screen of stacked shadow cards
+            // accumulates lift (make-kit dense-list rule).
+            variant="outline"
             className={cn(isSelected && 'ring-2 ring-accent-9')}
           >
             {/* Header row: primary field + optional selection checkbox */}

--- a/packages/core/src/ui/data-table-context.tsx
+++ b/packages/core/src/ui/data-table-context.tsx
@@ -3,8 +3,6 @@
 import { type ColumnPinningState, type Table } from '@tanstack/react-table'
 import React from 'react'
 
-import type { Density } from './data-table-toolbar'
-
 // ── Shared types ────────────────────────────────────────────────
 
 /** Editing state: which cell is currently in edit mode */
@@ -23,12 +21,6 @@ export function getColumnMetaClasses(meta?: Record<string, unknown>): string {
   return classes.join(' ')
 }
 
-export const densityPaddingMap: Record<Density, string> = {
-  compact: 'py-ds-02',
-  standard: 'py-ds-05',
-  comfortable: 'py-ds-07',
-}
-
 /** Interactive element selectors for row click filtering */
 export const INTERACTIVE_SELECTOR =
   'button, a, input, select, textarea, [role="checkbox"]'
@@ -39,8 +31,6 @@ export interface DataTableContextValue<TData = unknown> {
   table: Table<TData>
   /** All assembled columns (including _select, _expand) */
   allColumns: { id?: string; header?: unknown }[]
-  /** Current cell padding class based on density */
-  cellPadding: string
   /** Column pinning state for sticky positioning */
   columnPinningState: ColumnPinningState
   /** Whether sorting is enabled */

--- a/packages/core/src/ui/data-table-header.tsx
+++ b/packages/core/src/ui/data-table-header.tsx
@@ -30,7 +30,9 @@ function DataTableHeaderImpl({ stickyHeader }: { stickyHeader?: boolean }) {
   return (
     <TableHeader
       className={cn(
-        stickyHeader && 'sticky top-0 z-10 bg-surface-base',
+        // surface-raised, not base — the table lives on a card; a base-colored
+        // sticky bar would read as a grey stripe over the white surface.
+        stickyHeader && 'sticky top-0 z-10 bg-surface-raised',
       )}
     >
       {table.getHeaderGroups().map((headerGroup) => (
@@ -70,7 +72,7 @@ function DataTableHeaderImpl({ stickyHeader }: { stickyHeader?: boolean }) {
                       'flex items-center gap-ds-01 font-medium',
                       'cursor-pointer select-none',
                       '-ml-ds-01 rounded-control-inner px-ds-01 py-ds-01',
-                      'hover:bg-surface-raised transition-colors',
+                      'hover:bg-surface-raised-hover transition-colors',
                     )}
                     onClick={header.column.getToggleSortingHandler()}
                     aria-label={`Sort by ${typeof header.column.columnDef.header === 'string' ? header.column.columnDef.header : header.column.id}`}

--- a/packages/core/src/ui/data-table.tsx
+++ b/packages/core/src/ui/data-table.tsx
@@ -399,14 +399,16 @@ export function DataTable<TData, TValue>({
     enableHiding: false,
   }
 
-  // Expand toggle column
+  // Expand toggle column — aria-expanded lives on the BUTTON (not the row),
+  // in a dedicated column with a visually-hidden header (Roselli expando spec).
   const expandColumn: ColumnDef<TData, unknown> = {
     id: '_expand',
-    header: () => null,
+    header: () => <span className="sr-only">Expand rows</span>,
     cell: ({ row }) => (
       <button
         type="button"
         onClick={() => row.toggleExpanded()}
+        aria-expanded={row.getIsExpanded()}
         aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
         className="flex items-center justify-center p-ds-01 rounded-control-inner hover:bg-surface-raised-hover transition-colors"
       >
@@ -414,7 +416,7 @@ export function DataTable<TData, TValue>({
           icon={IconChevronRight}
           size="sm"
           className={cn(
-            'transition-transform duration-moderate-02',
+            'transition-transform duration-fast-02 ease-productive-standard',
             row.getIsExpanded() && 'rotate-90',
           )}
         />

--- a/packages/core/src/ui/data-table.tsx
+++ b/packages/core/src/ui/data-table.tsx
@@ -30,7 +30,6 @@ import { type BulkAction,DataTableBulkActions } from './data-table-bulk-actions'
 import { DataTableCards } from './data-table-card'
 import {
   DataTableProvider,
-  densityPaddingMap,
   type EditingCell,
 } from './data-table-context'
 import { DataTableHeader } from './data-table-header'
@@ -409,7 +408,7 @@ export function DataTable<TData, TValue>({
         type="button"
         onClick={() => row.toggleExpanded()}
         aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
-        className="flex items-center justify-center p-ds-01 rounded-control-inner hover:bg-surface-raised transition-colors"
+        className="flex items-center justify-center p-ds-01 rounded-control-inner hover:bg-surface-raised-hover transition-colors"
       >
         <Icon
           icon={IconChevronRight}
@@ -523,8 +522,6 @@ export function DataTable<TData, TValue>({
     onSelectionChangeRef.current(selected)
   }, [rowSelection, data])
 
-  const cellPadding = densityPaddingMap[density]
-
   const rows = table.getRowModel().rows
 
   // Virtualizer — always called but only active when virtualRows is true
@@ -563,7 +560,6 @@ export function DataTable<TData, TValue>({
         id: (col as { id?: string }).id,
         header: (col as { header?: unknown }).header,
       })),
-      cellPadding,
       columnPinningState,
       sortable,
       filterable,
@@ -582,7 +578,6 @@ export function DataTable<TData, TValue>({
     [
       table,
       allColumns.length,
-      cellPadding,
       columnPinningState,
       sortable,
       filterable,
@@ -604,7 +599,7 @@ export function DataTable<TData, TValue>({
 
   // Determine if we need a scroll wrapper for virtualization
   const tableContent = (
-    <Table aria-busy={loading || undefined}>
+    <Table density={density} aria-busy={loading || undefined}>
       <DataTableHeader stickyHeader={stickyHeader} />
       <DataTableBody
         loading={loading}

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -178,7 +178,8 @@ export {
   type StatFlashProps,
 } from './stat-flash'
 export { StatusDot, type StatusDotProps, type StatusDotStatus } from './status-dot'
-export { Table, TableBody, TableCaption, TableCell, type TableCellProps,type TableDensity, TableFooter, TableHead, TableHeader, type TableProps, TableRow, type TableRowProps } from './table'
+export { Table, TableBody, TableCaption, TableCell, type TableCellProps,type TableDensity, TableFooter, TableHead, TableHeader, type TableProps, TableRow, TableRowActions, type TableRowActionsProps,type TableRowProps } from './table'
+export { TableRowLink, type TableRowLinkProps } from './table-row-link'
 
 // Navigation
 export { Accordion, AccordionContent, type AccordionContentProps,AccordionItem, type AccordionItemProps, AccordionTrigger, type AccordionTriggerProps } from './accordion'

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -178,7 +178,7 @@ export {
   type StatFlashProps,
 } from './stat-flash'
 export { StatusDot, type StatusDotProps, type StatusDotStatus } from './status-dot'
-export { Table, TableBody, TableCaption, TableCell, type TableCellProps,TableFooter, TableHead, TableHeader, type TableProps, TableRow, type TableRowProps } from './table'
+export { Table, TableBody, TableCaption, TableCell, type TableCellProps,type TableDensity, TableFooter, TableHead, TableHeader, type TableProps, TableRow, type TableRowProps } from './table'
 
 // Navigation
 export { Accordion, AccordionContent, type AccordionContentProps,AccordionItem, type AccordionItemProps, AccordionTrigger, type AccordionTriggerProps } from './accordion'

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -144,7 +144,7 @@ export { Avatar, AvatarFallback, type AvatarFallbackProps, AvatarImage, type Ava
 export { Badge, type BadgeProps,badgeVariants } from './badge'
 export { BadgeGroup, type BadgeGroupProps } from './badge-group'
 export { BadgeIndicator, type BadgeIndicatorProps } from './badge-indicator'
-export { Card, CardAction, type CardActionPlacement, type CardActionProps, CardContent, CardDescription, CardFooter, CardHeader, type CardProps,CardTitle, cardVariants } from './card'
+export { Card, CardAction, type CardActionPlacement, type CardActionProps, CardBleed, type CardBleedProps, type CardBleedSide, CardContent, CardDescription, CardFooter, CardHeader, type CardProps,CardSection, CardTitle, cardVariants } from './card'
 export { Code, type CodeProps } from './code'
 export { ColorSwatch, type ColorSwatchProps } from './color-swatch'
 export { Progress, progressIndicatorVariants, type ProgressProps,progressTrackVariants } from './progress'

--- a/packages/core/src/ui/shape-presets.stories.tsx
+++ b/packages/core/src/ui/shape-presets.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import * as React from 'react'
 
 import { Button } from './button'
-import { Card } from './card'
+import { Card, CardContent } from './card'
 import { Input } from './input'
 
 const meta: Meta = {
@@ -54,9 +54,11 @@ function PresetSample({ preset, label, description }: { preset: string; label: s
         <Input size="lg" placeholder="Large input" />
       </div>
 
-      <Card variant="default" className="p-ds-04">
-        <div className="text-ds-md font-medium">Card surface</div>
-        <div className="text-ds-sm text-surface-fg-muted">Cards use `--radius-surface`, distinct from controls.</div>
+      <Card variant="default" size="sm">
+        <CardContent>
+          <div className="text-ds-md font-medium">Card surface</div>
+          <div className="text-ds-sm text-surface-fg-muted">Cards use `--radius-surface`, distinct from controls.</div>
+        </CardContent>
       </Card>
     </div>
   )
@@ -128,9 +130,11 @@ export const CustomPresetExample: Story = {
           <Button size="md" variant="outline">Soft control</Button>
         </div>
         <Input size="md" placeholder="Soft control" />
-        <Card variant="default" className="p-ds-04">
-          <div className="text-ds-md font-medium">Tight surface</div>
-          <div className="text-ds-sm text-surface-fg-muted">Inherits the 4px override scoped to this card.</div>
+        <Card variant="default" size="sm">
+          <CardContent>
+            <div className="text-ds-md font-medium">Tight surface</div>
+            <div className="text-ds-sm text-surface-fg-muted">Inherits the 4px override scoped to this card.</div>
+          </CardContent>
         </Card>
       </div>
     </div>

--- a/packages/core/src/ui/stat-card.stories.tsx
+++ b/packages/core/src/ui/stat-card.stories.tsx
@@ -347,3 +347,15 @@ export const LoadingFlat: Story = {
   },
   decorators: [(Story) => <div className="w-[280px]"><Story /></div>],
 }
+
+export const DenseGrid: Story = {
+  name: 'size="sm" — dense KPI grid',
+  render: () => (
+    <div className="grid w-[640px] grid-cols-4 gap-ds-04">
+      <StatCard size="sm" label="Tasks" value={86} delta={{ value: '+12', direction: 'up' }} />
+      <StatCard size="sm" label="Overdue" value={4} delta={{ value: '-2', direction: 'down' }} />
+      <StatCard size="sm" label="In review" value={11} delta={{ value: '+3', direction: 'up' }} />
+      <StatCard size="sm" label="Blocked" value={2} delta={{ value: '0', direction: 'neutral' }} />
+    </div>
+  ),
+}

--- a/packages/core/src/ui/stat-card.test.tsx
+++ b/packages/core/src/ui/stat-card.test.tsx
@@ -150,6 +150,19 @@ describe('StatCard', () => {
     expect(screen.getByText('View details')).toBeInTheDocument()
   })
 
+  // ── Size (delegated to Card) ────────────────────────────────────────────────
+  it('defaults to md and passes size to Card', () => {
+    const { container } = render(<StatCard label="Sales" value={12} />)
+    expect(container.firstChild).toHaveClass('[--card-spacing:var(--spacing-ds-05b)]')
+    expect(screen.getByText('12').closest('p')).toHaveClass('text-ds-3xl')
+  })
+
+  it('size="sm" tightens the card and steps the value down to 2xl', () => {
+    const { container } = render(<StatCard label="Sales" value={12} size="sm" />)
+    expect(container.firstChild).toHaveClass('[--card-spacing:var(--spacing-ds-05)]')
+    expect(screen.getByText('12').closest('p')).toHaveClass('text-ds-2xl')
+  })
+
   // ── Accent style + surface + flash (anti-convergence rework) ────────────────
   it('renders accentStyle="icon" with the provided icon', () => {
     const { container } = render(

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -4,7 +4,7 @@ import { IconMinus, IconTrendingDown, IconTrendingUp } from '@tabler/icons-react
 import { motion } from 'framer-motion'
 import * as React from 'react'
 
-import { Card, CardContent } from './card'
+import { Card, CardContent, CardFooter, type CardSize } from './card'
 import { Icon } from './icon'
 import { IconProvider } from './icon-context'
 import type { IconInput } from './lib/icon-input'
@@ -88,6 +88,12 @@ export interface StatCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   progress?: number
   /** Surface variant, delegated to Card: `default` (ring-in-shadow) | `elevated` | `outline` (border, no shadow) | `flat`. @default 'default' */
   variant?: 'default' | 'elevated' | 'outline' | 'flat'
+  /**
+   * Tile density, delegated to Card's size axis. `sm` tightens padding to 16px and steps
+   * the value down to `text-ds-2xl` — use it for dense KPI rows and narrow stat grids
+   * (e.g. stat-row's 140px tiles). @default 'md'
+   */
+  size?: CardSize
   /** How the brand accent reads: `none` (neutral — default), `icon` (accent chip around `icon`), or `tint` (subtle accent surface wash + accent value). */
   accentStyle?: 'none' | 'icon' | 'tint'
   /** When `accentStyle="icon"`: `soft` (tinted chip) or `solid` (filled accent chip). @default 'soft' */
@@ -194,7 +200,7 @@ function ProgressBar({ progress, label }: { progress: number; label: string }) {
     clamped >= 90 ? 'bg-success-9' : clamped >= 70 ? 'bg-warning-9' : 'bg-accent-9'
 
   return (
-    <div className="h-1 w-full rounded-pill bg-surface-raised mt-ds-04" role="progressbar" aria-label={`${label} progress`} aria-valuenow={clamped} aria-valuemin={0} aria-valuemax={100}>
+    <div className="h-1 w-full rounded-pill bg-surface-raised" role="progressbar" aria-label={`${label} progress`} aria-valuenow={clamped} aria-valuemin={0} aria-valuemax={100}>
       <div
         className={cn('h-full rounded-pill transition-[width] duration-moderate-02 ease-productive-standard', barColor)}
         style={{ width: `${clamped}%` }}
@@ -220,6 +226,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       secondaryLabel,
       progress,
       variant = 'default',
+      size = 'md',
       accentStyle = 'none',
       iconFill = 'soft',
       flash,
@@ -240,10 +247,10 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
 
     if (loading) {
       return (
-        <Card ref={ref} variant={variant} className={className} {...props}>
-          <CardContent>
-            <div className="h-ds-04 w-24 rounded-control-inner bg-skeleton-base animate-pulse mb-ds-05" />
-            <div className="h-ds-sm w-32 rounded-control bg-skeleton-base animate-pulse mb-ds-03" />
+        <Card ref={ref} variant={variant} size={size} className={className} aria-busy="true" {...props}>
+          <CardContent className="flex flex-col gap-ds-03">
+            <div className="h-ds-04 w-24 rounded-control-inner bg-skeleton-base animate-pulse" />
+            <div className="h-ds-sm w-32 rounded-control bg-skeleton-base animate-pulse" />
             <div className="h-3 w-16 rounded-control-inner bg-skeleton-base animate-pulse" />
           </CardContent>
         </Card>
@@ -274,10 +281,9 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
     const deltaNode = delta ? (
       <motion.div
         className={cn(
+          // Rhythm comes from CardContent's flex gap — no placement margins.
           'flex items-center gap-ds-02 text-ds-sm font-medium',
           deltaColour,
-          // block placement owns the gap to the value; inline rides the value's baseline row.
-          deltaPlacement === 'block' && 'mt-ds-03',
         )}
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
@@ -300,7 +306,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
 
     const cardContent = (
       <>
-        <div className="flex items-center justify-between mb-ds-04">
+        <div className="flex items-center justify-between">
           <motion.p
             className="text-ds-md font-medium text-surface-fg-muted"
             initial={{ opacity: 0 }}
@@ -345,38 +351,41 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
             ) : null}
           </div>
         </div>
-        <div className={cn(deltaPlacement === 'inline' && delta && 'flex items-baseline gap-ds-03')}>
-          <div className="overflow-hidden">
-            <motion.p
-              className={cn(
-                'inline-block text-ds-3xl font-semibold',
-                accentStyle === 'tint' ? 'text-accent-11' : 'text-surface-fg',
-              )}
-              initial={{ opacity: 0, y: '100%' }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={springs.smooth}
-            >
-              {prefix && (
-                <span className="text-surface-fg-muted text-ds-lg">{prefix}</span>
-              )}
-              <span className="tabular-nums">{value}</span>
-              {suffix && (
-                <span className="text-surface-fg-muted text-ds-lg">{suffix}</span>
-              )}
-            </motion.p>
+        <div className="flex flex-col gap-ds-01">
+          <div className={cn(deltaPlacement === 'inline' && delta && 'flex items-baseline gap-ds-03')}>
+            <div className="overflow-hidden">
+              <motion.p
+                className={cn(
+                  'inline-block font-semibold',
+                  size === 'sm' ? 'text-ds-2xl' : 'text-ds-3xl',
+                  accentStyle === 'tint' ? 'text-accent-11' : 'text-surface-fg',
+                )}
+                initial={{ opacity: 0, y: '100%' }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={springs.smooth}
+              >
+                {prefix && (
+                  <span className={cn('text-surface-fg-muted', size === 'sm' ? 'text-ds-md' : 'text-ds-lg')}>{prefix}</span>
+                )}
+                <span className="tabular-nums">{value}</span>
+                {suffix && (
+                  <span className={cn('text-surface-fg-muted', size === 'sm' ? 'text-ds-md' : 'text-ds-lg')}>{suffix}</span>
+                )}
+              </motion.p>
+            </div>
+            {deltaPlacement === 'inline' && deltaNode}
           </div>
-          {deltaPlacement === 'inline' && deltaNode}
+          {secondaryLabel && (
+            <motion.p
+              className="text-ds-sm text-surface-fg-subtle"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ ...tweens.fade, delay: 0.1 }}
+            >
+              {secondaryLabel}
+            </motion.p>
+          )}
         </div>
-        {secondaryLabel && (
-          <motion.p
-            className="text-ds-sm text-surface-fg-subtle mt-ds-01"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ ...tweens.fade, delay: 0.1 }}
-          >
-            {secondaryLabel}
-          </motion.p>
-        )}
         {progress != null && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -387,23 +396,34 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
           </motion.div>
         )}
         {deltaPlacement === 'block' && deltaNode}
-        {footer && (
-          <motion.div
-            className="mt-ds-04 pt-ds-04 border-t border-surface-border text-ds-sm"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ ...tweens.fade, delay: 0.25 }}
-          >
-            {footer}
-          </motion.div>
-        )}
       </>
     )
 
     // accentStyle="tint" → a subtle accent gradient wash over Card's surface.
     const tintClass =
       accentStyle === 'tint' ? 'bg-linear-to-t from-accent-2 to-surface-raised' : undefined
-    const body = <CardContent>{cardContent}</CardContent>
+    // Footer sits outside CardContent behind a full-width divider (both are direct
+    // children of Card, so the rule spans edge-to-edge — no inset border-t).
+    const body = (
+      <>
+        <CardContent className="flex flex-col gap-ds-03">{cardContent}</CardContent>
+        {footer && (
+          <>
+            <div aria-hidden="true" className="h-px w-full bg-surface-border-subtle" />
+            <CardFooter className="text-ds-sm">
+              <motion.div
+                className="w-full"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ ...tweens.fade, delay: 0.25 }}
+              >
+                {footer}
+              </motion.div>
+            </CardFooter>
+          </>
+        )}
+      </>
+    )
 
     // href → wrap Card in the framework Link (Card stays the shell; hover-lift inside).
     if (href) {
@@ -416,7 +436,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
           aria-label={computedAriaLabel}
           {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
         >
-          <Card variant={variant} interactive className={tintClass}>
+          <Card variant={variant} size={size} interactive className={tintClass}>
             {body}
           </Card>
         </Link>
@@ -429,6 +449,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
         <Card
           ref={ref}
           variant={variant}
+          size={size}
           interactive
           className={cn(tintClass, className)}
           role="button"
@@ -449,7 +470,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
     }
 
     return (
-      <Card ref={ref} variant={variant} className={cn(tintClass, className)} {...props}>
+      <Card ref={ref} variant={variant} size={size} className={cn(tintClass, className)} {...props}>
         {body}
       </Card>
     )

--- a/packages/core/src/ui/table-row-link.tsx
+++ b/packages/core/src/ui/table-row-link.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import * as React from 'react'
+
+import { useLink } from './lib/link-context'
+import { cn } from './lib/utils'
+
+export interface TableRowLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string
+  /**
+   * Stretch the click target across the whole row via a pseudo-element
+   * (a real `<a>`, so cmd/ctrl+click, middle-click, and "open in new tab"
+   * all work). Trade-off: the overlay blocks text selection inside the row —
+   * pass `stretch={false}` for a title-only link (GitHub-style) when row text
+   * must stay selectable.
+   * @default true
+   */
+  stretch?: boolean
+}
+
+/**
+ * A real-anchor row link for tables — place inside the row's primary
+ * `<TableCell className="relative">`. Replaces `onClick`-on-row navigation,
+ * which breaks cmd+click / middle-click / context-menu and isn't announced as
+ * a link by screen readers (never put onClick on a `<tr>`).
+ *
+ * Mechanics: the stretch pseudo-element is anchored to the CELL, not the row —
+ * Safari ignores `position: relative` on `<tr>` — and spans `100vw`; the Table
+ * root clips it (`overflow-x-clip`). Keyboard focus draws a row-level ring via
+ * TableRow's `has-[[data-slot=row-link]:focus-visible]` rule, so the anchor
+ * suppresses its own outline.
+ *
+ * Other interactive elements in the row (menu buttons, checkboxes) must sit
+ * above the stretch: give them `className="relative z-[1]"` (IconButton etc.).
+ *
+ * @example
+ * <TableRow>
+ *   <TableCell className="relative">
+ *     <TableRowLink href={`/projects/${id}`}>{name}</TableRowLink>
+ *   </TableCell>
+ *   <TableCell><Badge color="success">Active</Badge></TableCell>
+ *   <TableCell>
+ *     <TableRowActions>
+ *       <IconButton className="relative z-[1]" size="xs" variant="ghost" aria-label={`Actions for ${name}`} icon={<IconDots />} />
+ *     </TableRowActions>
+ *   </TableCell>
+ * </TableRow>
+ */
+const TableRowLink = React.forwardRef<HTMLAnchorElement, TableRowLinkProps>(
+  ({ className, stretch = true, children, ...props }, ref) => {
+    const Link = useLink()
+    return (
+      <Link
+        ref={ref}
+        data-slot="row-link"
+        className={cn(
+          'font-medium text-surface-fg no-underline',
+          stretch
+            ? // row ring comes from TableRow's has-[] rule; suppress the anchor's own
+              'focus-visible:outline-hidden after:absolute after:inset-y-0 after:left-0 after:w-[100vw] after:content-[""]'
+            : 'rounded-control-inner hover:underline focus-visible:outline-2 focus-visible:outline-accent-9 focus-visible:outline-offset-2',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Link>
+    )
+  },
+)
+TableRowLink.displayName = 'TableRowLink'
+
+export { TableRowLink }

--- a/packages/core/src/ui/table.stories.tsx
+++ b/packages/core/src/ui/table.stories.tsx
@@ -10,8 +10,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableRowActions,
 } from './table'
 import { TruncatedText } from './truncated-text'
+import { Button } from './button'
+import { TableRowLink } from './table-row-link'
 
 const meta: Meta<typeof Table> = {
   title: 'Components/Data Display/Table',
@@ -236,6 +239,90 @@ export const SelectedRows: Story = {
         <TableRow data-state="selected"><TableCell>#1041</TableCell><TableCell><Badge color="warning" size="xs">Sent</Badge></TableCell><TableCell className="text-right tabular-nums">₹80,000</TableCell></TableRow>
         <TableRow data-state="selected"><TableCell>#1040</TableCell><TableCell><Badge color="success" size="xs">Paid</Badge></TableCell><TableCell className="text-right tabular-nums">₹2,10,500</TableCell></TableRow>
         <TableRow><TableCell>#1039</TableCell><TableCell><Badge color="error" size="xs">Overdue</Badge></TableCell><TableCell className="text-right tabular-nums">₹36,900</TableCell></TableRow>
+      </TableBody>
+    </Table>
+  ),
+}
+
+export const RowLinks: Story = {
+  name: 'TableRowLink (whole-row navigation)',
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Project</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Owner</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {[
+          { name: 'Karm v2 — client portal', status: 'Active', owner: 'Yogin S' },
+          { name: 'Muhurat launch site', status: 'Review', owner: 'Goutham K' },
+          { name: 'Brand refresh', status: 'Active', owner: 'Amal M' },
+        ].map((p) => (
+          <TableRow key={p.name}>
+            <TableCell className="relative">
+              <TableRowLink href={`#${encodeURIComponent(p.name)}`}>{p.name}</TableRowLink>
+            </TableCell>
+            <TableCell><Badge color={p.status === 'Active' ? 'success' : 'warning'} size="xs">{p.status}</Badge></TableCell>
+            <TableCell className="text-surface-fg-muted">{p.owner}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+}
+
+export const RowActions: Story = {
+  name: 'TableRowActions (hover / focus reveal)',
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Deliverable</TableHead>
+          <TableHead>Version</TableHead>
+          <TableHead numeric>Size</TableHead>
+          <TableHead><span className="sr-only">Actions</span></TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {[
+          { name: 'Brand deck — final', v: 'v4', size: '48 MB' },
+          { name: 'Logo pack', v: 'v2', size: '12 MB' },
+          { name: 'Site copy — homepage', v: 'v7', size: '204 KB' },
+        ].map((d) => (
+          <TableRow key={d.name}>
+            <TableCell>{d.name}</TableCell>
+            <TableCell className="text-surface-fg-muted">{d.v}</TableCell>
+            <TableCell numeric>{d.size}</TableCell>
+            <TableCell>
+              <TableRowActions>
+                <Button variant="ghost" size="xs" aria-label={`Download ${d.name}`}>Download</Button>
+                <Button variant="ghost" size="xs" aria-label={`Delete ${d.name}`}>Delete</Button>
+              </TableRowActions>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+}
+
+export const NumericColumns: Story = {
+  name: 'numeric cells',
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Client</TableHead>
+          <TableHead numeric>Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow><TableCell>Meridian</TableCell><TableCell numeric>₹4,95,600.00</TableCell></TableRow>
+        <TableRow><TableCell>Vetra</TableCell><TableCell numeric>₹80,000.00</TableCell></TableRow>
+        <TableRow><TableCell>Kavya &amp; Co</TableCell><TableCell numeric className="text-error-11">(₹36,900.00)</TableCell></TableRow>
       </TableBody>
     </Table>
   ),

--- a/packages/core/src/ui/table.stories.tsx
+++ b/packages/core/src/ui/table.stories.tsx
@@ -101,10 +101,51 @@ export const Empty: Story = {
       </TableHeader>
       <TableBody>
         <TableRow>
-          <TableCell colSpan={3} className="h-24 text-center text-surface-fg-muted">
+          <TableCell colSpan={3} className="py-ds-07 text-center text-surface-fg-muted">
             No results found.
           </TableCell>
         </TableRow>
+      </TableBody>
+    </Table>
+  ),
+}
+
+export const Densities: Story = {
+  render: () => (
+    <div className="flex flex-col gap-ds-05">
+      {(['compact', 'standard', 'comfortable'] as const).map((density) => (
+        <Table key={density} density={density}>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{density}</TableHead>
+              <TableHead>Discipline</TableHead>
+              <TableHead className="text-right">Hours</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow><TableCell>Goutham K</TableCell><TableCell>UI/UX</TableCell><TableCell className="text-right tabular-nums">142</TableCell></TableRow>
+            <TableRow><TableCell>Yogin S</TableCell><TableCell>Product</TableCell><TableCell className="text-right tabular-nums">128</TableCell></TableRow>
+          </TableBody>
+        </Table>
+      ))}
+    </div>
+  ),
+}
+
+export const Striped: Story = {
+  render: () => (
+    <Table striped>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Task</TableHead>
+          <TableHead className="text-right">Estimate</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow><TableCell>Token sweep</TableCell><TableCell className="text-right tabular-nums">3h</TableCell></TableRow>
+        <TableRow><TableCell>Chart palette</TableCell><TableCell className="text-right tabular-nums">5h</TableCell></TableRow>
+        <TableRow><TableCell>Storybook deploy</TableCell><TableCell className="text-right tabular-nums">1h</TableCell></TableRow>
+        <TableRow><TableCell>Release notes</TableCell><TableCell className="text-right tabular-nums">2h</TableCell></TableRow>
       </TableBody>
     </Table>
   ),

--- a/packages/core/src/ui/table.stories.tsx
+++ b/packages/core/src/ui/table.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Avatar, AvatarFallback } from './avatar'
+import { Badge } from './badge'
 import {
   Table,
   TableBody,
@@ -9,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from './table'
+import { TruncatedText } from './truncated-text'
 
 const meta: Meta<typeof Table> = {
   title: 'Components/Data Display/Table',
@@ -146,6 +149,93 @@ export const Striped: Story = {
         <TableRow><TableCell>Chart palette</TableCell><TableCell className="text-right tabular-nums">5h</TableCell></TableRow>
         <TableRow><TableCell>Storybook deploy</TableCell><TableCell className="text-right tabular-nums">1h</TableCell></TableRow>
         <TableRow><TableCell>Release notes</TableCell><TableCell className="text-right tabular-nums">2h</TableCell></TableRow>
+      </TableBody>
+    </Table>
+  ),
+}
+
+// Rich cell recipes — the patterns real tables are made of. Density→avatar rule:
+// compact = text only, standard = Avatar size "xs", comfortable = "xs" or "sm".
+const people = [
+  { name: 'Goutham Krishnan', email: 'goutham@devalok.in', initials: 'GK', role: 'UI/UX', tags: ['Karm', 'Muhurat'], extra: 0, amount: '₹1,80,000' },
+  { name: 'Yogin Sadanandan', email: 'yogin@devalok.in', initials: 'YS', role: 'Product', tags: ['Karm', 'Brand', 'Web'], extra: 2, amount: '₹2,40,000' },
+  { name: 'Amal Mathew', email: 'amal@devalok.in', initials: 'AM', role: 'Motion', tags: [], extra: 0, amount: '—' },
+]
+
+export const RichCells: Story = {
+  name: 'Rich cells (user / tags / money / empty)',
+  render: () => (
+    <Table density="comfortable">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Member</TableHead>
+          <TableHead>Role</TableHead>
+          <TableHead>Projects</TableHead>
+          <TableHead className="text-right">Billed</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {people.map((p) => (
+          <TableRow key={p.email}>
+            {/* User cell: xs avatar keeps the 37px standard row; both lines truncate */}
+            <TableCell>
+              <div className="flex items-center gap-ds-03 min-w-0">
+                <Avatar size="xs">
+                  <AvatarFallback>{p.initials}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 leading-ds-tight">
+                  <TruncatedText as="p" className="text-surface-fg font-medium">{p.name}</TruncatedText>
+                  <TruncatedText as="p" mode="middle" className="text-ds-sm text-surface-fg-muted">{p.email}</TruncatedText>
+                </div>
+              </div>
+            </TableCell>
+            <TableCell className="text-surface-fg-muted">{p.role}</TableCell>
+            {/* Tag group with +N overflow — never let badges wrap the row taller */}
+            <TableCell>
+              {p.tags.length === 0 ? (
+                <span className="text-surface-fg-subtle" aria-label="No projects">—</span>
+              ) : (
+                <div className="flex items-center gap-ds-02">
+                  {p.tags.slice(0, 2).map((t) => (
+                    <Badge key={t} color="neutral" size="xs">{t}</Badge>
+                  ))}
+                  {p.extra > 0 && (
+                    <span className="text-ds-sm text-surface-fg-subtle">+{p.extra}</span>
+                  )}
+                </div>
+              )}
+            </TableCell>
+            {/* Money cell: right-aligned tabular figures; em-dash for empty */}
+            <TableCell className="text-right tabular-nums">{p.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right tabular-nums">₹4,20,000</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+}
+
+export const SelectedRows: Story = {
+  name: 'Selected + hover states',
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow><TableCell>#1042</TableCell><TableCell><Badge color="success" size="xs">Paid</Badge></TableCell><TableCell className="text-right tabular-nums">₹4,95,600</TableCell></TableRow>
+        <TableRow data-state="selected"><TableCell>#1041</TableCell><TableCell><Badge color="warning" size="xs">Sent</Badge></TableCell><TableCell className="text-right tabular-nums">₹80,000</TableCell></TableRow>
+        <TableRow data-state="selected"><TableCell>#1040</TableCell><TableCell><Badge color="success" size="xs">Paid</Badge></TableCell><TableCell className="text-right tabular-nums">₹2,10,500</TableCell></TableRow>
+        <TableRow><TableCell>#1039</TableCell><TableCell><Badge color="error" size="xs">Overdue</Badge></TableCell><TableCell className="text-right tabular-nums">₹36,900</TableCell></TableRow>
       </TableBody>
     </Table>
   ),

--- a/packages/core/src/ui/table.test.tsx
+++ b/packages/core/src/ui/table.test.tsx
@@ -10,7 +10,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableRowActions,
 } from './table'
+import { TableRowLink } from './table-row-link'
 
 describe('Table', () => {
   const renderTable = () =>
@@ -171,5 +173,110 @@ describe('Table', () => {
       </Table>,
     )
     expect(screen.getByRole('columnheader')).toHaveClass('text-ds-sm', 'font-medium', 'text-surface-fg-muted', 'py-(--table-py)')
+  })
+
+  describe('numeric', () => {
+    it('right-aligns cells with tabular figures; header follows', () => {
+      render(
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead numeric>Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell numeric>₹80,000</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>,
+      )
+      expect(screen.getByRole('columnheader')).toHaveClass('text-right')
+      expect(screen.getByRole('cell')).toHaveClass('text-right', 'tabular-nums')
+    })
+  })
+
+  describe('TableRowActions', () => {
+    it('is hidden until row hover/focus but stays permanently in the tab order (opacity reveal)', () => {
+      render(
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <TableRowActions data-testid="actions">
+                  <button type="button">Delete</button>
+                </TableRowActions>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>,
+      )
+      const actions = screen.getByTestId('actions')
+      expect(actions).toHaveClass(
+        'opacity-0',
+        'group-hover/row:opacity-100',
+        'group-focus-within/row:opacity-100',
+        'pointer-coarse:opacity-100',
+      )
+      // reveal is opacity-based — the button must be focusable at all times
+      expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    })
+
+    it('persist keeps actions always visible', () => {
+      render(
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <TableRowActions data-testid="actions" persist>
+                  <button type="button">Delete</button>
+                </TableRowActions>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>,
+      )
+      expect(screen.getByTestId('actions')).toHaveClass('opacity-100')
+      expect(screen.getByTestId('actions')).not.toHaveClass('opacity-0')
+    })
+  })
+
+  describe('TableRowLink', () => {
+    it('renders a real anchor with the row-link slot marker and full-row stretch', () => {
+      render(
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell className="relative">
+                <TableRowLink href="/projects/1">Karm v2</TableRowLink>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>,
+      )
+      const link = screen.getByRole('link', { name: 'Karm v2' })
+      expect(link).toHaveAttribute('href', '/projects/1')
+      expect(link).toHaveAttribute('data-slot', 'row-link')
+      expect(link).toHaveClass('after:absolute', 'after:w-[100vw]')
+      // row draws the focus ring; the anchor suppresses its own
+      expect(link).toHaveClass('focus-visible:outline-hidden')
+    })
+
+    it('stretch={false} renders a plain title link with its own focus ring', () => {
+      render(
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <TableRowLink href="/projects/1" stretch={false}>Karm v2</TableRowLink>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>,
+      )
+      const link = screen.getByRole('link', { name: 'Karm v2' })
+      expect(link).not.toHaveClass('after:absolute')
+      expect(link).toHaveClass('focus-visible:outline-2')
+    })
   })
 })

--- a/packages/core/src/ui/table.test.tsx
+++ b/packages/core/src/ui/table.test.tsx
@@ -74,4 +74,73 @@ describe('Table', () => {
     const { container } = renderTable()
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('rows carry a hairline border and a visible (raised-hover) hover wash', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    )
+    const row = screen.getAllByRole('row')[0]
+    expect(row).toHaveClass('border-b', 'border-surface-border-subtle', 'hover:bg-surface-raised-hover')
+  })
+
+  it('density defaults to standard and sets --table-py; cells read it', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    )
+    expect(screen.getByRole('table')).toHaveClass('[--table-py:var(--spacing-ds-03)]')
+    expect(screen.getByRole('cell')).toHaveClass('py-(--table-py)', 'px-ds-04')
+  })
+
+  it('density="compact" and "comfortable" reassign the variable', () => {
+    const { rerender } = render(<Table density="compact"><TableBody><TableRow><TableCell>C</TableCell></TableRow></TableBody></Table>)
+    expect(screen.getByRole('table')).toHaveClass('[--table-py:var(--spacing-ds-02)]')
+    rerender(<Table density="comfortable"><TableBody><TableRow><TableCell>C</TableCell></TableRow></TableBody></Table>)
+    expect(screen.getByRole('table')).toHaveClass('[--table-py:var(--spacing-ds-04)]')
+  })
+
+  it('edge cells read --table-edge so tables align with card slots', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    )
+    expect(screen.getByRole('table')).toHaveClass('[--table-edge:var(--card-spacing,var(--spacing-ds-04))]')
+    expect(screen.getByRole('cell')).toHaveClass('first:pl-(--table-edge)', 'last:pr-(--table-edge)')
+  })
+
+  it('striped is opt-in — zebra class only when set', () => {
+    const { rerender } = render(<Table><TableBody><TableRow><TableCell>C</TableCell></TableRow></TableBody></Table>)
+    expect(screen.getByRole('table')).not.toHaveClass('[&_tbody_tr:nth-child(even)]:bg-surface-base')
+    rerender(<Table striped><TableBody><TableRow><TableCell>C</TableCell></TableRow></TableBody></Table>)
+    expect(screen.getByRole('table')).toHaveClass('[&_tbody_tr:nth-child(even)]:bg-surface-base')
+  })
+
+  it('header cells are quieter than data — text-ds-sm muted, density-tracked padding', () => {
+    render(
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+          </TableRow>
+        </TableHeader>
+      </Table>,
+    )
+    expect(screen.getByRole('columnheader')).toHaveClass('text-ds-sm', 'font-medium', 'text-surface-fg-muted', 'py-(--table-py)')
+  })
 })

--- a/packages/core/src/ui/table.test.tsx
+++ b/packages/core/src/ui/table.test.tsx
@@ -6,6 +6,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
   TableHeader,
   TableRow,
@@ -87,6 +88,34 @@ describe('Table', () => {
     )
     const row = screen.getAllByRole('row')[0]
     expect(row).toHaveClass('border-b', 'border-surface-border-subtle', 'hover:bg-surface-raised-hover')
+  })
+
+  it('selected rows have an explicit selected+hover step (accent-4)', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow data-state="selected">
+            <TableCell>Cell</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>,
+    )
+    const row = screen.getAllByRole('row')[0]
+    expect(row).toHaveClass('data-[state=selected]:bg-accent-3', 'data-[state=selected]:hover:bg-accent-4')
+  })
+
+  it('footer is a surface-base band, not a translucent raised wash', () => {
+    render(
+      <Table>
+        <TableFooter data-testid="tfoot">
+          <TableRow>
+            <TableCell>Total</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>,
+    )
+    const tfoot = screen.getByTestId('tfoot')
+    expect(tfoot).toHaveClass('bg-surface-base', 'border-t', 'border-surface-border-subtle')
   })
 
   it('density defaults to standard and sets --table-py; cells read it', () => {

--- a/packages/core/src/ui/table.tsx
+++ b/packages/core/src/ui/table.tsx
@@ -17,6 +17,15 @@ const densityClasses: Record<TableDensity, string> = {
   comfortable: '[--table-py:var(--spacing-ds-04)]',
 }
 
+export interface TableCellBaseProps {
+  /**
+   * Quantitative column: right-aligns and uses tabular figures so digits line up.
+   * Keep decimal places consistent per column; identifier-numbers (dates, phones,
+   * IDs) stay left-aligned — they're names, not quantities.
+   */
+  numeric?: boolean
+}
+
 export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
   /** Row density — vertical cell padding for header + body. @default 'standard' */
   density?: TableDensity
@@ -33,7 +42,9 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
       <table
         ref={ref}
         className={cn(
-          "w-full caption-bottom text-ds-md [--table-edge:var(--card-spacing,var(--spacing-ds-04))]",
+          // overflow-x-clip contains TableRowLink's 100vw stretch pseudo-element
+          // without creating a horizontal scrollbar (the wrapper owns scrolling).
+          "w-full caption-bottom text-ds-md overflow-x-clip [--table-edge:var(--card-spacing,var(--spacing-ds-04))]",
           densityClasses[density],
           striped && "[&_tbody_tr:nth-child(even)]:bg-surface-base",
           className,
@@ -94,7 +105,11 @@ const TableRow = React.forwardRef<
       // surface-raised hover would be invisible (the 0.44-era port bug).
       // selected+hover gets its own explicit step — without it the hover and
       // selected classes tie on specificity and stylesheet order decides.
-      "border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3 data-[state=selected]:hover:bg-accent-4",
+      // `group/row` lets TableRowActions reveal on row hover/focus; the has-[]
+      // rule draws a row-level focus ring when a TableRowLink inside is
+      // keyboard-focused (the anchor itself suppresses its own ring).
+      "group/row border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3 data-[state=selected]:hover:bg-accent-4",
+      "has-[[data-slot=row-link]:focus-visible]:outline-2 has-[[data-slot=row-link]:focus-visible]:outline-accent-9 has-[[data-slot=row-link]:focus-visible]:-outline-offset-2",
       className,
     )}
     {...props}
@@ -104,8 +119,8 @@ TableRow.displayName = "TableRow"
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+  React.ThHTMLAttributes<HTMLTableCellElement> & TableCellBaseProps
+>(({ className, numeric, ...props }, ref) => (
   <th
     ref={ref}
     scope="col"
@@ -113,6 +128,7 @@ const TableHead = React.forwardRef<
       // Header is quieter than the data: one step smaller, medium, muted.
       // Height tracks density via the same --table-py the body cells read.
       "py-(--table-py) px-ds-04 first:pl-(--table-edge) last:pr-(--table-edge) text-left align-middle text-ds-sm font-medium text-surface-fg-muted [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      numeric && "text-right",
       className,
     )}
     {...props}
@@ -122,18 +138,61 @@ TableHead.displayName = "TableHead"
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+  React.TdHTMLAttributes<HTMLTableCellElement> & TableCellBaseProps
+>(({ className, numeric, ...props }, ref) => (
   <td
     ref={ref}
     className={cn(
       "py-(--table-py) px-ds-04 first:pl-(--table-edge) last:pr-(--table-edge) align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      numeric && "text-right tabular-nums",
       className,
     )}
     {...props}
   />
 ))
 TableCell.displayName = "TableCell"
+
+export interface TableRowActionsProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Always show the actions instead of revealing on row hover/focus. Use for
+   * tables where actions must be permanently discoverable (the GitLab stance),
+   * or when the row has few columns and the density win doesn't matter.
+   */
+  persist?: boolean
+}
+
+/**
+ * Right-aligned action cluster for a table row, revealed on row hover — and,
+ * critically, on keyboard focus: the buttons stay in the tab order permanently
+ * (opacity reveal, never display:none) and appear the moment focus enters the
+ * row (WCAG 1.4.13). On touch devices (no hover) they are always visible.
+ *
+ * Give the actions column a visually-hidden header: `<TableHead><span className="sr-only">Actions</span></TableHead>`.
+ *
+ * @example
+ * <TableCell>
+ *   <TableRowActions>
+ *     <IconButton size="xs" variant="ghost" aria-label={`Download ${name}`} icon={<IconDownload />} />
+ *     <IconButton size="xs" variant="ghost" aria-label={`Delete ${name}`} icon={<IconTrash />} />
+ *   </TableRowActions>
+ * </TableCell>
+ */
+const TableRowActions = React.forwardRef<HTMLDivElement, TableRowActionsProps>(
+  ({ className, persist, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex items-center justify-end gap-ds-01 transition-opacity duration-fast-01 ease-productive-standard",
+        persist
+          ? "opacity-100"
+          : "opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 pointer-coarse:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+TableRowActions.displayName = "TableRowActions"
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -160,4 +219,5 @@ export {
   TableHead,
   TableHeader,
   TableRow,
+  TableRowActions,
 }

--- a/packages/core/src/ui/table.tsx
+++ b/packages/core/src/ui/table.tsx
@@ -72,7 +72,10 @@ const TableFooter = React.forwardRef<
   <tfoot
     ref={ref}
     className={cn(
-      "bg-[color-mix(in_srgb,var(--color-surface-raised)_50%,transparent)] font-medium [&>tr]:last:border-b-0",
+      // surface-base band, not raised@50% — the footer must read against the
+      // card surface the table lives on (same mis-mapped shadcn muted/50 family
+      // as the row-hover bug).
+      "border-t border-surface-border-subtle bg-surface-base font-medium [&>tr]:last:border-b-0",
       className
     )}
     {...props}
@@ -89,7 +92,9 @@ const TableRow = React.forwardRef<
     className={cn(
       // raised-hover, NOT raised — tables live on cards (surface-raised), so a
       // surface-raised hover would be invisible (the 0.44-era port bug).
-      "border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3",
+      // selected+hover gets its own explicit step — without it the hover and
+      // selected classes tie on specificity and stylesheet order decides.
+      "border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3 data-[state=selected]:hover:bg-accent-4",
       className,
     )}
     {...props}

--- a/packages/core/src/ui/table.tsx
+++ b/packages/core/src/ui/table.tsx
@@ -3,25 +3,53 @@ import * as React from "react"
 
 import { cn } from "./lib/utils"
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-ds-md", className)}
-      {...props}
-    />
-  </div>
-))
+/** Row density — sets --table-py, which header and body cells both read. */
+type TableDensity = 'compact' | 'standard' | 'comfortable'
+
+// One variable pair drives the table's spacing (same pattern as Card):
+// --table-py    vertical cell padding per density (4 / 8 / 12px → rows ≈ 29 / 37 / 45px)
+// --table-edge  first/last-cell inline padding — inherits --card-spacing when the table
+//               sits inside a Card, so edge columns align with the card's slots;
+//               falls back to ds-04 (12px) standalone.
+const densityClasses: Record<TableDensity, string> = {
+  compact: '[--table-py:var(--spacing-ds-02)]',
+  standard: '[--table-py:var(--spacing-ds-03)]',
+  comfortable: '[--table-py:var(--spacing-ds-04)]',
+}
+
+export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
+  /** Row density — vertical cell padding for header + body. @default 'standard' */
+  density?: TableDensity
+  /**
+   * Zebra striping (even body rows get the faintest surface step). Opt-in only —
+   * for very wide/dense tables; hairline separators are the default row cue.
+   */
+  striped?: boolean
+}
+
+const Table = React.forwardRef<HTMLTableElement, TableProps>(
+  ({ className, density = 'standard', striped, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn(
+          "w-full caption-bottom text-ds-md [--table-edge:var(--card-spacing,var(--spacing-ds-04))]",
+          densityClasses[density],
+          striped && "[&_tbody_tr:nth-child(even)]:bg-surface-base",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  ),
+)
 Table.displayName = "Table"
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("", className)} {...props} />
+  <thead ref={ref} className={cn("[&_tr]:border-b [&_tr]:border-surface-border-subtle", className)} {...props} />
 ))
 TableHeader.displayName = "TableHeader"
 
@@ -59,8 +87,10 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "transition-colors hover:bg-surface-raised data-[state=selected]:bg-accent-3",
-      className
+      // raised-hover, NOT raised — tables live on cards (surface-raised), so a
+      // surface-raised hover would be invisible (the 0.44-era port bug).
+      "border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3",
+      className,
     )}
     {...props}
   />
@@ -75,8 +105,10 @@ const TableHead = React.forwardRef<
     ref={ref}
     scope="col"
     className={cn(
-      "h-ds-md px-ds-03 text-left font-medium text-surface-fg-muted [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      // Header is quieter than the data: one step smaller, medium, muted.
+      // Height tracks density via the same --table-py the body cells read.
+      "py-(--table-py) px-ds-04 first:pl-(--table-edge) last:pr-(--table-edge) text-left align-middle text-ds-sm font-medium text-surface-fg-muted [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className,
     )}
     {...props}
   />
@@ -90,8 +122,8 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "py-ds-03 px-ds-03 [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
+      "py-(--table-py) px-ds-04 first:pl-(--table-edge) last:pr-(--table-edge) align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className,
     )}
     {...props}
   />
@@ -110,9 +142,9 @@ const TableCaption = React.forwardRef<
 ))
 TableCaption.displayName = "TableCaption"
 
-export type TableProps = React.HTMLAttributes<HTMLTableElement>
 export type TableRowProps = React.HTMLAttributes<HTMLTableRowElement>
 export type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement>
+export type { TableDensity }
 
 export {
   Table,


### PR DESCRIPTION
## What

Four design-review batches on one branch, each previewed as an artifact + signed off before implementation.

1. **Card variable model** (`9439e83f`) — `size` assigns `--card-spacing`/`--card-gap`; slots/CardAction/CardBleed read the pair. CardSizeContext + 2 lookup maps deleted; rendered spacing unchanged. New: `CardBleed`, `orientation="horizontal"` + `CardSection`, dev warning for bare-text Card children. StatCard: `size` prop, flex-gap rhythm, full-width footer rule, aria-busy skeleton. Offender cleanup (notification-preferences double-gap, stories, make-kit guides).
2. **Table frame** (`13e6f5a7`) — restore lost row `border-b`; fix invisible hover token (`surface-raised` → `surface-raised-hover`, 4 sites); `density` prop via `--table-py` (rows 29/37/45px, was 29/53/85); `--table-edge` aligns first/last cells with card slots; quiet header; opt-in `striped`; DataTableCards composes `Card size="sm" variant="outline"`.
3. **Footer + recipes** (`9e92db48`) — TableFooter invisible raised@50% → `surface-base` band; explicit selected+hover step (accent-4); cell recipes (user cell, tag +N, money conventions) + density→avatar mapping (two-line identity = comfortable only).
4. **Row features** (`638fc280`) — `TableRowLink` (real-anchor whole-row navigation, Safari-safe cell-anchored stretch, row focus ring, `stretch={false}` mode), `TableRowActions` (opacity reveal, permanently tabbable, :focus-within + touch fallbacks, `persist`), `numeric` prop, expansion a11y (`aria-expanded` on button, sr-only header) + animated reveal (springs.smooth, useReducedMotion self-guard; virtual rows instant). Plus make-kit table guide sync.

## Why

Cross-system research (shadcn 2025, Radix Themes, Chakra, Mantine, Polaris, Carbon, MUI, Atlassian, Primer + Roselli/WCAG/NN/g) — three research reports drove the specs. Convergent patterns: one CSS variable as spacing source of truth; horizontal hairlines + 4-8% hover wash + 32/40/48 density; structural cells shipped, content cells documented.

## Verification

- typecheck ✓ · full suite green · build 6/6 ✓ · SSR smoke 147/147 ✓ per commit
- New stories: FullBleedMedia, Horizontal, SpacingOverride, DenseGrid, Densities, Striped, RichCells, SelectedRows, RowLinks, RowActions, NumericColumns
- Visible default change: standard table rows tighten ~53→37px — Chromatic will flag table stories on merge; that diff is the fix working.
- Note: the `segmented-control.tsx` lint error in local runs belongs to uncommitted parallel wave-1 work, not this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGt9mqG7gmiGjMV9zPVNLH