### PR TITLE
fix(core): round magic font-sizes to DS tokens (Message + VideoPreview)

### DIFF
--- a/.changeset/round-magic-fontsizes.md
+++ b/.changeset/round-magic-fontsizes.md
@@ -1,0 +1,9 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Round eight hard-coded font-sizes in Message and VideoPreview up to DS type-scale tokens (v0.44 followups item E). Chat sender name and message/edit bodies move `text-[13px]` → `text-ds-md` (14px); the chat timestamp and the video-preview timecode + playback-rate button move `text-[11px]` → `text-ds-sm` (12px).
+
+Rationale: peer systems closest to our use (Atlassian, IBM Carbon) hold a 12px legibility floor and carry no 11/13px step — chat body is primary reading text, so it takes the canonical `ds-md` body step rather than shrinking. Token utilities set font-size only in TW4, so line-heights are unchanged.
+
+Visible effect: chat text reads slightly roomier. The `badge-indicator` count pill intentionally keeps its 11px value — a decorative numeral in a fixed 18px pill, not body text, so the text floor doesn't apply. Non-breaking (no API change).

--- a/packages/core/src/composed/file-preview/video-preview.tsx
+++ b/packages/core/src/composed/file-preview/video-preview.tsx
@@ -205,13 +205,13 @@ export default function VideoPreview({ url, onError }: { url: string; onError?: 
                 onMuteToggle={() => { setMuted(!muted); if (videoRef.current) videoRef.current.muted = !muted }}
                 variant="dark"
               />
-              <span className="text-[11px] font-mono text-white/70 tabular-nums">
+              <span className="text-ds-sm font-mono text-white/70 tabular-nums">
                 {formatTime(currentTime)} / {formatTime(duration)}
               </span>
               <div className="flex-1" />
               <button
                 onClick={() => cyclePlaybackRate(1)}
-                className="text-[11px] font-mono text-white/70 hover:text-white px-1 rounded-control-inner hover:bg-white/10 transition-colors"
+                className="text-ds-sm font-mono text-white/70 hover:text-white px-1 rounded-control-inner hover:bg-white/10 transition-colors"
                 aria-label={`Playback speed: ${playbackRate}x`}
               >
                 {playbackRate}x

--- a/packages/core/src/ui/chat/message.tsx
+++ b/packages/core/src/ui/chat/message.tsx
@@ -250,10 +250,10 @@ function MessageAuthor({
 
   return (
     <div className="flex items-baseline gap-ds-02">
-      <span className="font-semibold text-[13px] text-surface-fg">{name}</span>
+      <span className="font-semibold text-ds-md text-surface-fg">{name}</span>
       {badge}
       {timeStr && (
-        <span className="text-[11px] text-surface-fg-subtle/50">{timeStr}</span>
+        <span className="text-ds-sm text-surface-fg-subtle/50">{timeStr}</span>
       )}
     </div>
   )
@@ -270,7 +270,7 @@ function MessageBody({ children, className, ...props }: MessageBodyProps) {
   return (
     <div
       className={cn(
-        'text-[13px] leading-relaxed text-surface-fg whitespace-pre-wrap',
+        'text-ds-md leading-relaxed text-surface-fg whitespace-pre-wrap',
         className,
       )}
       {...props}
@@ -344,7 +344,7 @@ function MessageEditableBody({
 
   if (isEditing) {
     return (
-      <div className="text-[13px] leading-relaxed">
+      <div className="text-ds-md leading-relaxed">
         <Textarea
           ref={textareaRef}
           value={editDraft}
@@ -352,7 +352,7 @@ function MessageEditableBody({
           onKeyDown={handleKeyDown}
           onBlur={handleSave}
           // compact inline-edit overrides on top of the Textarea base
-          className="resize-none rounded-control-inner bg-surface-raised-hover px-ds-02 py-ds-01 text-[13px] leading-relaxed"
+          className="resize-none rounded-control-inner bg-surface-raised-hover px-ds-02 py-ds-01 text-ds-md leading-relaxed"
           rows={2}
         />
         <div className="mt-ds-01 text-ds-xs text-surface-fg-subtle/50">
@@ -365,7 +365,7 @@ function MessageEditableBody({
   return (
     <div
       className={cn(
-        'text-[13px] leading-relaxed text-surface-fg whitespace-pre-wrap',
+        'text-ds-md leading-relaxed text-surface-fg whitespace-pre-wrap',
         canEdit && 'cursor-pointer hover:bg-surface-raised-hover rounded-control-inner transition-colors',
       )}
       onClick={handleStartEdit}


### PR DESCRIPTION
## What

v0.44 followups **item E** — eight hard-coded font-sizes move to the DS type scale (rounded *up*):

| Site | Before | After |
|------|--------|-------|
| Message sender name | `text-[13px]` | `text-ds-md` (14) |
| Message body / edit ×4 | `text-[13px]` | `text-ds-md` (14) |
| Message timestamp | `text-[11px]` | `text-ds-sm` (12) |
| VideoPreview timecode + rate | `text-[11px]` | `text-ds-sm` (12) |

`badge-indicator` **intentionally keeps** `text-[11px]` — a decorative numeral in a fixed 18px count pill, not body text, so the legibility floor doesn't apply.

## Why round up, not down

Peer systems closest to our use hold a **12px legibility floor** with no 11/13px step: Atlassian explicitly raised smallest text 11→12 for accessibility; IBM Carbon's caption/label both sit at 12. Chat body is *primary reading text*, so it takes the canonical `ds-md` body step rather than shrinking. Every rounding was ±1px and equidistant, so this was a judgment call grounded in that research — not a coin-flip.

TW4 `--text-ds-*` utilities set **font-size only**, so `leading-relaxed` / `leading-none` / default line-heights are untouched — pure size swaps.

## Verification

- `typecheck` ✓
- `lint` ✓ (0 errors; 3 pre-existing a11y *warnings* on untouched lines)
- Tests ✓ — `message.test.tsx` + `file-preview.test.tsx` + `chat-a11y.test.tsx` → 39/39. No test asserted the old classes.

## Visible effect

Chat text reads slightly roomier — the correct direction (legibility + canonical body step), not a shrink. Chromatic will flag the chat + video-preview stories on merge; **that diff is the change**. Non-breaking (no API change) → patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4vPCYw2cPST2rou4QKZNo