### PR TITLE
chore: widen /check-karm-feedback to include mcp-submitted

### DIFF
--- a/.claude/commands/check-karm-feedback.md
+++ b/.claude/commands/check-karm-feedback.md
@@ -1,9 +1,17 @@
-Read all open GitHub Issues on `devalok-design/shilp-sutra` with label `karm-ai-agent-feedback`.
+Read all open GitHub Issues on `devalok-design/shilp-sutra` filed by AI agents — those with label `karm-ai-agent-feedback` (Karm's agent flow) OR `mcp-submitted` (filed via the MCP `report_issue` tool by any consumer agent):
+
+```bash
+gh issue list --repo devalok-design/shilp-sutra --state open \
+  --search 'label:karm-ai-agent-feedback,mcp-submitted' \
+  --json number,title,labels,author,createdAt
+```
+
+(A comma-separated `label:` qualifier is an OR in GitHub search.) `mcp-submitted` issues are **unvetted** — filed programmatically by an agent that hit a wall, carrying `agent-filed` + `needs-triage`. Treat their claims as reports to verify, not confirmed bugs.
 
 For each issue:
 1. Read the issue title, body, and any comments
 2. Investigate the reported problem against the actual codebase — check if the component/export/behavior exists and works as described
 3. Categorize: confirmed bug, already works (reporter error), docs gap, or missing feature
-4. Present a summary table of all open issues with your findings
+4. Present a summary table of all open issues with your findings (include which label/source each came from)
 
 **Do NOT fix code, comment on issues, or close issues until the user explicitly approves.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,13 +164,13 @@ This complements the static `llms.txt` router + `mcp-manifest.json` with interac
 ## Consumer AI Agent Feedback Protocol
 
 This repo receives feedback from AI agents working on consumer apps (e.g., Karm).
-Feedback arrives as GitHub Issues on `devalok-design/shilp-sutra` labeled `karm-ai-agent-feedback`.
+Feedback arrives as GitHub Issues on `devalok-design/shilp-sutra` labeled `karm-ai-agent-feedback` (Karm's flow) or `mcp-submitted` (filed via the MCP `report_issue` tool by any consumer agent).
 
 **You do NOT check or act on these automatically.** Only act when triggered:
 
 ### /check-karm-feedback
 
-Read all open issues labeled `karm-ai-agent-feedback` on `devalok-design/shilp-sutra`.
+Read all open issues labeled `karm-ai-agent-feedback` OR `mcp-submitted` on `devalok-design/shilp-sutra`.
 For each issue:
 1. Investigate the reported problem against the actual codebase
 2. Summarize findings (confirmed bug, already works, docs gap, etc.)


### PR DESCRIPTION
The MCP `report_issue` tool labels its filings `mcp-submitted`; `/check-karm-feedback` previously read only `karm-ai-agent-feedback`, so MCP-filed issues were never triaged by the skill.

- Skill now reads open issues with `karm-ai-agent-feedback` OR `mcp-submitted` (comma-OR label search).
- Flags `mcp-submitted` issues as unvetted (verify before acting).
- CLAUDE.md § Consumer AI Agent Feedback Protocol updated to match.

Docs/tooling only — no package code, not shipped in the tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)