### PR TITLE
fix(release): compiled-CSS coverage false-positive on focus-ring

### DIFF
--- a/packages/core/src/composed/file-preview/shared.tsx
+++ b/packages/core/src/composed/file-preview/shared.tsx
@@ -61,7 +61,7 @@ export function ToolbarDivider() {
 // ============================================================
 // Shared: MediaSlider — slim seek/scrub/volume control
 // Composes the Radix Slider primitive (the same one ui/Slider uses) so it's
-// keyboard-operable (Arrow/Home/End), focus-ringed, and forced-colors-safe —
+// keyboard-operable (Arrow/Home/End), shows a visible focus ring, and forced-colors-safe —
 // unlike the old mouse-only <div role="slider">. Styled slim for media chrome;
 // the thumb is hover/focus-reveal (hidden at rest, shown on hover, drag, or
 // keyboard focus). `tone="dark"` = white-on-overlay; `tone="light"` = accent.

--- a/scripts/audit-compiled-css.mjs
+++ b/scripts/audit-compiled-css.mjs
@@ -111,7 +111,7 @@ const MUST_EMIT = [
   /\bz-(base|raised|dropdown|sticky|overlay|modal|popover|toast|tooltip)\b/g,
   /\b(text-heading|text-body|text-label|text-label-plain)-[a-z0-9]+/g,
   /\btext-(caption|overline|code)\b/g,
-  /\bfocus-ring(?:-inset|-sm)?/g,
+  /\bfocus-ring(?:-inset|-sm)?\b/g,
   /\btouch-target\b/g,
   /\btabular-nums\b/g,
   /\b(pt|pb|pl|pr|p)-safe\b/g,


### PR DESCRIPTION
The 0.45.0 release failed the **Compiled-CSS coverage (Webpack)** gate: `focus-ring` flagged as used-but-not-emitted.

**Root cause — false positive.** A prose word in the MediaSlider comment (`focus-ringed`) matched the audit's `/\bfocus-ring(?:-inset|-sm)?/` pattern, so the audit thought the `focus-ring` utility was referenced by a shipped component. It isn't — the only real usage is the foundations showcase *story* (excluded from consumer bundles), so the utility legitimately isn't in the consumer's compiled CSS.

**Fix (both belt + suspenders):**
- Reword the comment so it no longer contains a class-shaped token.
- Harden the audit pattern with a trailing `\b` so prose like `focus-ringed` can't match the utility name — still matches `focus-ring` / `-inset` / `-sm` and real `className` usage (verified).

Unblocks the 0.45.0 Version Packages PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)