### PR TITLE
fix(core): settle spring-overshoot + guard non-transform motion loops (W5 motion compliance)

### DIFF
--- a/.changeset/w5-motion-compliance.md
+++ b/.changeset/w5-motion-compliance.md
@@ -1,0 +1,10 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Motion compliance pass (anti-convergence v1.1 motion rules / locked decision B "settle, don't bounce").
+
+- **Reduced-motion guards (2):** the avatar online-status dot and the deadline-indicator overdue/critical state animate a continuous opacity pulse (`repeat: Infinity`). These are non-transform loops that framer's global `MotionConfig reducedMotion="user"` cannot stop, so they now self-guard with `useReducedMotion()` — reduced-motion users get the static variant (colour still signals status/urgency). No change for everyone else.
+- **Spring-overshoot retunes (6):** resting-state indicators that popped with `springs.bouncy` (ζ≈0.53, visible overshoot) now settle — radio dot and filter count → `springs.snappy`; count badge, avatar badge, and stat-card delta → `springs.smooth` (matching the delta's sibling, which was already smooth); multi-select selection check → `springs.snappy`.
+
+Deliberate-moment pops (toast completion icons, upload-success check, devadoot celebration) and gesture-following springs (segmented-control slider, attachment-strip layout) keep `bouncy` — the rule's allowed exceptions. Non-breaking (no API change).

--- a/packages/core/src/composed/deadline-indicator.tsx
+++ b/packages/core/src/composed/deadline-indicator.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { IconClock } from '@tabler/icons-react'
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 
 import { Icon } from '../ui/icon'
@@ -95,7 +95,10 @@ const DeadlineIndicator = React.forwardRef<HTMLSpanElement, DeadlineIndicatorPro
 
   const isOverdue = minutesRemaining <= 0
   const isCritical = minutesRemaining <= criticalThreshold && minutesRemaining > 0
-  const shouldPulse = isOverdue || isCritical
+  // Non-transform opacity loop — MotionConfig won't stop it, so drop the pulse
+  // under reduced motion. Colour still signals urgency.
+  const prefersReduced = useReducedMotion()
+  const shouldPulse = (isOverdue || isCritical) && !prefersReduced
 
   const showTooltip = format === 'relative'
   const tooltipContent = deadlineDate.toLocaleString()

--- a/packages/core/src/composed/filter-bar.tsx
+++ b/packages/core/src/composed/filter-bar.tsx
@@ -193,7 +193,7 @@ function FilterMultiSelect({
               key={count}
               initial={{ scale: 0.8 }}
               animate={{ scale: 1 }}
-              transition={springs.bouncy}
+              transition={springs.snappy}
               className="inline-flex"
             >
               <Badge size="xs" variant="solid" className="ml-ds-01">

--- a/packages/core/src/composed/multi-select-popover.tsx
+++ b/packages/core/src/composed/multi-select-popover.tsx
@@ -241,7 +241,7 @@ const MultiSelectPopover = React.forwardRef<HTMLDivElement, MultiSelectPopoverPr
             <motion.span
               initial={{ scale: 0 }}
               animate={{ scale: 1 }}
-              transition={springs.bouncy}
+              transition={springs.snappy}
               className="inline-flex shrink-0"
             >
               <Icon icon={IconCheck} size="sm" className="text-accent-11" />

--- a/packages/core/src/ui/avatar.tsx
+++ b/packages/core/src/ui/avatar.tsx
@@ -2,7 +2,7 @@
 
 import * as AvatarPrimitive from "@primitives/react-avatar"
 import { cva, type VariantProps } from "class-variance-authority"
-import { motion } from "framer-motion"
+import { motion, useReducedMotion } from "framer-motion"
 import * as React from "react"
 
 import { springs } from "./lib/motion"
@@ -174,6 +174,8 @@ const Avatar = React.forwardRef<
   AvatarProps
 >(({ className, size, shape, status, ring, badge, loading, children, ...props }, ref) => {
   const resolvedShape = shape ?? 'circle'
+  // MotionConfig can't stop this opacity loop (non-transform), so guard it locally.
+  const prefersReduced = useReducedMotion()
 
   // Build ring classes for the outer wrapper
   const ringClasses = ring && ring !== 'none'
@@ -207,7 +209,7 @@ const Avatar = React.forwardRef<
         {children}
       </AvatarPrimitive.Root>
       {status && (
-        status === 'online' ? (
+        status === 'online' && !prefersReduced ? (
           <motion.span
             className={cn('absolute bottom-0 right-0 rounded-pill ring-2 ring-surface-raised', statusColorMap[status], statusDotSizeMap[size ?? 'md'])}
             animate={{ opacity: [1, 0.75, 1] }}
@@ -230,7 +232,7 @@ const Avatar = React.forwardRef<
           <motion.span
             initial={{ scale: 0 }}
             animate={{ scale: 1 }}
-            transition={springs.bouncy}
+            transition={springs.smooth}
             className="absolute -right-1 -top-1 flex min-w-[16px] items-center justify-center rounded-pill bg-error-9 px-1 text-[10px] font-bold leading-[16px] text-error-fg ring-2 ring-surface-raised"
             data-slot="avatar-badge"
             role="status"

--- a/packages/core/src/ui/badge-indicator.tsx
+++ b/packages/core/src/ui/badge-indicator.tsx
@@ -58,7 +58,7 @@ export function BadgeIndicator({
             initial={prefersReduced ? { opacity: 0 } : { scale: 0, opacity: 0 }}
             animate={prefersReduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
             exit={prefersReduced ? { opacity: 0 } : { scale: 0, opacity: 0 }}
-            transition={springs.bouncy}
+            transition={springs.smooth}
             className={cn(
               'absolute flex items-center justify-center rounded-pill font-sans font-semibold ring-2 ring-surface-raised',
               COLOR_CLASSES[color],

--- a/packages/core/src/ui/radio.tsx
+++ b/packages/core/src/ui/radio.tsx
@@ -73,7 +73,7 @@ const RadioGroupItem = React.forwardRef<
           className="flex items-center justify-center"
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
-          transition={springs.bouncy}
+          transition={springs.snappy}
         >
           <IconCircle className={cn(radioIndicatorClasses[size], 'fill-accent-9 text-accent-11')} />
         </motion.span>

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -293,7 +293,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
           className="inline-flex"
           initial={{ opacity: 0.5, scale: 1.4 }}
           animate={{ opacity: 1, scale: 1 }}
-          transition={springs.bouncy}
+          transition={springs.smooth}
         >
           <Icon icon={DeltaIcon} size="sm" />
         </motion.span>


### PR DESCRIPTION
## What

Motion-compliance pass triggered by re-auditing shilp-sutra against Setu's **anti-convergence v1.1** (new `motion` section) + the project's locked decision **B** ("settle, don't bounce").

**Reduced-motion guards (2)** — the avatar online-status dot and the deadline-indicator overdue/critical state animate a continuous *opacity* pulse (`repeat: Infinity`). framer's global `MotionConfig reducedMotion="user"` only disables **transform/layout** animation, so these non-transform loops played regardless. Both now self-guard with `useReducedMotion()` → static variant under reduced motion (colour still signals status/urgency). **No default-view change.**

**Spring-overshoot retunes (6)** — resting-state indicators popping with `springs.bouncy` (ζ≈0.53, real overshoot) now settle:

| Site | Was | Now |
|------|-----|-----|
| `radio.tsx:76` dot | bouncy | `snappy` |
| `filter-bar.tsx:196` count | bouncy | `snappy` |
| `multi-select-popover.tsx:244` check | bouncy | `snappy` |
| `badge-indicator.tsx:61` | bouncy | `smooth` |
| `avatar.tsx:233` badge | bouncy | `smooth` |
| `stat-card.tsx:296` delta | bouncy | `smooth` (matches its already-smooth sibling) |

**Kept `bouncy`** (rule's allowed deliberate/gesture exceptions): toast completion icons, upload-success check, devadoot celebration, segmented-control slider, attachment-strip layout.

## Audit context

Full anti-convergence v1.1 sweep found the component code **clean on every visual slop tell** (palette, sparkle, gradient-text, accent-rails, rounded-everything all pass — Wave 1 + 0.45 closed those). The only real gaps were motion (this PR) and em-dashes in docs (separate). Re-roll (W6) is a quality item, not a compliance one.

## Verification

- `typecheck` ✓ · `lint` ✓ (0 errors) · **98/98** tests on the 7 touched components.
- Motion is non-visual in a static diff — reviewed via a live before/after demo (real spring physics from the actual `stiffness/damping/mass`).

Non-breaking (no API change) → patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4vPCYw2cPST2rou4QKZNo
