### PR TITLE
fix(playground): Checkbox/Switch use state prop (0.49 field-state)

### DIFF
--- a/apps/playground/src/components/ComponentSandbox/ComponentRegistry.tsx
+++ b/apps/playground/src/components/ComponentSandbox/ComponentRegistry.tsx
@@ -286,7 +286,7 @@ export const COMPONENT_REGISTRY: ComponentEntry[] = [
       <div className="flex items-center gap-2">
         <Checkbox
           disabled={props.disabled}
-          error={props.error}
+          state={props.error ? 'error' : undefined}
           defaultChecked={props.checked}
         />
         <label className="text-ds-md text-surface-fg">{props.label}</label>
@@ -326,7 +326,7 @@ export const COMPONENT_REGISTRY: ComponentEntry[] = [
       <div className="flex items-center gap-2">
         <Switch
           disabled={props.disabled}
-          error={props.error}
+          state={props.error ? 'error' : undefined}
           defaultChecked={props.checked}
         />
         <label className="text-ds-md text-surface-fg">{props.label}</label>


### PR DESCRIPTION
Unblocks the Release + Deploy-Storybook workflows, which went red on `main` right after #134 merged.

**Cause:** playground `ComponentRegistry.tsx` passed the removed `error` boolean to `Checkbox`/`Switch` (fix #2 renamed it to `state`). Missed in #134's sweep because it was `error={props.error}` inside a render fn, not inline `<Checkbox error>` — and the release path's `build:fresh` (no cache) builds playground where PR CI's scoped build didn't.

**Fix:** `error={props.error}` → `state={props.error ? 'error' : undefined}` (Checkbox + Switch).

**Verified:** `pnpm build:fresh` green (5/5, post-build audit clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)