### PR TITLE
fix(core): stop minifying internal export names to reserved words (#139)

### DIFF
--- a/.changeset/fix-reserved-word-export-alias.md
+++ b/.changeset/fix-reserved-word-export-alias.md
@@ -1,0 +1,19 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Fix a build failure in Next.js/Turbopack (App Router / RSC) consumers.
+
+`0.49.0` shipped `dist/_chunks/primitives.js` with an internal cross-chunk
+export aliased to the JavaScript reserved word `in` (`export { Mo as in }`).
+That is legal ESM, but Next.js turns every export of a `"use client"` module
+into a `const` binding when generating its RSC client-reference proxy —
+emitting the illegal `export const in = …` and failing the consumer's
+`next build` with `Expected ident`.
+
+The reserved word came from the bundler minifying internal export names into a
+short base-N pool that includes reserved words. Set
+`rollupOptions.output.minifyInternalExports: false` so internal export aliases
+stay readable, valid identifiers. No public API change.
+
+Fixes #139.

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -148,6 +148,16 @@ export default defineConfig({
       output: {
         entryFileNames: '[name].js',
         chunkFileNames: '_chunks/[name].js',
+        // Keep readable internal cross-chunk export names. When minified, the
+        // bundler mangles internal export aliases to short base-N names whose
+        // pool includes JS reserved words — 0.49.0 shipped `export { Mo as in }`
+        // in _chunks/primitives.js. That's legal ESM, but Next.js/Turbopack
+        // turns every export of a "use client" module into a `const` binding
+        // for its RSC client-reference proxy, emitting the illegal
+        // `export const in = …` and failing consumers' `next build`
+        // ("Expected ident"). Disabling this keeps aliases as valid identifiers.
+        // See devalok-design/shilp-sutra#139.
+        minifyInternalExports: false,
         manualChunks(id) {
           if (id.includes('node_modules')) {
             if (id.includes('@tiptap/') || id.includes('prosemirror'))


### PR DESCRIPTION
Fixes #139.

## Problem
`0.49.0` fails `next build` for Next.js/Turbopack (App Router / RSC) consumers. `dist/_chunks/primitives.js` (a `"use client"` chunk) contains an internal cross-chunk export aliased to the reserved word `in`:

```js
export { … , Mo as in, … }
```

That's valid ESM, but Next's RSC layer turns every export of a client module into a `const` binding for its client-reference proxy → illegal `export const in = …` → `Expected ident`. Karm (Next 16 / Turbopack) couldn't build against 0.49.0 and had to ship a local `pnpm patch` to unblock.

## Root cause
The bundler minifies internal (cross-chunk) export names into a short base-N pool that includes JS reserved words. `in` was the alias it picked for one export. Scan of 0.49.0 dist found exactly one offender.

## Fix
`rollupOptions.output.minifyInternalExports: false` in `packages/core/vite.config.ts` — internal export aliases stay readable, valid identifiers. No public API change.

## Verification
- Rebuilt dist: **zero** reserved-word export aliases across all `.js` (grepped `in|do|if|for|new|var|typeof|…`). `primitives.js` now exports `Mo as MotionFade`-style names.
- `pnpm typecheck` — clean.

## Trade-off / reviewer note
Disabling internal-export minification grows the dist slightly (readable export names in chunk interfaces; gzip-friendly, they repeat). If the **bundle-size gate** in `pre-publish-audit.mjs` trips, that's expected from this change — the size increase buys Turbopack/RSC compatibility. A more surgical fix (excluding only reserved words from the mangler's pool) isn't exposed as a Rolldown/rollup option, so disabling the mangling is the standard remedy.

Patch bump changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)