### PR TITLE
fix(release): pin npm@11 for OIDC publish (npm 12 broke sigstore)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,13 @@ jobs:
           # which downloads a clean tarball and sets up bin shims without
           # relying on the removed npm CLI.
           curl -qL https://www.npmjs.com/install.sh | sh
+          # install.sh pulls the LATEST npm. As of 2026-07 that is npm 12.x,
+          # whose libnpmpublish@12 breaks `npm publish --provenance` with
+          # "Cannot find module 'sigstore'" and fails the whole release.
+          # Pin to the 11.x line (libnpmpublish@11), which bundles sigstore and
+          # is the version OIDC trusted publishing has always used here.
+          # See the 2026-07-09 release failure.
+          npm i -g npm@11
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
npm 12.0.0's `libnpmpublish@12` fails `npm publish --provenance` with `Cannot find module 'sigstore'` — this broke the 0.7.0 release (version bumped on main, never published to npm). `install.sh` always pulls latest, so it drifted onto v12. Pin `npm@11` (libnpmpublish@11, bundles sigstore) after install.sh. Merging re-triggers Release; since main (0.7.0/0.46.0/0.2.0) > npm, it publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)