### PR TITLE
fix: migrate remaining 0.49 consumers off removed symbols

### DIFF
--- a/packages/core/make-kit/components/form.md
+++ b/packages/core/make-kit/components/form.md
@@ -69,7 +69,7 @@ Use inside a custom control to consume FormField context.
 
 | Control | Manual wiring needed |
 |---|---|
-| `<Select>` / `<SelectTrigger>` | Set `color="error"` on `SelectTrigger` from your validation state. |
+| `<Select>` / `<SelectTrigger>` | Set `state="error"` on `SelectTrigger` from your validation state. |
 | `<Checkbox>`, `<Radio>`, `<Switch>` | Pair `<Label htmlFor>` manually. State is visual on the control. |
 
 ## Examples
@@ -134,7 +134,7 @@ The Input receives `aria-describedby` (linked to FormHelperText), `aria-invalid=
     <FormField state={errors.role ? 'error' : 'helper'}>
       <Label htmlFor="role">Role</Label>
       <Select>
-        <SelectTrigger id="role" color={errors.role ? 'error' : 'default'}>
+        <SelectTrigger id="role" state={errors.role ? 'error' : 'default'}>
           <SelectValue placeholder="Choose a role" />
         </SelectTrigger>
         <SelectContent>

--- a/packages/core/make-kit/components/icon.md
+++ b/packages/core/make-kit/components/icon.md
@@ -14,7 +14,7 @@ For the broader icon system (which icons exist, how to register custom ones, the
 - Any inline SVG icon — inside Button slots, IconButton, Badge slots, table cells, list rows.
 - Need an interactive icon button? Use `<IconButton>`, not Icon wrapped in `<button>`.
 - Need a static cluster of related icons? Use `<IconGroup>`.
-- Need a status indicator? Use `<StatusDot>` or `<Badge dot>` — they're optimized for that.
+- Need a status indicator? Use `<Dot>` or `<Badge dot>` — they're optimized for that.
 
 Tabler-only. Don't mix icon libraries — see `foundations/icons.md` for the rationale.
 
@@ -129,7 +129,7 @@ Input's IconProvider sets size by input size: `xs` / `sm` input → `sm` icon, `
 </Stack>
 ```
 
-For most status displays prefer `<StatusDot>` — purpose-built. Use this pattern only when you need a specific icon shape.
+For most status displays prefer `<Dot>` — purpose-built. Use this pattern only when you need a specific icon shape.
 
 ## Composability
 

--- a/packages/core/make-kit/components/overview.md
+++ b/packages/core/make-kit/components/overview.md
@@ -77,7 +77,7 @@ Permanent inline message?
 Status of an item?
   → <Badge>          — pill label (status / tag)
   → <StatusBadge>    — colored dot + label (discriminated union: status="online"/"away"/...)
-  → <StatusDot>      — just the colored dot
+  → <Dot>            — just the colored status/indicator dot
 
 Temporary notification?
   → toast.success / error / warning / info (imperative) — must have <Toaster /> mounted
@@ -256,7 +256,7 @@ Code?
 | Skeleton | `/ui/skeleton` |
 | Badge | `/ui/badge` |
 | StatusBadge | `/composed/status-badge` |
-| StatusDot | `/ui/status-dot` |
+| Dot | `/ui/dot` |
 | EmptyState | `/composed/empty-state` |
 
 ### Layout

--- a/packages/core/make-kit/components/select.md
+++ b/packages/core/make-kit/components/select.md
@@ -98,7 +98,7 @@ Styling lives on the **Trigger**, not on `Select` root. Setting `<Select size="l
 <FormField state={errors.role ? 'error' : 'helper'}>
   <Label htmlFor="role">Role</Label>
   <Select value={role} onValueChange={setRole}>
-    <SelectTrigger id="role" color={errors.role ? 'error' : 'default'}>
+    <SelectTrigger id="role" state={errors.role ? 'error' : 'default'}>
       <SelectValue placeholder="Choose a role" />
     </SelectTrigger>
     <SelectContent>

--- a/packages/core/make-kit/components/table.md
+++ b/packages/core/make-kit/components/table.md
@@ -233,7 +233,7 @@ Table + Badge (server-safe via Badge.Group context — verify per use) + Avatar 
 
 - **Server-safe:** Table and its sub-components are pure HTML semantic wrappers. No state, no context. Use in RSC trees without `'use client'`.
 - **TableHead scope:** Headers automatically get `scope="col"` for screen-reader navigation. Don't override it.
-- **Composes with primitives:** Drop `<Badge>`, `<Avatar>`, `<IconButton>`, `<StatusDot>` inside cells. Check each component's server-safety if you need RSC compatibility.
+- **Composes with primitives:** Drop `<Badge>`, `<Avatar>`, `<IconButton>`, `<Dot>` inside cells. Check each component's server-safety if you need RSC compatibility.
 - **TableCaption:** Renders as HTML `<caption>` — screen readers announce it before content. Use it for any non-trivial table.
 
 See `foundations/typography.md` for the body / label variants inside cells, `foundations/surfaces.md` for table-in-card surface guidance.

--- a/packages/core/src/composed/schedule-view.test.tsx
+++ b/packages/core/src/composed/schedule-view.test.tsx
@@ -17,7 +17,7 @@ const sampleEvents: ScheduleEvent[] = [
     title: 'Team Standup',
     start: new Date('2026-03-17T09:00:00Z'),
     end: new Date('2026-03-17T09:30:00Z'),
-    color: 'primary',
+    color: 'accent',
   },
   {
     id: '2',

--- a/packages/core/src/ui/checkbox.stories.tsx
+++ b/packages/core/src/ui/checkbox.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Checkbox> = {
   argTypes: {
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },
-    error: { control: 'boolean' },
+    state: { control: 'select', options: ['default', 'error', 'warning', 'success'] },
     indeterminate: { control: 'boolean' },
     size: { control: 'radio', options: ['sm', 'md', 'lg'] },
   },

--- a/packages/core/src/ui/motion.stories.tsx
+++ b/packages/core/src/ui/motion.stories.tsx
@@ -558,7 +558,7 @@ export const SlowAndContinuous: StoryObj = {
           <div className="space-y-ds-04 max-w-sm">
             <div className="space-y-ds-02">
               <span className="text-ds-sm text-surface-fg-muted">Determinate</span>
-              <Progress value={progress} showLabel />
+              <Progress value={progress} showValue />
               <Button variant="outline" size="sm" onClick={startProgress}>
                 {progress >= 100 ? 'Restart' : 'Start'}
               </Button>
@@ -1148,7 +1148,7 @@ export const ReducedMotionDemo: StoryObj = {
           <div className="grid grid-cols-2 gap-ds-04">
             <div className="space-y-ds-02">
               <span className="text-ds-xs text-surface-fg-muted">Progress bar</span>
-              <Progress value={65} showLabel />
+              <Progress value={65} showValue />
             </div>
             <div className="space-y-ds-02">
               <span className="text-ds-xs text-surface-fg-muted">Skeleton</span>

--- a/tests/smoke-consumer/app/page.tsx
+++ b/tests/smoke-consumer/app/page.tsx
@@ -27,7 +27,7 @@ import { Progress } from '@devalok/shilp-sutra/ui/progress'
 import { RadioGroup, RadioGroupItem } from '@devalok/shilp-sutra/ui/radio'
 import { Skeleton } from '@devalok/shilp-sutra/ui/skeleton'
 import { Spinner } from '@devalok/shilp-sutra/ui/spinner'
-import { StatusDot } from '@devalok/shilp-sutra/ui/status-dot'
+import { Dot } from '@devalok/shilp-sutra/ui/dot'
 import { Stepper, Step } from '@devalok/shilp-sutra/ui/stepper'
 import { Switch } from '@devalok/shilp-sutra/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@devalok/shilp-sutra/ui/tabs'
@@ -121,13 +121,13 @@ export default function Page() {
               <Avatar size="xl" badge={5} shape="rounded"><AvatarFallback>B</AvatarFallback></Avatar>
             </div>
 
-            {/* StatusDot — exercises processing-ants-* animations */}
+            {/* Dot — status indicator (StatusDot merged into Dot in 0.49.0) */}
             <div className="flex gap-ds-03">
-              <StatusDot status="healthy" pulse />
-              <StatusDot status="warning" />
-              <StatusDot status="critical" />
-              <StatusDot status="neutral" />
-              <StatusDot status="inactive" variant="ring" />
+              <Dot color="success" pulse />
+              <Dot color="warning" />
+              <Dot color="error" />
+              <Dot color="neutral" />
+              <Dot color="neutral" variant="off" />
             </div>
 
             {/* Alert — exercises shadow-error/success/warning + bg-{status}-* */}


### PR DESCRIPTION
Unblocks the 0.49.0 publish. The release path's **consumer-smoke** (Next 16 + Turbopack) and Storybook builds surfaced consumers the #134 sweep (packages/core-only) missed:

- `tests/smoke-consumer/app/page.tsx`: `StatusDot` → `Dot` (this blocked the publish gate — publish is correctly gated behind the smoke test, so **0.49.0 did not publish**)
- `src/ui/motion.stories.tsx`: `Progress showLabel` → `showValue` (2×)
- `src/ui/checkbox.stories.tsx`: stale `error` argType → `state` select
- `src/composed/schedule-view.test.tsx`: `ScheduleEvent color 'primary'` → `'accent'`
- `make-kit/components/{form,select,icon,overview,table}.md`: `SelectTrigger color`→`state`, `StatusDot`→`Dot`

Did an exhaustive whole-repo sweep (excluding other worktrees + build artifacts) for **every** removed/renamed 0.49 symbol — this is the complete set. typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)