### PR TITLE
feat(core): add Surface — low-level elevated container primitive

### DIFF
--- a/.changeset/surface-primitive.md
+++ b/.changeset/surface-primitive.md
@@ -1,0 +1,23 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Add `Surface` — the low-level elevated container primitive.
+
+Every mature design system ships one (MUI `Paper`, Carbon `Tile`, Chakra/Polaris `Box`) and builds its semantic Card on top; shilp-sutra had only the opinionated `Card` (gap-model padding, slots), so ~29 components hand-rolled `bg-surface-raised … shadow-raised` because there was nothing lighter to compose. `Surface` fills that gap.
+
+```tsx
+import { Surface } from '@devalok/shilp-sutra/ui/surface'
+
+<Surface elevation="raised" padding="md">…</Surface>
+<Surface elevation="flat" bordered padding="sm">…</Surface>   // on-page tile
+<Surface asChild elevation="raised"><a href="/x">…</a></Surface>
+```
+
+- `elevation`: `flat | raised | floating | overlay` (binds a surface-bg token to a shadow token)
+- `padding`: `none | sm | md | lg` (simple all-side — not Card's gap model)
+- `radius`: `none | control | surface | overlay | pill`
+- `bordered`: border-led edge; dev-warns if combined with a shadowed elevation (the double-edge anti-pattern)
+- `asChild`: render as the child element via Slot
+
+Server-safe. Additive only — no existing component changed. (Follow-ups: refactor `Card` to compose `Surface`, and migrate the hand-rolled surfaces.)

--- a/packages/core/docs/components/ui/surface.md
+++ b/packages/core/docs/components/ui/surface.md
@@ -1,0 +1,55 @@
+# Surface
+
+- Import: @devalok/shilp-sutra/ui/surface
+- Server-safe: Yes
+- Category: ui
+
+The low-level elevated container primitive. Owns background + shadow + radius + optional padding and border — nothing else. Card, Popover, Toast, Sheet, and other surfaces compose it.
+
+## Props
+### Surface
+    elevation: "flat" | "raised" | "floating" | "overlay"
+    padding: "none" | "sm" | "md" | "lg"
+    radius: "none" | "control" | "surface" | "overlay" | "pill"
+    bordered: boolean
+    asChild: boolean — render as the passed child element (Radix Slot) instead of a div
+
+## Defaults
+    Surface: elevation="raised", padding="none", radius="surface", bordered=false
+
+## Elevation
+    flat      — bg-surface-raised, no shadow (pair with `bordered` for an on-page tile)
+    raised    — bg-surface-raised + shadow-raised (card level)
+    floating  — bg-surface-overlay + shadow-floating (toasts, floating toolbars)
+    overlay   — bg-surface-overlay + shadow-overlay (popovers, menus, dialogs)
+
+## Padding
+    none=0 · sm=ds-04 (12px) · md=ds-05 (16px) · lg=ds-06 (24px) — simple all-side (not Card's gap model)
+
+## Example
+```jsx
+// Raised panel with padding
+<Surface elevation="raised" padding="md">…</Surface>
+
+// On-page, border-led tile (no shadow)
+<Surface elevation="flat" bordered padding="sm">…</Surface>
+
+// The whole surface is a link
+<Surface asChild elevation="raised" padding="sm">
+  <a href="/upgrade">Upgrade to Pro</a>
+</Surface>
+```
+
+## Composability
+- Server-safe — renders in RSC trees.
+- The base layer: `Card` = Surface + gap-model padding + color edge + header/content/footer slots. Reach for Card when you want that slot rhythm; reach for Surface for a plain elevated box.
+- `asChild` merges the surface classes onto your own element (a link, section, or `motion.div`) with no extra wrapper node.
+- Padding is symmetric all-side. For asymmetric or gap-model spacing, use Card or add your own utilities via `className`.
+
+## Gotchas
+- **Edge OR elevation, never both.** Combining `bordered` with a shadowed elevation (raised/floating/overlay) is the double-edge anti-pattern and dev-warns. Use `elevation="flat"` with `bordered`, or drop `bordered` and let the shadow be the edge.
+- `flat` still uses `bg-surface-raised` (a card without a shadow), not the page background — it is a surface, not a hole.
+
+## Changes
+### Unreleased
+- **Added** Initial release — `elevation` / `padding` / `radius` / `bordered` / `asChild`. The low-level surface primitive that Card and other surfaces compose.

--- a/packages/core/llms.txt
+++ b/packages/core/llms.txt
@@ -100,6 +100,7 @@ Format: `[name](doc path): summary`. Import paths follow `@devalok/shilp-sutra/<
 - [stat-flash](docs/components/ui/stat-flash.md)
 - [status-dot](docs/components/ui/status-dot.md)
 - [stepper](docs/components/ui/stepper.md)
+- [surface](docs/components/ui/surface.md): The low-level elevated container primitive
 - [switch](docs/components/ui/switch.md)
 - [table](docs/components/ui/table.md)
 - [table-row-link](docs/components/ui/table-row-link.md)

--- a/packages/core/make-kit/components/overview.md
+++ b/packages/core/make-kit/components/overview.md
@@ -144,8 +144,11 @@ Page wrapper?
 Vertical / horizontal stack?
   → <Stack direction="col|row" gap="ds-*">
 
-A card / panel?
-  → <Card> — surface-raised + shadow-raised
+A plain elevated box (no slots)?
+  → <Surface elevation="raised" padding="md"> — the low-level surface Card is built on
+
+A card / panel (header / content / footer rhythm)?
+  → <Card> — Surface + gap-model padding + slots
   → <Card variant="..."> — tinted by color prop
 
 A grid?
@@ -261,6 +264,7 @@ Code?
 |---|---|
 | Container | `/ui/container` |
 | Stack | `/ui/stack` |
+| Surface | `/ui/surface` |
 | Card | `/ui/card` |
 | AspectRatio | `/ui/aspect-ratio` |
 | Separator | `/ui/separator` |
@@ -305,4 +309,4 @@ Code?
 
 ## Per-component guides
 
-See `components/{button|card|input|dialog|badge|select|tabs|toast|form|table|dropdown-menu|popover|text|stack|icon}.md` for prop tables, examples, and rules.
+See `components/{button|card|surface|input|dialog|badge|select|tabs|toast|form|table|dropdown-menu|popover|text|stack|icon}.md` for prop tables, examples, and rules.

--- a/packages/core/make-kit/components/surface.md
+++ b/packages/core/make-kit/components/surface.md
@@ -1,0 +1,60 @@
+# Surface
+
+```tsx
+import { Surface } from '@devalok/shilp-sutra/ui/surface'
+```
+
+The low-level elevated container. It paints a tokened surface — background + shadow + radius, with optional padding and border — and nothing else. Card, Popover, Toast, and Sheet are built on it.
+
+## When to use
+
+- You need a plain elevated box (a promo, a callout, a small panel) and don't need Card's header/content/footer slots.
+- You're building a new component that sits on a surface — compose `Surface`, never hand-roll `bg-surface-raised … shadow-raised`.
+
+Use `<Card>` instead when you want the gap-model padding rhythm and the `CardHeader`/`CardContent`/`CardFooter` slots. Use raw utilities for nothing — if it's a surface, it's a `Surface`.
+
+## Elevation — and which to pick
+
+| `elevation` | Surface | Use for |
+|---|---|---|
+| `flat` | `bg-surface-raised`, no shadow | On-page tiles. Pair with `bordered` for an edge. |
+| `raised` *(default)* | `bg-surface-raised` + `shadow-raised` | Cards, panels — anything sitting on the page. |
+| `floating` | `bg-surface-overlay` + `shadow-floating` | Toasts, floating toolbars. |
+| `overlay` | `bg-surface-overlay` + `shadow-overlay` | Popovers, menus, dialogs. |
+
+## Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `elevation` | `flat \| raised \| floating \| overlay` | `raised` | bg + shadow together. |
+| `padding` | `none \| sm \| md \| lg` | `none` | Simple all-side: 0 / 12 / 16 / 24px. Not Card's gap model. |
+| `radius` | `none \| control \| surface \| overlay \| pill` | `surface` | Maps `rounded-*` tokens. |
+| `bordered` | `boolean` | `false` | Border-led edge. Only for `flat` — see Rules. |
+| `asChild` | `boolean` | `false` | Render as the child element (Slot). |
+
+Plus all native `div` props. Server-safe; forwards ref.
+
+## Examples
+
+```tsx
+// Raised panel with padding
+<Surface elevation="raised" padding="md">…</Surface>
+
+// On-page, border-led tile (no shadow)
+<Surface elevation="flat" bordered padding="sm">…</Surface>
+
+// Overlay chrome
+<Surface elevation="overlay" padding="sm" radius="overlay">…</Surface>
+
+// The whole surface is a link — no wrapper node
+<Surface asChild elevation="raised" padding="sm">
+  <a href="/upgrade">Upgrade to Pro</a>
+</Surface>
+```
+
+## Rules
+
+- **Edge OR elevation, never both.** `bordered` + a shadowed `elevation` is the double-edge anti-pattern (dev-warns). Use `elevation="flat" bordered`, or drop `bordered`.
+- `flat` is still a surface (`bg-surface-raised`), not the page — a card without a shadow, not a hole in the page.
+- Don't reach for `Surface` when you mean `Card` — if you're rebuilding header/content/footer spacing by hand, use `Card`.
+- Padding is symmetric. For anything asymmetric, use `className` or `Card`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -377,6 +377,11 @@
       "import": "./dist/ui/stepper.js",
       "default": "./dist/ui/stepper.js"
     },
+    "./ui/surface": {
+      "types": "./dist/ui/surface.d.ts",
+      "import": "./dist/ui/surface.js",
+      "default": "./dist/ui/surface.js"
+    },
     "./ui/switch": {
       "types": "./dist/ui/switch.d.ts",
       "import": "./dist/ui/switch.js",

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -178,6 +178,7 @@ export {
   type StatFlashProps,
 } from './stat-flash'
 export { StatusDot, type StatusDotProps, type StatusDotStatus } from './status-dot'
+export { Surface, type SurfaceProps, surfaceVariants } from './surface'
 export { Table, TableBody, TableCaption, TableCell, type TableCellBaseProps,type TableCellProps,type TableDensity, TableFooter, TableHead, TableHeader, type TableProps, TableRow, TableRowActions, type TableRowActionsProps,type TableRowProps } from './table'
 export { TableRowLink, type TableRowLinkProps } from './table-row-link'
 

--- a/packages/core/src/ui/surface.stories.tsx
+++ b/packages/core/src/ui/surface.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Surface } from './surface'
+
+const meta: Meta<typeof Surface> = {
+  title: 'Components/Layout/Surface',
+  component: Surface,
+  tags: ['autodocs', 'stable'],
+  argTypes: {
+    elevation: {
+      control: 'select',
+      options: ['flat', 'raised', 'floating', 'overlay'],
+    },
+    padding: { control: 'select', options: ['none', 'sm', 'md', 'lg'] },
+    radius: {
+      control: 'select',
+      options: ['none', 'control', 'surface', 'overlay', 'pill'],
+    },
+    bordered: { control: 'boolean' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The low-level elevated container. Owns background + shadow + radius + optional padding/border only. Card, Popover, Toast, and friends compose it. Use a shadow OR a bordered flat — never both.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof Surface>
+
+export const Default: Story = {
+  args: { elevation: 'raised', padding: 'md' },
+  render: (args) => <Surface {...args}>Surface</Surface>,
+}
+
+export const Elevations: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-ds-06 bg-surface-base p-ds-06">
+      {(['flat', 'raised', 'floating', 'overlay'] as const).map((e) => (
+        <Surface
+          key={e}
+          elevation={e}
+          padding="md"
+          bordered={e === 'flat'}
+          className="w-40 text-center text-ds-sm text-surface-fg-subtle"
+        >
+          {e}
+        </Surface>
+      ))}
+    </div>
+  ),
+}
+
+export const Padding: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-ds-05">
+      {(['none', 'sm', 'md', 'lg'] as const).map((p) => (
+        <Surface key={p} elevation="raised" padding={p}>
+          <span className="rounded-control-inner bg-accent-3 px-ds-02 py-ds-01 text-ds-sm text-accent-11">
+            {p}
+          </span>
+        </Surface>
+      ))}
+    </div>
+  ),
+}
+
+export const BorderedFlat: Story = {
+  name: 'Bordered (flat, on-page tile)',
+  args: { elevation: 'flat', bordered: true, padding: 'md' },
+  render: (args) => (
+    <div className="bg-surface-base p-ds-06">
+      <Surface {...args} className="w-48">
+        On-page tile — border-led, no shadow.
+      </Surface>
+    </div>
+  ),
+}
+
+export const AsChildLink: Story = {
+  name: 'asChild (renders as a link)',
+  render: () => (
+    <Surface asChild elevation="raised" padding="md" className="block w-56 no-underline">
+      <a href="#upgrade">
+        <span className="text-ds-sm font-semibold text-surface-fg">Upgrade to Pro</span>
+        <span className="mt-ds-01 block text-ds-sm text-surface-fg-subtle">
+          The whole surface is the link.
+        </span>
+      </a>
+    </Surface>
+  ),
+}

--- a/packages/core/src/ui/surface.test.tsx
+++ b/packages/core/src/ui/surface.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { describeConformance } from '../test-utils/conformance'
+import { Surface } from './surface'
+
+describeConformance('Surface', (props) => <Surface {...props} />)
+
+describe('Surface', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('defaults to raised elevation (bg + shadow) with surface radius', () => {
+    const { container } = render(<Surface>hi</Surface>)
+    const el = container.firstChild as HTMLElement
+    expect(el).toHaveClass('bg-surface-raised', 'shadow-raised', 'rounded-surface')
+  })
+
+  it('flat elevation keeps the bg but drops the shadow', () => {
+    const { container } = render(<Surface elevation="flat">hi</Surface>)
+    const el = container.firstChild as HTMLElement
+    expect(el).toHaveClass('bg-surface-raised')
+    expect(el).not.toHaveClass('shadow-raised')
+  })
+
+  it('overlay elevation uses the overlay bg + shadow', () => {
+    const { container } = render(<Surface elevation="overlay">hi</Surface>)
+    expect(container.firstChild).toHaveClass('bg-surface-overlay', 'shadow-overlay')
+  })
+
+  it('applies the padding scale', () => {
+    const { container } = render(<Surface padding="md">hi</Surface>)
+    expect(container.firstChild).toHaveClass('p-ds-05')
+  })
+
+  it('applies a radius override', () => {
+    const { container } = render(<Surface radius="pill">hi</Surface>)
+    expect(container.firstChild).toHaveClass('rounded-pill')
+  })
+
+  it('bordered adds a border (paired with flat)', () => {
+    const { container } = render(
+      <Surface elevation="flat" bordered>
+        hi
+      </Surface>,
+    )
+    expect(container.firstChild).toHaveClass('border', 'border-surface-border-strong')
+  })
+
+  it('renders as the child element when asChild, carrying the surface classes', () => {
+    render(
+      <Surface asChild elevation="raised">
+        <a href="/x">link</a>
+      </Surface>,
+    )
+    const link = screen.getByRole('link', { name: 'link' })
+    expect(link).toHaveClass('bg-surface-raised', 'shadow-raised')
+  })
+
+  it('dev-warns when bordered is combined with a shadowed elevation (double-edge)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(
+      <Surface elevation="raised" bordered>
+        hi
+      </Surface>,
+    )
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('double-edge'))
+  })
+
+  it('does not warn for a bordered flat surface', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(
+      <Surface elevation="flat" bordered>
+        hi
+      </Surface>,
+    )
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/ui/surface.tsx
+++ b/packages/core/src/ui/surface.tsx
@@ -1,0 +1,123 @@
+// @server-safe
+import { Slot } from '@primitives/react-slot'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import { cn } from './lib/utils'
+
+// Bundlers (Vite, Next.js, webpack) define process.env.NODE_ENV; guard for raw ESM.
+declare const process: { env: { NODE_ENV?: string } } | undefined
+
+const surfaceVariants = cva('', {
+  variants: {
+    // Elevation binds a surface-bg token to a shadow token — the one axis that
+    // matters. `flat` sits on the page with no shadow (pair with `bordered` for a
+    // Carbon-Tile edge); `raised` is the card level; `floating`/`overlay` are the
+    // popover/menu/toast levels. bg + shadow always move together, so there is no
+    // way to produce an un-tokened surface.
+    elevation: {
+      flat: 'bg-surface-raised',
+      raised: 'bg-surface-raised shadow-raised',
+      floating: 'bg-surface-overlay shadow-floating',
+      overlay: 'bg-surface-overlay shadow-overlay',
+    },
+    // Simple, symmetric all-side padding — NOT Card's gap model. This is what keeps
+    // Surface low-level: a plain box you can drop content into. Reach for Card when
+    // you want the header/content/footer slot rhythm.
+    padding: {
+      none: '',
+      sm: 'p-ds-04',
+      md: 'p-ds-05',
+      lg: 'p-ds-06',
+    },
+    radius: {
+      none: 'rounded-none',
+      control: 'rounded-control',
+      surface: 'rounded-surface',
+      overlay: 'rounded-overlay',
+      pill: 'rounded-pill',
+    },
+    // Border-led edge (Carbon-Tile style). Meant for `elevation="flat"`; combining it
+    // with a shadowed elevation is the double-edge anti-pattern and dev-warns below.
+    bordered: {
+      true: 'border border-surface-border-strong',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    elevation: 'raised',
+    padding: 'none',
+    radius: 'surface',
+    bordered: false,
+  },
+})
+
+export interface SurfaceProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof surfaceVariants> {
+  /** Render as the passed child element (Radix Slot) instead of a `div` — wrap a link,
+   * section, or `motion.div` without adding a wrapper node. */
+  asChild?: boolean
+}
+
+/**
+ * Surface — the low-level elevated container primitive.
+ *
+ * The building block every panel, card, popover, and toast surface sits on. It owns
+ * exactly one job: paint a tokened surface (background + shadow), with optional radius,
+ * padding, and border. It has no slots, no color axis, and no motion — those belong to
+ * the components composed on top of it (Card = Surface + gap-model padding + slots).
+ *
+ * **Elevation:** `flat` (bg, no shadow — pair with `bordered`) | `raised` (card level,
+ * default) | `floating` (toasts, floating toolbars) | `overlay` (popovers, menus, dialogs).
+ *
+ * **Padding:** `none` (default) | `sm` (12px) | `md` (16px) | `lg` (24px) — simple all-side.
+ *
+ * **Edge vs. elevation:** use a shadow (`raised`/`floating`/`overlay`) OR a `bordered`
+ * `flat` — never both (the double-edge anti-pattern; dev-warns).
+ *
+ * @example
+ * // A raised panel with comfortable padding:
+ * <Surface elevation="raised" padding="md">…</Surface>
+ *
+ * @example
+ * // An on-page, border-led tile (no shadow):
+ * <Surface elevation="flat" bordered padding="sm">…</Surface>
+ *
+ * @example
+ * // Wrap a link as the surface itself:
+ * <Surface asChild elevation="raised" padding="sm">
+ *   <a href="/upgrade">…</a>
+ * </Surface>
+ */
+const Surface = React.forwardRef<HTMLDivElement, SurfaceProps>(
+  (
+    { className, elevation, padding, radius, bordered, asChild = false, ...props },
+    ref,
+  ) => {
+    if (
+      typeof process !== 'undefined' &&
+      process?.env.NODE_ENV !== 'production' &&
+      bordered &&
+      (elevation ?? 'raised') !== 'flat'
+    ) {
+      console.warn(
+        '[shilp-sutra] <Surface> combines `bordered` with a shadowed `elevation` — the double-edge anti-pattern. Pick one: use elevation="flat" with `bordered`, or drop `bordered` and let the shadow be the edge.',
+      )
+    }
+    const Comp = asChild ? Slot : 'div'
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          surfaceVariants({ elevation, padding, radius, bordered }),
+          className,
+        )}
+        {...props}
+      />
+    )
+  },
+)
+Surface.displayName = 'Surface'
+
+export { Surface, surfaceVariants }


### PR DESCRIPTION
## What

Adds **`Surface`** — the low-level elevated container primitive shilp-sutra never had.

Every mature system ships one (MUI `Paper`, Carbon `Tile`, Chakra/Polaris `Box`) and builds its semantic Card on top. shilp-sutra jumped straight to the opinionated `Card` (gap-model padding + `CardHeader`/`Content`/`Footer` slots), so **~29 components hand-roll `bg-surface-raised … shadow-raised`** — there was nothing lighter to compose. `Surface` fills that gap.

```tsx
import { Surface } from '@devalok/shilp-sutra/ui/surface'

<Surface elevation="raised" padding="md">…</Surface>
<Surface elevation="flat" bordered padding="sm">…</Surface>   // on-page tile
<Surface asChild elevation="raised"><a href="/x">…</a></Surface>
```

## API
| prop | values | default |
|------|--------|---------|
| `elevation` | flat · raised · floating · overlay | raised |
| `padding` | none · sm · md · lg (0/12/16/24) | none |
| `radius` | none · control · surface · overlay · pill | surface |
| `bordered` | boolean — dev-warns if paired with a shadowed elevation (double-edge) | false |
| `asChild` | boolean (Slot) | false |

`elevation` binds a surface-bg token to a shadow token; `padding` is simple all-side (not Card's gap model). Server-safe, forwards ref.

## Scope
**Additive only — no existing component changed.** Follow-ups (separate PRs): refactor `Card` to compose `Surface`; migrate the ~29 hand-rolled surfaces.

## Verification
- `typecheck` ✓ · `lint` ✓ (0 errors) · **13/13 tests** (conformance + elevation/padding/radius/bordered/asChild + both double-edge warn cases)
- `build-component-docs` ✓ (docs/components/ui/surface.md present) · manifest + llms.txt router regenerated
- New files: `surface.tsx` + stories + test + docs entry + make-kit guide (+ overview) + barrel export + `./ui/surface` subpath + changeset (minor)

Labeled `visual-review` so Chromatic renders the new Surface stories (Elevations, Padding, BorderedFlat, AsChildLink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H4vPCYw2cPST2rou4QKZNo
