### PR TITLE
refactor(core): compose Skeleton in StatCard + Avatar loading (W6 batch 1a)

### DIFF
--- a/.changeset/w6-compose-skeletons.md
+++ b/.changeset/w6-compose-skeletons.md
@@ -1,0 +1,10 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Compose the `Skeleton` primitive in StatCard and Avatar loading states instead of hand-rolling the shimmer (W6 compose-don't-re-roll).
+
+- **StatCard** loading state: three `bg-skeleton-base animate-pulse` divs → `<Skeleton>`.
+- **Avatar** loading state: the placeholder was hand-rolled AND used the wrong token (`bg-surface-raised-hover`); now `<Skeleton>` with the correct `bg-skeleton-base`.
+
+Both are visually identical (Skeleton defaults to the same `pulse`) and now inherit `motion-reduce:animate-none` for free. Non-breaking.

--- a/packages/core/src/ui/avatar.tsx
+++ b/packages/core/src/ui/avatar.tsx
@@ -7,6 +7,7 @@ import * as React from "react"
 
 import { springs } from "./lib/motion"
 import { cn } from "./lib/utils"
+import { Skeleton } from "./skeleton"
 
 // ── Contexts so AvatarFallback can inherit shape & size from Avatar ──
 type AvatarShape = 'circle' | 'square' | 'rounded'
@@ -184,8 +185,8 @@ const Avatar = React.forwardRef<
   if (loading) {
     return (
       <span ref={ref} className={cn('relative inline-flex shrink-0', ringClasses)}>
-        <span
-          className={cn(avatarVariants({ size, shape }), 'animate-pulse bg-surface-raised-hover')}
+        <Skeleton
+          className={cn(avatarVariants({ size, shape }))}
           data-slot="avatar-skeleton"
         />
       </span>

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -12,6 +12,7 @@ import { useLink } from './lib/link-context'
 import { springs, tweens } from './lib/motion'
 import { normalizeIcon } from './lib/normalize-icon'
 import { cn } from './lib/utils'
+import { Skeleton } from './skeleton'
 import { type FlashPreset, type FlashSpec, type FlashSpeed,StatFlash } from './stat-flash'
 
 /**
@@ -249,9 +250,9 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       return (
         <Card ref={ref} variant={variant} size={size} className={className} aria-busy="true" {...props}>
           <CardContent className="flex flex-col gap-ds-03">
-            <div className="h-ds-04 w-24 rounded-control-inner bg-skeleton-base animate-pulse" />
-            <div className="h-ds-sm w-32 rounded-control bg-skeleton-base animate-pulse" />
-            <div className="h-3 w-16 rounded-control-inner bg-skeleton-base animate-pulse" />
+            <Skeleton className="h-ds-04 w-24 rounded-control-inner" />
+            <Skeleton className="h-ds-sm w-32" />
+            <Skeleton className="h-3 w-16 rounded-control-inner" />
           </CardContent>
         </Card>
       )


### PR DESCRIPTION
## What — W6 compose-don't-re-roll, batch 1a (Skeleton)

Two loading states hand-rolled the skeleton shimmer instead of composing the `Skeleton` primitive:

- **StatCard** loading — 3 `bg-skeleton-base animate-pulse` divs → `<Skeleton>`.
- **Avatar** loading — hand-rolled span that also used the **wrong token** (`bg-surface-raised-hover` instead of `bg-skeleton-base`); now `<Skeleton>`.

## Why this batch is safe

Skeleton defaults to `animation="pulse"`, so the output is **visually identical** — plus both now inherit `motion-reduce:animate-none` for free, and the Avatar token bug is fixed. `cn` is `twMerge`, so `avatarVariants`' radius still wins (circle avatars stay round).

## Verification

`typecheck` ✓ · `lint` ✓ (0 errors) · 51/51 tests (avatar + stat-card). Non-breaking → patch.

## Context

Part of the W6 audit (compose-don't-re-roll). The remaining batches — field/button/card composes (data-table filter Input, toolbar Buttons, sidebar promo Card), the primitive-fix-first set (Badge dot-color → status-badge; Card radius override → command-bar/error-boundary hero), and Progress re-rolls — are visual changes and will land separately after sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4vPCYw2cPST2rou4QKZNo
