### PR TITLE
fix(site): reduce AI-convergence tells + correct /agents docs

### DIFF
--- a/apps/site/app/agents/page.tsx
+++ b/apps/site/app/agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { IconBrandGithub, IconFileText, IconRobot, IconSparkles, IconTerminal } from '@tabler/icons-react'
+import { IconBrandGithub, IconFileText, IconRobot, IconTerminal } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
@@ -71,14 +71,11 @@ export default function AgentsPage() {
           <div className="max-w-3xl rounded-control border border-accent-7 bg-accent-2 p-ds-06 mb-ds-12">
             <div className="flex items-start gap-ds-04 mb-ds-04">
               <span className="w-10 h-10 rounded-control-inner bg-accent-9 text-accent-fg flex items-center justify-center shrink-0">
-                <IconSparkles size={20} />
+                <IconTerminal size={20} />
               </span>
               <div className="flex flex-col">
-                <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
-                  One install
-                </span>
-                <span className="text-ds-md text-surface-fg font-semibold mt-ds-01">
-                  Run this in your terminal.
+                <span className="text-ds-md text-surface-fg font-semibold">
+                  One install. Run this in your terminal.
                 </span>
               </div>
             </div>
@@ -128,10 +125,8 @@ export default function AgentsPage() {
               {resources.map((r) => (
                 <Card key={r.title}>
                   <CardHeader>
-                    <div className="flex items-center gap-ds-03">
-                      <span className="w-9 h-9 rounded-control-inner bg-accent-3 text-accent-11 flex items-center justify-center">
-                        <r.icon size={16} />
-                      </span>
+                    <div className="flex items-center gap-ds-02">
+                      <r.icon size={16} className="text-accent-11 shrink-0" />
                       <CardTitle className="text-[length:var(--typo-heading-sm-size)]">{r.title}</CardTitle>
                     </div>
                     <CardDescription>{r.body}</CardDescription>

--- a/apps/site/app/agents/page.tsx
+++ b/apps/site/app/agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { IconBrandGithub, IconFileText, IconRobot, IconTerminal } from '@tabler/icons-react'
+import { IconBrandGithub, IconFileText, IconPlug, IconRobot, IconTerminal } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
@@ -35,16 +35,16 @@ const resources = [
   {
     icon: IconFileText,
     title: 'llms.txt',
-    body: 'Concise cheatsheet, 660 lines. Setup playbook, peer-dep matrix, breaking changes, design rules. Inject this into any chat.',
+    body: 'The router index. Setup playbook, peer-dep matrix, breaking changes, design rules, and pointers into per-component docs. Inject this into any chat.',
     cmd: 'curl https://raw.githubusercontent.com/devalok-design/shilp-sutra/main/packages/core/llms.txt',
     href: 'https://github.com/devalok-design/shilp-sutra/blob/main/packages/core/llms.txt',
   },
   {
-    icon: IconFileText,
-    title: 'llms-full.txt',
-    body: 'Exhaustive per-component reference, 6,900 lines. Every prop, every variant, every example. Reach for this when llms.txt is too brief.',
-    cmd: 'curl https://raw.githubusercontent.com/devalok-design/shilp-sutra/main/packages/core/llms-full.txt',
-    href: 'https://github.com/devalok-design/shilp-sutra/blob/main/packages/core/llms-full.txt',
+    icon: IconPlug,
+    title: 'Hosted MCP',
+    body: 'Live Model Context Protocol server. Your agent queries the current component APIs, tokens, and upgrade guidance on demand, over MCP, with no files to sync.',
+    cmd: 'https://shilp-sutra.devalok.in/mcp',
+    href: 'https://shilp-sutra.devalok.in/mcp',
   },
   {
     icon: IconTerminal,
@@ -64,8 +64,8 @@ export default function AgentsPage() {
           <PageHeader
             eyebrow="For your AI editor"
             title="Your AI editor already knows shilp-sutra."
-            subtitle="One install. Four files. Every release."
-            description="We ship an installable skill, two flavours of llms.txt, and AGENTS.md with every release so your coding agent doesn't guess at the library. Install once, never paste docs into chat again."
+            subtitle="One install. Every release."
+            description="We ship an installable skill, an llms.txt router, a hosted MCP server, and AGENTS.md with every release so your coding agent doesn't guess at the library. Install once, never paste docs into chat again."
           />
 
           <div className="max-w-3xl rounded-control border border-accent-7 bg-accent-2 p-ds-06 mb-ds-12">

--- a/apps/site/app/blocks/page.tsx
+++ b/apps/site/app/blocks/page.tsx
@@ -11,7 +11,7 @@ import { getAllBlocks } from '@/lib/blocks-registry'
 export const metadata: Metadata = {
   title: 'Blocks',
   description:
-    'Real pages. Real spacing. Real copy. Multi-component shilp-sutra blocks for dashboards, auth flows, pricing pages, data tables. Copy the source, drop it in, ship.',
+    'Real pages, not toys. Multi-component shilp-sutra blocks for dashboards, auth flows, pricing pages, data tables. Copy the source, drop it in, ship.',
 }
 
 export default function BlocksIndexPage() {
@@ -24,7 +24,7 @@ export default function BlocksIndexPage() {
           <div className="flex flex-col gap-ds-09">
             <PageHeader
               eyebrow="Blocks"
-              title="Real pages. Real spacing. Real copy."
+              title="Real pages, not toys."
               subtitle="Multi-component surfaces lifted from real work. Dashboards, sign-up flows, pricing pages, data tables."
               description="Each block recolours with the brand switcher. Copy the source, paste, ship."
             />

--- a/apps/site/app/components/page.tsx
+++ b/apps/site/app/components/page.tsx
@@ -30,7 +30,7 @@ export default async function ComponentsPage() {
             <FeaturedComponents />
             <div className="flex flex-col gap-ds-04">
               <header className="flex flex-col gap-ds-02 max-w-3xl">
-                <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+                <span className="text-ds-xs text-surface-fg-subtle">
                   Browse all
                 </span>
                 <h2 className="text-[length:var(--typo-heading-md-size)] font-[number:var(--typo-heading-md-weight)] leading-[var(--typo-heading-md-leading)] text-surface-fg">

--- a/apps/site/app/docs/page.tsx
+++ b/apps/site/app/docs/page.tsx
@@ -113,7 +113,7 @@ export default function DocsIndexPage() {
 
             <section className="flex flex-col gap-ds-05">
               <header className="flex flex-col gap-ds-02 max-w-3xl">
-                <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+                <span className="text-ds-xs text-surface-fg-subtle">
                   Install
                 </span>
                 <h2 className="text-[length:var(--typo-heading-md-size)] font-[number:var(--typo-heading-md-weight)] leading-[var(--typo-heading-md-leading)] text-surface-fg">
@@ -176,7 +176,7 @@ function DocsSection({
   return (
     <section className="flex flex-col gap-ds-04">
       <header className="flex flex-col gap-ds-01">
-        <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">{eyebrow}</span>
+        <span className="text-ds-xs text-surface-fg-subtle">{eyebrow}</span>
         <h2 className="text-ds-lg text-surface-fg font-semibold">{title}</h2>
       </header>
       <ul className="flex flex-col gap-ds-03">
@@ -196,9 +196,7 @@ function DocLinkCard({ item }: { item: DocCard }) {
         className={CARD_INTERACTIVE + ' flex flex-col gap-ds-03 h-full'}
       >
         <div className="flex items-start justify-between gap-ds-03">
-          <span className="w-9 h-9 rounded-control-inner bg-accent-3 text-accent-11 flex items-center justify-center shrink-0">
-            <item.Icon size={18} />
-          </span>
+          <item.Icon size={18} className="text-accent-11 shrink-0 mt-1" />
           <IconArrowRight
             size={16}
             className="text-surface-fg-subtle group-hover:translate-x-1 group-hover:text-surface-fg transition-transform duration-fast-02 ease-productive-standard shrink-0 mt-1"

--- a/apps/site/app/opengraph-image.tsx
+++ b/apps/site/app/opengraph-image.tsx
@@ -39,20 +39,6 @@ export default async function OpengraphImage() {
           position: 'relative',
         }}
       >
-        {/* Corner brand glow — soft accent-9 puddle */}
-        <div
-          style={{
-            position: 'absolute',
-            top: -180,
-            right: -180,
-            width: 520,
-            height: 520,
-            borderRadius: 9999,
-            background: 'oklch(0.6 0.22 360 / 0.35)',
-            filter: 'blur(80px)',
-          }}
-        />
-
         {/* Header — eyebrow + studio mark */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 16, zIndex: 1 }}>
           <div
@@ -67,8 +53,7 @@ export default async function OpengraphImage() {
             style={{
               fontSize: 22,
               fontWeight: 500,
-              letterSpacing: 1.5,
-              textTransform: 'uppercase',
+              letterSpacing: 0.3,
               color: 'oklch(0.4 0.12 360)',
             }}
           >
@@ -132,7 +117,7 @@ export default async function OpengraphImage() {
             shilp-sutra.devalok.in
           </div>
           <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
-            <div style={{ width: 8, height: 8, borderRadius: 9999, background: '#22c55e' }} />
+            <div style={{ width: 8, height: 8, borderRadius: 9999, background: 'oklch(0.6 0.22 360)' }} />
             <span>Made in Bharat by Devalok</span>
           </div>
         </div>

--- a/apps/site/app/themer/archetypes/page.tsx
+++ b/apps/site/app/themer/archetypes/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/lib/archetype-presets'
 
 export const metadata: Metadata = {
-  title: 'Archetype gallery — Themer',
+  title: 'Archetype gallery · Themer',
   description:
     'Seven archetype presets, side by side. Click one to see its result page with install commands and CSS to paste.',
 }
@@ -48,7 +48,7 @@ export default function ArchetypeGalleryPage() {
               eyebrow="Themer · Archetypes"
               title="Pick one that feels right."
               subtitle="Seven presets. Same components, seven personalities."
-              description="Each archetype bundles a coherent set of role tokens — corner radius, density, borders, shadows, motion. Click any card to land on its result page with install commands + the CSS snippet to paste."
+              description="Each archetype bundles a coherent set of role tokens: corner radius, density, borders, shadows, motion. Click any card to land on its result page with install commands + the CSS snippet to paste."
               meta={
                 <Link
                   href="/themer"
@@ -97,12 +97,12 @@ export default function ArchetypeGalleryPage() {
             </section>
 
             <section className="border-t border-surface-border-subtle pt-ds-08 flex flex-col gap-ds-03 max-w-2xl">
-              <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+              <span className="text-ds-xs text-surface-fg-subtle">
                 Want more control?
               </span>
               <p className="text-ds-md text-surface-fg-muted leading-relaxed">
                 Archetypes are a starting point, not a cage. After you pick one, the result page
-                exposes the underlying role tokens. Override any of them in your own CSS — radius,
+                exposes the underlying role tokens. Override any of them in your own CSS: radius,
                 density, motion, borders. Or start from your{' '}
                 <Link href="/themer/brand" className="text-accent-11 underline underline-offset-2">
                   brand color

--- a/apps/site/app/themer/brand/page.tsx
+++ b/apps/site/app/themer/brand/page.tsx
@@ -7,7 +7,7 @@ import { SiteHeader } from '@/components/site-header'
 import { BrandImportPanel } from '@/components/themer/BrandImportPanel'
 
 export const metadata: Metadata = {
-  title: 'Use my brand — Themer',
+  title: 'Use my brand · Themer',
   description:
     'Paste a hex or dial OKLCH. shilp-sutra generates the 12-step ramp and suggests an archetype that pairs with your color.',
 }
@@ -37,13 +37,13 @@ export default function BrandImportPage() {
             <BrandImportPanel />
 
             <section className="border-t border-surface-border-subtle pt-ds-08 flex flex-col gap-ds-03 max-w-2xl">
-              <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+              <span className="text-ds-xs text-surface-fg-subtle">
                 Why OKLCH?
               </span>
               <p className="text-ds-md text-surface-fg-muted leading-relaxed">
                 OKLCH lets us hold lightness steady across the ramp while you change the hue.
-                That's what keeps step 1 and step 12 readable on the same backgrounds at every hue —
-                something the old HSL/HSV ramps couldn't do. If you only have a hex, that's fine:
+                That's what keeps step 1 and step 12 readable on the same backgrounds at every hue.
+                The old HSL/HSV ramps couldn't do that. If you only have a hex, that's fine:
                 we approximate the hue from RGB and let you fine-tune from there.
               </p>
             </section>

--- a/apps/site/app/themer/page.tsx
+++ b/apps/site/app/themer/page.tsx
@@ -6,7 +6,7 @@ import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
 
 export const metadata: Metadata = {
-  title: 'Themer — shilp-sutra',
+  title: 'Themer · shilp-sutra',
   description:
     'Make shilp-sutra look like your brand. Pick the path that fits where you are: brand colors in hand, an archetype to clone, a guided wizard, or just browsing.',
 }
@@ -65,7 +65,7 @@ export default function ThemerLandingPage() {
               eyebrow="Themer"
               title="Make it look like you."
               subtitle="Four ways in. Same place to land."
-              description="The Themer is one funnel with four entry doors. Pick the door that fits where you are right now — each path drops you at a result page with install commands, a CSS snippet, and a live preview."
+              description="The Themer is one funnel with four entry doors. Pick the door that fits where you are right now. Each path drops you at a result page with install commands, a CSS snippet, and a live preview."
             />
 
             <section
@@ -78,7 +78,7 @@ export default function ThemerLandingPage() {
                   href={p.href}
                   className="group flex flex-col gap-ds-03 rounded-surface border border-surface-border-subtle bg-surface-2 p-ds-06 transition-colors duration-fast-01 hover:border-accent-7 hover:bg-surface-3"
                 >
-                  <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+                  <span className="text-ds-xs text-surface-fg-subtle">
                     {p.eyebrow}
                   </span>
                   <h2 className="text-ds-xl font-semibold text-surface-fg">{p.title}</h2>
@@ -93,7 +93,7 @@ export default function ThemerLandingPage() {
             </section>
 
             <section className="border-t border-surface-border-subtle pt-ds-08 flex flex-col gap-ds-03 max-w-2xl">
-              <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+              <span className="text-ds-xs text-surface-fg-subtle">
                 Under the hood
               </span>
               <h3 className="text-ds-lg font-semibold text-surface-fg">CSS variables. No JS theme provider.</h3>

--- a/apps/site/app/themer/result/page.tsx
+++ b/apps/site/app/themer/result/page.tsx
@@ -21,7 +21,7 @@ import { buildAgentPrompt } from '@/lib/themer-prompt'
 import { parseThemerParams } from '@/lib/themer-state'
 
 export const metadata: Metadata = {
-  title: 'Result — Themer',
+  title: 'Result · Themer',
   description:
     'Your shilp-sutra theme: one prompt for your AI editor, or install + CSS to paste by hand. Live preview included.',
 }
@@ -77,14 +77,14 @@ export default async function ResultPage({ searchParams }: ResultPageProps) {
                 {/* MANUAL FALLBACK — install + CSS paste by hand */}
                 <section className="flex flex-col gap-ds-05 border-t border-surface-border-subtle pt-ds-07">
                   <div className="flex flex-col gap-ds-02 max-w-2xl">
-                    <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+                    <span className="text-ds-xs text-surface-fg-subtle">
                       Prefer to do it by hand?
                     </span>
                     <h2 className="text-ds-xl font-semibold text-surface-fg">
                       Install, paste, verify.
                     </h2>
                     <p className="text-ds-sm text-surface-fg-muted leading-relaxed">
-                      Three steps — about a minute. Skip this section entirely if you used the
+                      Three steps, about a minute. Skip this section entirely if you used the
                       prompt above.
                     </p>
                   </div>
@@ -136,7 +136,7 @@ export default async function ResultPage({ searchParams }: ResultPageProps) {
               </div>
 
               <aside className="flex flex-col gap-ds-04 lg:sticky lg:top-[5.5rem] lg:self-start">
-                <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+                <span className="text-ds-xs text-surface-fg-subtle">
                   Live preview
                 </span>
                 <PreviewFrame
@@ -168,7 +168,7 @@ export default async function ResultPage({ searchParams }: ResultPageProps) {
             </div>
 
             <section className="border-t border-surface-border-subtle pt-ds-08 flex flex-col gap-ds-03 max-w-2xl">
-              <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+              <span className="text-ds-xs text-surface-fg-subtle">
                 Want to tweak more?
               </span>
               <p className="text-ds-md text-surface-fg-muted leading-relaxed">

--- a/apps/site/app/themer/wizard/page.tsx
+++ b/apps/site/app/themer/wizard/page.tsx
@@ -7,7 +7,7 @@ import { SiteHeader } from '@/components/site-header'
 import { WizardFlow } from '@/components/themer/WizardFlow'
 
 export const metadata: Metadata = {
-  title: 'Wizard — Themer',
+  title: 'Wizard · Themer',
   description:
     'Five questions. We pick the archetype, density, shape, motion, and accent for you, then drop you at a result page.',
 }

--- a/apps/site/app/theming/page.tsx
+++ b/apps/site/app/theming/page.tsx
@@ -25,17 +25,10 @@ export default function ThemingPage() {
               subtitle="Pick a hue. Set the chroma. The twelve-step ramp generates itself."
               description="Every component on the site recolours live as you move the sliders. Buttons, badges, alerts, focus rings. Drop the exported CSS into your project and your whole app follows."
               meta={
-                <div className="flex flex-wrap gap-ds-02 text-ds-xs">
-                  <span className="inline-flex items-center gap-ds-02 rounded-control-inner border border-surface-border-subtle bg-surface-raised px-ds-03 py-ds-02 text-surface-fg-subtle">
-                    No theme provider. CSS-vars only.
-                  </span>
-                  <span className="inline-flex items-center gap-ds-02 rounded-control-inner border border-surface-border-subtle bg-surface-raised px-ds-03 py-ds-02 text-surface-fg-subtle">
-                    Light + dark generated together.
-                  </span>
-                  <span className="inline-flex items-center gap-ds-02 rounded-control-inner border border-surface-border-subtle bg-surface-raised px-ds-03 py-ds-02 text-surface-fg-subtle">
-                    Same algorithm shilp-sutra ships with.
-                  </span>
-                </div>
+                <Text variant="body-sm" className="text-surface-fg-subtle">
+                  No theme provider, CSS-vars only. Light and dark generate together, from the same
+                  algorithm shilp-sutra ships with.
+                </Text>
               }
             />
 
@@ -51,7 +44,7 @@ export default function ThemingPage() {
                     Try the Themer.
                   </Text>
                   <Text variant="body-sm" className="text-surface-fg-muted">
-                    Four entry doors — pick an archetype, paste your brand color, take a wizard, or
+                    Four entry doors: pick an archetype, paste your brand color, take a wizard, or
                     just see a result page. Each drops you at install + CSS to paste, no editing
                     required.
                   </Text>

--- a/apps/site/components/agent-callout.tsx
+++ b/apps/site/components/agent-callout.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { IconArrowRight, IconBook, IconSparkles } from '@tabler/icons-react'
+import { IconArrowRight, IconBook } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 
 /**
@@ -11,22 +11,14 @@ export function AgentCallout() {
   return (
     <section className="mx-auto max-w-4xl px-page-x py-ds-12">
       <div className="rounded-surface border border-accent-7 bg-accent-2 p-ds-08 flex flex-col gap-ds-05">
-        <header className="flex items-start gap-ds-04">
-          <div className="w-10 h-10 rounded-control-inner bg-accent-9 text-accent-fg flex items-center justify-center shrink-0">
-            <IconSparkles size={20} />
-          </div>
-          <div className="flex flex-col">
-            <span className="text-ds-xs text-accent-11 uppercase tracking-wide">
-              Built for AI editors
-            </span>
-            <h2 className="text-ds-xl text-surface-fg font-semibold mt-ds-01">
-              Your editor already knows the library.
-            </h2>
-            <p className="text-ds-md text-surface-fg-muted max-w-2xl mt-ds-03">
-              Install the Agent Skill once. Cursor, Claude Code, Codex, Aider then write code
-              that compiles the first time. Every component, every prop, every gotcha.
-            </p>
-          </div>
+        <header className="flex flex-col gap-ds-03">
+          <h2 className="text-ds-xl text-surface-fg font-semibold">
+            Your editor already knows the library.
+          </h2>
+          <p className="text-ds-md text-surface-fg-muted max-w-2xl">
+            Built for AI editors. Install the Agent Skill once. Cursor, Claude Code, Codex, Aider
+            then write code that compiles the first time. Every component, every prop, every gotcha.
+          </p>
         </header>
 
         <footer className="flex flex-wrap items-center gap-ds-03 pt-ds-02">

--- a/apps/site/components/built-with.tsx
+++ b/apps/site/components/built-with.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type CSSProperties } from 'react'
 import Link from 'next/link'
-import { IconArrowUpRight, IconLock, IconSparkles } from '@tabler/icons-react'
+import { IconArrowUpRight, IconLock } from '@tabler/icons-react'
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Text } from '@devalok/shilp-sutra/ui/text'
@@ -279,23 +279,14 @@ function FeaturedCard({ consumer }: { consumer: Consumer }) {
       style={style}
       className="relative overflow-hidden rounded-surface border border-accent-7 bg-linear-to-br from-accent-2 via-accent-3 to-accent-2"
     >
-      {/* Decorative brand glow in the corner — purely atmospheric. Sized
-          smaller on mobile so it doesn't dominate the layout. */}
-      <span
-        aria-hidden
-        className="pointer-events-none absolute -top-16 -right-16 w-40 h-40 sm:-top-20 sm:-right-20 sm:w-64 sm:h-64 rounded-pill opacity-40 blur-3xl"
-        style={{ background: `var(--color-accent-9)` }}
-      />
-
       <div className="relative grid grid-cols-1 lg:grid-cols-[1.4fr_1fr] gap-ds-06 lg:gap-ds-08 p-ds-05 sm:p-ds-06 lg:p-ds-08">
         {/* Left — identity + pitch */}
         <div className="flex flex-col gap-ds-05 min-w-0">
           <div className="flex items-center gap-ds-03 min-w-0">
             <BrandTile iconSrc={consumer.iconSrc} domain={consumer.domain} name={consumer.name} size={40} />
             <div className="flex flex-col min-w-0">
-              <span className="text-ds-xs uppercase tracking-wide text-accent-11 inline-flex items-center gap-ds-02 truncate">
-                <IconSparkles size={12} aria-hidden className="shrink-0" />
-                <span className="truncate">Flagship · {consumer.status}</span>
+              <span className="text-ds-xs uppercase tracking-wide text-accent-11 truncate">
+                Flagship · {consumer.status}
               </span>
               <Text variant="heading-xl" className="text-surface-fg text-balance">
                 {consumer.name}
@@ -399,7 +390,7 @@ function SecondaryCard({ consumer }: { consumer: Consumer }) {
   // arrow chevron are dropped entirely on internal-only cards so they
   // stop suggesting interaction they can't deliver.
   const cardClass = [
-    'group relative flex flex-col gap-ds-04 overflow-hidden rounded-surface border bg-surface-raised shadow-raised h-full',
+    'group relative flex flex-col gap-ds-04 overflow-hidden rounded-surface border bg-surface-raised h-full',
     isInteractive
       ? 'border-surface-border-subtle hover:shadow-raised-hover hover:border-accent-7 hover:-translate-y-px focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base transition-[border-color,box-shadow,transform] duration-fast-02 ease-productive-standard cursor-pointer'
       : 'border-surface-border-subtle',
@@ -408,11 +399,6 @@ function SecondaryCard({ consumer }: { consumer: Consumer }) {
   const body = (
     <article style={style} className={cardClass}>
       <div className="relative h-16 bg-linear-to-br from-accent-3 to-accent-2 border-b border-surface-border-subtle overflow-hidden shrink-0">
-        <span
-          aria-hidden
-          className="pointer-events-none absolute -top-10 -right-10 w-32 h-32 rounded-pill opacity-40 blur-2xl"
-          style={{ background: `var(--color-accent-9)` }}
-        />
         <div className="relative h-full flex items-center justify-between gap-ds-03 px-ds-04 min-w-0">
           <BrandTile
             iconSrc={consumer.iconSrc}

--- a/apps/site/components/component-showcase.tsx
+++ b/apps/site/components/component-showcase.tsx
@@ -10,7 +10,6 @@ import {
   IconLink,
   IconMoon,
   IconPalette,
-  IconSparkles,
   IconSun,
 } from '@tabler/icons-react'
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
@@ -80,7 +79,7 @@ function DemoCard({
   return (
     <article className="flex flex-col gap-ds-05 p-ds-06 rounded-surface border border-transparent bg-surface-raised shadow-raised">
       <header className="flex flex-col">
-        <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">{eyebrow}</span>
+        <span className="text-ds-xs text-surface-fg-subtle">{eyebrow}</span>
         <h3 className="text-ds-md text-surface-fg font-semibold mt-ds-01">{title}</h3>
         <p className="text-ds-sm text-surface-fg-subtle mt-ds-02">{caption}</p>
       </header>
@@ -119,8 +118,8 @@ function CommandPaletteDemo() {
     {
       label: 'Brand',
       items: [
-        { id: 'b-mira', label: 'Switch to Mira (saffron)', icon: <IconSparkles size={14} />, onSelect: () => (window.location.href = '/theming?hue=55&chroma=0.18') },
-        { id: 'b-atlas', label: 'Switch to Atlas (indigo)', icon: <IconSparkles size={14} />, onSelect: () => (window.location.href = '/theming?hue=245&chroma=0.19') },
+        { id: 'b-mira', label: 'Switch to Mira (saffron)', icon: <IconPalette size={14} />, onSelect: () => (window.location.href = '/theming?hue=55&chroma=0.18') },
+        { id: 'b-atlas', label: 'Switch to Atlas (indigo)', icon: <IconPalette size={14} />, onSelect: () => (window.location.href = '/theming?hue=245&chroma=0.19') },
       ],
     },
     {

--- a/apps/site/components/feature-grid.tsx
+++ b/apps/site/components/feature-grid.tsx
@@ -1,6 +1,5 @@
 import { IconLayoutGrid, IconPalette, IconShield, IconUsers } from '@tabler/icons-react'
 import { Text } from '@devalok/shilp-sutra/ui/text'
-import { CARD_RESTING } from '@/lib/card-recipe'
 
 /**
  * Three pillars + one builder card. Per docs/copy/shilp-sutra-copy-context.md §3.
@@ -46,15 +45,15 @@ export function FeatureGrid() {
             Three pillars. One promise.
           </Text>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-ds-06">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-ds-08 gap-y-ds-07">
           {features.map((f) => (
-            <article key={f.title} className={CARD_RESTING + ' flex flex-col gap-ds-03'}>
-              <div className="w-9 h-9 rounded-control-inner bg-accent-3 text-accent-11 flex items-center justify-center">
-                <f.icon size={18} />
+            <div key={f.title} className="flex flex-col gap-ds-02">
+              <div className="flex items-center gap-ds-02">
+                <f.icon size={18} className="text-accent-11 shrink-0" />
+                <h3 className="text-ds-md text-surface-fg font-semibold">{f.title}</h3>
               </div>
-              <h3 className="text-ds-md text-surface-fg font-semibold">{f.title}</h3>
               <p className="text-ds-sm text-surface-fg-subtle">{f.body}</p>
-            </article>
+            </div>
           ))}
         </div>
       </div>

--- a/apps/site/components/featured-components.tsx
+++ b/apps/site/components/featured-components.tsx
@@ -25,7 +25,7 @@ export function FeaturedComponents() {
     <TooltipProvider delayDuration={200}>
       <section className="mb-ds-12">
         <header className="flex flex-col gap-ds-03 max-w-3xl mb-ds-08">
-          <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+          <span className="text-ds-xs text-surface-fg-subtle">
             Featured · live demos
           </span>
           <h2 className="text-[length:var(--typo-heading-xl-size)] font-[number:var(--typo-heading-xl-weight)] leading-[var(--typo-heading-xl-leading)] tracking-[var(--typo-heading-xl-tracking)] text-surface-fg">
@@ -68,7 +68,7 @@ function FeatureCard({
   return (
     <article className="group flex flex-col gap-ds-04 p-ds-05b rounded-surface bg-surface-raised shadow-raised transition-[box-shadow,translate] duration-fast-02 ease-productive-standard hover:shadow-raised-hover hover:-translate-y-px">
       <header className="flex flex-col">
-        <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">{slug}</span>
+        <span className="text-ds-xs text-surface-fg-subtle">{slug}</span>
         <h3 className="text-ds-md text-surface-fg font-semibold mt-ds-01">{title}</h3>
         <p className="text-ds-sm text-surface-fg-subtle mt-ds-02">{caption}</p>
       </header>

--- a/apps/site/components/landing-surface.tsx
+++ b/apps/site/components/landing-surface.tsx
@@ -98,7 +98,7 @@ export function LandingSurface() {
           </div>
           <Badge variant="soft" color="success" size="sm">
             <span className="inline-flex items-center gap-1">
-              <span className="w-1.5 h-1.5 rounded-pill bg-success-9 animate-pulse" />
+              <span className="w-1.5 h-1.5 rounded-pill bg-success-9 motion-safe:animate-pulse" />
               streaming
             </span>
           </Badge>

--- a/apps/site/components/page-header.tsx
+++ b/apps/site/components/page-header.tsx
@@ -33,7 +33,7 @@ export function PageHeader({
   return (
     <header className={['flex flex-col gap-ds-03 max-w-3xl mb-ds-09', className].filter(Boolean).join(' ')}>
       {eyebrow && (
-        <div className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">{eyebrow}</div>
+        <div className="text-ds-xs text-surface-fg-subtle">{eyebrow}</div>
       )}
       <h1 className="text-[length:var(--typo-heading-2xl-size)] font-[number:var(--typo-heading-2xl-weight)] leading-[var(--typo-heading-2xl-leading)] tracking-[var(--typo-heading-2xl-tracking)] text-surface-fg text-balance">
         {title}

--- a/apps/site/components/site-footer.tsx
+++ b/apps/site/components/site-footer.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { IconHeartFilled } from '@tabler/icons-react'
 import { Text } from '@devalok/shilp-sutra/ui/text'
 
 const linkGroups = [
@@ -73,7 +74,9 @@ export function SiteFooter() {
         </div>
         <div className="mt-ds-09 pt-ds-06 border-t border-surface-border-subtle flex flex-col gap-ds-04">
           <Text variant="body-sm" className="text-surface-fg-muted text-center sm:text-left">
-            Made in Bharat with <span aria-label="orange heart" role="img">🧡</span> by{' '}
+            Made in Bharat with{' '}
+            <IconHeartFilled size={14} className="inline align-[-2px] text-accent-9" aria-label="love" />{' '}
+            by{' '}
             <Link
               href="https://devalok.in"
               target="_blank"

--- a/apps/site/components/themer/AgentPromptHero.tsx
+++ b/apps/site/components/themer/AgentPromptHero.tsx
@@ -29,7 +29,7 @@ export function AgentPromptHero({ prompt }: AgentPromptHeroProps) {
   return (
     <section
       aria-label="One-prompt setup for AI agents"
-      className="relative overflow-hidden rounded-surface border border-accent-7 bg-linear-to-br from-accent-2 via-surface-2 to-accent-3 p-ds-06 md:p-ds-08"
+      className="relative overflow-hidden rounded-surface border border-accent-7 bg-accent-2 p-ds-06 md:p-ds-08"
     >
       <div className="flex flex-col gap-ds-05 max-w-3xl">
         <h2 className="text-ds-3xl md:text-ds-4xl font-semibold text-surface-fg leading-tight text-balance">

--- a/apps/site/components/themer/BrandImportPanel.tsx
+++ b/apps/site/components/themer/BrandImportPanel.tsx
@@ -129,7 +129,7 @@ export function BrandImportPanel() {
         </div>
 
         <div className="rounded-surface border border-surface-border-subtle bg-surface-2 p-ds-04 flex flex-col gap-ds-02">
-          <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+          <span className="text-ds-xs text-surface-fg-subtle">
             Suggested archetype
           </span>
           <div className="flex items-baseline justify-between">
@@ -148,7 +148,7 @@ export function BrandImportPanel() {
       </div>
 
       <div className="flex flex-col gap-ds-04">
-        <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+        <span className="text-ds-xs text-surface-fg-subtle">
           Live preview · {suggestion.name}
         </span>
         <PreviewFrame

--- a/apps/site/components/themer/WizardFlow.tsx
+++ b/apps/site/components/themer/WizardFlow.tsx
@@ -161,7 +161,7 @@ export function WizardFlow() {
       </div>
 
       <aside className="flex flex-col gap-ds-03 lg:w-[320px]">
-        <span className="text-ds-xs text-surface-fg-subtle uppercase tracking-wide">
+        <span className="text-ds-xs text-surface-fg-subtle">
           Live preview
         </span>
         <PreviewFrame

--- a/apps/site/content/blocks/pricing/block.tsx
+++ b/apps/site/content/blocks/pricing/block.tsx
@@ -73,7 +73,7 @@ const faqs = [
   },
   {
     q: 'Will Bespoke fork the package?',
-    a: 'No fork. We extend, never branch off. Custom work lands in your repo as a thin layer on top of @devalok/shilp-sutra, so upgrades stay clean and your patches survive.',
+    a: 'No fork. Custom work lands in your repo as a thin layer on top of @devalok/shilp-sutra, so upgrades stay clean and your patches survive.',
   },
 ] as const
 
@@ -96,7 +96,7 @@ export function PricingBlock() {
         {tiers.map((tier) => (
           <Card
             key={tier.name}
-            className={tier.featured ? 'border-accent-9 shadow-overlay relative' : ''}
+            className={tier.featured ? 'border-accent-9 relative' : ''}
           >
             {tier.featured && (
               <div className="absolute -top-3 left-ds-05">
@@ -140,7 +140,7 @@ export function PricingBlock() {
 
       <section className="max-w-2xl mx-auto px-page-x flex flex-col gap-ds-05">
         <Text variant="heading-md" className="text-surface-fg text-center">
-          Honest questions, honest answers.
+          Common questions.
         </Text>
         <dl className="flex flex-col gap-ds-04">
           {faqs.map((f) => (

--- a/apps/site/content/showcase/atlas.tsx
+++ b/apps/site/content/showcase/atlas.tsx
@@ -14,7 +14,6 @@ import {
   IconPlus,
   IconSearch,
   IconSettings,
-  IconSparkles,
   IconTrendingUp,
   IconUsers,
 } from '@tabler/icons-react'
@@ -310,7 +309,7 @@ export function AtlasShowcase() {
                       </div>
                       <SheetFooter>
                         <Button variant="soft" onClick={() => setSheetOpen(false)}>Cancel</Button>
-                        <Button onClickAsync={createProject} startIcon={<IconSparkles size={14} />}>
+                        <Button onClickAsync={createProject} startIcon={<IconPlus size={14} />}>
                           Create project
                         </Button>
                       </SheetFooter>

--- a/apps/site/content/showcase/devalok.tsx
+++ b/apps/site/content/showcase/devalok.tsx
@@ -8,12 +8,12 @@ import {
   IconArrowUpRight,
   IconBrandGithub,
   IconBuildingArch,
+  IconBulb,
   IconCircleCheck,
   IconCompass,
   IconDeviceLaptop,
   IconFeather,
   IconNotebook,
-  IconSparkles,
 } from '@tabler/icons-react'
 
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
@@ -75,7 +75,7 @@ const practices: { name: string; tag: string; body: string; Icon: typeof IconCom
     name: 'Strategy + research',
     tag: 'Foundational',
     body: 'The interviews, the field notes, the positioning work that the visible work rests on.',
-    Icon: IconSparkles,
+    Icon: IconBulb,
   },
 ]
 
@@ -346,7 +346,7 @@ export function DevalokShowcase() {
       <Card className="bg-accent-2 border-accent-7">
         <CardContent className="flex flex-col gap-ds-04 py-ds-06">
           <div className="flex items-start gap-ds-03">
-            <IconSparkles size={20} className="text-accent-11 mt-1 shrink-0" aria-hidden />
+            <IconFeather size={20} className="text-accent-11 mt-1 shrink-0" aria-hidden />
             <div className="flex flex-col gap-ds-01">
               <Text variant="heading-sm" className="text-surface-fg">
                 Conversation, understanding, creation.


### PR DESCRIPTION
Audits `apps/site` against setu's anti-convergence layer (`server/house/anti-convergence.yaml` v1.1) and applies fixes. **Site-only** — does not trigger the npm release pipeline (`release.yml` paths-ignore `apps/site/**`); merge deploys the site via Railway.

Complements the earlier `feat(core)! anti-convergence surface pass (#82)` — that was tokens/surfaces; this is the marketing-site tells. The stale `feat/site-anti-convergence` branch is fully superseded (all its fixes already in main).

## Fixes

**Verbal**
- 7 `sparkle-ai-glyph` icons removed/replaced (`IconSparkles` → action icons or dropped): agent-callout, /agents, atlas "Create project" → Plus, brand-swap items → Palette, built-with, devalok showcase ×2
- footer orange-heart emoji → `IconHeartFilled`
- `em-dash-tic`: 5 body-copy + 5 metadata-title em dashes → comma/colon/·
- `contrastive-negation` + `false-honesty` copy (pricing block)
- `tricolon`: blocks index title, theming meta pills → prose

**Visual**
- `eyebrow-kicker`: dropped the `uppercase tracking-wide` signature in `PageHeader` + 11 pages/components
- `icon-tile-above-heading` → inline icons (agent-callout, /agents resources, docs cards, feature-grid)
- `everything-a-card`: feature-grid rebuilt without card boxes
- `accent-rail-and-double-edge`: built-with card + pricing featured tier → edge OR elevation
- `blob-glass-glow`: removed 4 decorative blur glows (built-with ×2, OG image, AgentPromptHero wash → solid)
- `off-mean-palette`: OG status dot `#22c55e` → brand pink

**Motion**
- `no-reduced-motion`: landing-surface pulse → `motion-safe:animate-pulse`

## Left exempt (deliberate craft, per the layer's precedence clause)
AuroraBloom, lotus/aurora WebGL, unified-canvas + showcase brand-swap demos, per-product gradient fills, figma-make numbered steps, pricing 3-tier template. Hero kept centered (maintainer choice).

## Also (separate concern)
`/agents` advertised **llms-full.txt** (removed in 0.45.0) — curl 404'd. Replaced with the hosted MCP card; refreshed llms.txt copy.

Verified locally: `next build` ✓, `tsc --noEmit` ✓, `next lint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)