### PR TITLE
fix(core): remove AI-slop design tells across components

### DIFF
--- a/.changeset/deslop-audit-fixes.md
+++ b/.changeset/deslop-audit-fixes.md
@@ -1,0 +1,23 @@
+---
+'@devalok/shilp-sutra': patch
+---
+
+De-slop audit polish — removes AI-generated design "tells" flagged by an adversarial pass over the whole system (tokens + all components). No public API removed; two additive opt-in props added.
+
+**Reliability (the important one): content is now visible by default.** Several components started at `opacity: 0` and only appeared once a Framer entrance fired — so a backgrounded tab, a hydration stall, or a throttled animation engine could render them blank. Most alarming was `StatCard`'s primary value. Content no longer depends on an animation completing.
+
+- `StatCard`: new **`reveal?: boolean`** prop (default `false`). Off = value/label/progress render statically (content-safe). On = a subtle settle that never hides content. The old always-on roll-up (which strand-hid the number inside `overflow-hidden`) is gone.
+- `EmptyState`, `ActivityFeed`, chat `Message`, AI `Conversation` / `BlockRenderer` / stat-row: entrance reveals no longer gate opacity (pure fades → static; slides keep the slide, drop the opacity gating).
+- `Avatar` image no longer starts transparent.
+
+**Glow / bloom removal.**
+- `Button`: solid variants no longer bloom a colored `shadow-brand`/`shadow-error/success/warning` halo on hover. Kept the tonal `shadow-raised` base and the fill-deepen.
+- `Dot`: `pulse` now animates a contained fade on the dot itself instead of an expanding `animate-ping` glow ring.
+- `DevadootIcon`: removed the blurred-shape-copy glow layer (kept the gradient fill and shimmer).
+- `CommandBar`: removed the `blur(8px)` outer-glow copy behind the processing border (kept the animated border).
+
+**Motion polish.**
+- Removed hover-grow (`hover:scale-*`) on Combobox clear button, Slider thumb (kept the active/grab scale), ScheduleView event tiles, and AvatarGroup. `BottomNavbar` tap feedback is a press-shrink, not a lift.
+- `EmptyState` icon is a bare mark now (dropped the filled tile and the infinite bob).
+
+**Behavior change (minor, opt-out → opt-in):** `Badge` status dot no longer pulses by default. New **`dotPulse?: boolean`** prop (default `false`) restores it. A badge dot that previously pulsed will render static unless `dotPulse` is set.

--- a/packages/core/src/ai/block-renderer.tsx
+++ b/packages/core/src/ai/block-renderer.tsx
@@ -99,7 +99,7 @@ const BlockRenderer = React.forwardRef<HTMLDivElement, BlockRendererProps>(({
         return (
           <motion.div
             key={key}
-            initial={{ opacity: 0, y: 12 }}
+            initial={{ y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ ...springs.responsive, delay: index * (staggerDelay / 1000) }}
           >

--- a/packages/core/src/ai/blocks/stat-row.tsx
+++ b/packages/core/src/ai/blocks/stat-row.tsx
@@ -42,7 +42,7 @@ const StatRowBlock = React.memo(function StatRowBlock({
           <motion.div
             key={stat.label}
             className="flex-1 min-w-[140px]"
-            initial={{ opacity: 0, y: 8 }}
+            initial={{ y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ ...springs.responsive, delay: index * 0.08 }}
           >

--- a/packages/core/src/ai/command-bar.tsx
+++ b/packages/core/src/ai/command-bar.tsx
@@ -94,23 +94,6 @@ function GradientBorderWrap({
         },
       }}
     >
-      {/* Subtle outer glow */}
-      <motion.div
-        className={cn('absolute inset-0 -z-10', rounded)}
-        style={{
-          background: 'linear-gradient(var(--gradient-angle, 0deg), #D33163, #9B5DE5, #C850C0, #D33163)',
-          backgroundSize: '300% 300%',
-          filter: 'blur(8px)',
-        }}
-        animate={{
-          opacity: [0.3, 0.5, 0.3],
-          backgroundPosition: ['0% 0%', '100% 100%', '0% 0%'],
-        }}
-        transition={{
-          opacity: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
-          backgroundPosition: { duration: 4, repeat: Infinity, ease: 'linear' },
-        }}
-      />
       {children}
     </motion.div>
   )

--- a/packages/core/src/ai/conversation.tsx
+++ b/packages/core/src/ai/conversation.tsx
@@ -120,7 +120,7 @@ function UserMessage({
   return (
     <motion.div
       className="bg-surface-raised rounded-surface px-ds-05 py-ds-04"
-      initial={{ opacity: 0, y: 8 }}
+      initial={{ y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={springs.snappy}
     >
@@ -242,7 +242,7 @@ function ScrollToBottomPill({ onClick }: { onClick: () => void }) {
       role="button"
       aria-label="Scroll to latest response"
       className="absolute bottom-ds-04 left-1/2 -translate-x-1/2 z-10 flex items-center gap-ds-02 bg-accent-9 text-accent-fg text-ds-xs font-medium rounded-pill px-ds-04 py-ds-02 shadow-floating"
-      initial={{ opacity: 0, y: 8 }}
+      initial={{ y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 8 }}
       transition={springs.snappy}

--- a/packages/core/src/ai/devadoot-icon.tsx
+++ b/packages/core/src/ai/devadoot-icon.tsx
@@ -65,7 +65,6 @@ const DevadootIcon = React.memo(function DevadootIcon({
   const { reducedMotion } = useMotion()
   const gradientRotation = useGradientRotation(state)
   const gradientId = React.useId()
-  const filterId = React.useId()
 
   // Static fallback for reduced motion
   if (reducedMotion) {
@@ -94,9 +93,6 @@ const DevadootIcon = React.memo(function DevadootIcon({
         : state === 'responded'
           ? { s1: BRAND_BRIGHT, s2: BRAND_PINK, s3: BRAND_BRIGHT }
           : { s1: BRAND_PINK, s2: BRAND_ROSE, s3: BRAND_PINK }
-
-  // Glow blur intensity
-  const glowBlur = state === 'processing' ? 3 : state === 'error' ? 2.5 : 0
 
   return (
     <span
@@ -152,35 +148,9 @@ const DevadootIcon = React.memo(function DevadootIcon({
               transition={{ duration: state === 'processing' ? 3 : 5, repeat: Infinity, repeatType: 'reverse', ease: 'easeInOut', delay: 1 }}
             />
           </motion.linearGradient>
-
-          {/* Glow filter — blur applied to shadow layer */}
-          <filter id={filterId} x="-50%" y="-50%" width="200%" height="200%">
-            <motion.feGaussianBlur
-              in="SourceGraphic"
-              animate={{ stdDeviation: glowBlur }}
-              transition={{ duration: 0.6, ease: 'easeOut' }}
-            />
-          </filter>
         </defs>
 
-        {/* Layer 1: Glow shadow (blurred, semi-transparent copy behind) */}
-        <AnimatePresence>
-          {(state === 'processing' || state === 'error') && (
-            <motion.path
-              d={CHAKRA_PATH}
-              fill={`url(#${gradientId})`}
-              filter={`url(#${filterId})`}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: [0.2, 0.45, 0.2] }}
-              exit={{ opacity: 0 }}
-              transition={{
-                opacity: { duration: 3, repeat: Infinity, ease: 'easeInOut' },
-              }}
-            />
-          )}
-        </AnimatePresence>
-
-        {/* Layer 2: Shimmer highlight (bright overlay that pulses) */}
+        {/* Layer 1: Shimmer highlight (bright overlay that pulses) */}
         <AnimatePresence>
           {state === 'processing' && (
             <motion.path

--- a/packages/core/src/composed/activity-feed.tsx
+++ b/packages/core/src/composed/activity-feed.tsx
@@ -258,7 +258,7 @@ function GroupHeader({
 }) {
   return (
     <motion.div
-      initial={{ opacity: 0 }}
+      initial={false}
       animate={{ opacity: 1 }}
       transition={tweens.fade}
       className={cn(
@@ -345,7 +345,7 @@ const ActivityFeed = React.forwardRef<HTMLDivElement, ActivityFeedProps>(
                 <div className={cn('relative flex flex-col', compact ? 'gap-1' : 'gap-3')}>
                   <div className="absolute bottom-0 left-[3px] top-0 w-px bg-surface-border" />
                   {group.items.map((item, index) => (
-                    <motion.div key={item.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ ...tweens.fade, delay: index * 0.03 }}>
+                    <motion.div key={item.id} initial={false} animate={{ opacity: 1 }} transition={{ ...tweens.fade, delay: index * 0.03 }}>
                       {resolveEntry(item, index)}
                     </motion.div>
                   ))}
@@ -358,7 +358,7 @@ const ActivityFeed = React.forwardRef<HTMLDivElement, ActivityFeedProps>(
             {/* Timeline line */}
             <div className="absolute bottom-0 left-[3px] top-0 w-px bg-surface-border" />
             {visibleItems.map((item, index) => (
-              <motion.div key={item.id} initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ ...tweens.fade, delay: index * 0.03 }}>
+              <motion.div key={item.id} initial={false} animate={{ opacity: 1 }} transition={{ ...tweens.fade, delay: index * 0.03 }}>
                 {resolveEntry(item, index)}
               </motion.div>
             ))}

--- a/packages/core/src/composed/avatar-group.tsx
+++ b/packages/core/src/composed/avatar-group.tsx
@@ -144,7 +144,7 @@ const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
     }
 
     const spotlightClasses =
-      'transition-[transform,opacity] duration-300 ease-out hover:z-50 hover:scale-105 group-hover:[&:not(:hover)]:opacity-85'
+      'transition-opacity duration-300 ease-out hover:z-50 group-hover:[&:not(:hover)]:opacity-85'
 
     return (
       <TooltipProvider>
@@ -258,7 +258,7 @@ const AvatarGroup = React.forwardRef<HTMLDivElement, AvatarGroupProps>(
                       borderClass,
                       overlapClass,
                       `flex cursor-pointer items-center justify-center bg-accent-2 font-semibold text-accent-11 ${textSizeClass}`,
-                      'hover:scale-105 hover:bg-accent-3 transition-[transform,background-color] duration-300 ease-out',
+                      'hover:bg-accent-3 transition-colors duration-300 ease-out',
                     )}
                     style={{ zIndex: 0, transform: getExpandTransform(displayed.length) }}
                   >

--- a/packages/core/src/composed/empty-state.tsx
+++ b/packages/core/src/composed/empty-state.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { motion, useReducedMotion } from 'framer-motion'
+import { motion } from 'framer-motion'
 import * as React from 'react'
 
 import { IconProvider, type IconSize } from '../ui/icon-context'
@@ -52,7 +52,6 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
     },
     ref,
   ) => {
-    const reducedMotion = useReducedMotion()
     const resolvedIconSize = iconSize ?? (compact ? 'sm' : 'md')
     const iconSizeClass = {
       sm: 'h-ico-sm w-ico-sm',
@@ -75,20 +74,18 @@ const EmptyState = React.forwardRef<HTMLDivElement, EmptyStateProps>(
         )}
         {...props}
       >
-        <motion.div
+        <div
           className={cn(
-            'flex items-center justify-center rounded-overlay-lg bg-surface-raised text-surface-fg-subtle',
+            'flex items-center justify-center text-surface-fg-subtle',
             compact ? 'h-ds-md w-ds-md' : 'h-ds-lg w-ds-lg',
           )}
-          animate={reducedMotion ? {} : { y: [0, -4, 0] }}
-          transition={reducedMotion ? {} : { repeat: Infinity, duration: 3, ease: 'easeInOut' }}
         >
           <IconProvider size={iconToken}>{resolvedIcon}</IconProvider>
-        </motion.div>
+        </div>
 
         <motion.div
           className="flex max-w-[280px] flex-col gap-ds-02"
-          initial={{ opacity: 0 }}
+          initial={false}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.2, ...tweens.fade }}
         >

--- a/packages/core/src/composed/schedule-view.tsx
+++ b/packages/core/src/composed/schedule-view.tsx
@@ -236,7 +236,7 @@ function DayColumn({
               className={cn(
                 'absolute left-ds-01 right-ds-01 rounded-control-inner px-ds-02 py-ds-01',
                 'text-left text-ds-xs font-medium overflow-hidden cursor-pointer',
-                'hover:shadow-raised hover:scale-[1.02] transition-[box-shadow,transform] duration-fast-02 ease-productive-standard',
+                'hover:shadow-raised transition-[box-shadow] duration-fast-02 ease-productive-standard',
                 'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9',
                 colorClass,
               )}

--- a/packages/core/src/shell/bottom-navbar.tsx
+++ b/packages/core/src/shell/bottom-navbar.tsx
@@ -90,7 +90,7 @@ function BottomNavLink({
   const Link = useLink()
   const prefersReducedMotion = useReducedMotion()
   return (
-    <motion.div whileTap={prefersReducedMotion ? undefined : { y: -2 }} transition={prefersReducedMotion ? { duration: 0 } : springs.snappy} className="flex max-w-[70px] flex-1">
+    <motion.div whileTap={prefersReducedMotion ? undefined : { scale: 0.96 }} transition={prefersReducedMotion ? { duration: 0 } : springs.snappy} className="flex max-w-[70px] flex-1">
       <Link
         href={item.href}
         onClick={onClick}

--- a/packages/core/src/ui/avatar.tsx
+++ b/packages/core/src/ui/avatar.tsx
@@ -2,7 +2,7 @@
 
 import * as AvatarPrimitive from "@primitives/react-avatar"
 import { cva, type VariantProps } from "class-variance-authority"
-import { motion, useReducedMotion } from "framer-motion"
+import { motion } from "framer-motion"
 import * as React from "react"
 
 import { Dot, type DotColor, type DotSize } from "./dot"
@@ -174,8 +174,6 @@ const Avatar = React.forwardRef<
   AvatarProps
 >(({ className, size, shape, status, ring, badge, loading, children, ...props }, ref) => {
   const resolvedShape = shape ?? 'circle'
-  // MotionConfig can't stop this opacity loop (non-transform), so guard it locally.
-  const prefersReduced = useReducedMotion()
 
   // Build ring classes for the outer wrapper
   const ringClasses = ring && ring !== 'none'
@@ -209,17 +207,14 @@ const Avatar = React.forwardRef<
         {children}
       </AvatarPrimitive.Root>
       {status && (
-        <motion.span
+        <span
           className="absolute bottom-0 right-0"
           role="img"
           aria-label={statusLabelMap[status]}
-          {...(status === 'online' && !prefersReduced
-            ? { animate: { opacity: [1, 0.75, 1] }, transition: { duration: 2.5, repeat: Infinity, ease: 'easeInOut' } }
-            : {})}
         >
-          {/* Shared Dot primitive: colour + contrast ring; wrapper owns position + presence breathe + a11y. */}
+          {/* Shared Dot primitive: colour + contrast ring; wrapper owns position + a11y. */}
           <Dot color={statusDotColor[status]} size={statusDotSize[size ?? 'md']} withBorder aria-hidden />
-        </motion.span>
+        </span>
       )}
       {showBadge && (
         badge === 'dot' ? (
@@ -258,7 +253,7 @@ const AvatarImage = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
   <motion.span
-    initial={{ opacity: 0, scale: 0.96 }}
+    initial={{ scale: 0.96 }}
     animate={{ opacity: 1, scale: 1 }}
     transition={springs.smooth}
     className="absolute inset-0 h-full w-full"

--- a/packages/core/src/ui/badge.tsx
+++ b/packages/core/src/ui/badge.tsx
@@ -125,6 +125,8 @@ interface BadgeProps
   startIcon?: IconInput
   endIcon?: IconInput
   dot?: boolean
+  /** Pulse the status dot (opt-in; static by default). @default false */
+  dotPulse?: boolean
   onDismiss?: () => void
   selected?: boolean
   disabled?: boolean
@@ -149,6 +151,7 @@ const Badge = React.forwardRef<HTMLElement, BadgeProps>(
       startIcon,
       endIcon,
       dot,
+      dotPulse,
       onDismiss,
       onClick,
       selected,
@@ -251,7 +254,7 @@ const Badge = React.forwardRef<HTMLElement, BadgeProps>(
               transition={springs.snappy}
               className="inline-flex shrink-0"
             >
-              <Dot color="current" size="sm" pulse />
+              <Dot color="current" size="sm" pulse={dotPulse} />
             </motion.span>
           )}
         </AnimatePresence>

--- a/packages/core/src/ui/button.tsx
+++ b/packages/core/src/ui/button.tsx
@@ -56,11 +56,11 @@ export const buttonVariants = cva(
       },
     },
     compoundVariants: [
-      // ============ SOLID ============ (colored hover shadows — shadow tints with the button's own hue)
-      { variant: 'solid', color: 'accent',  className: 'bg-accent-9 text-accent-fg hover:bg-accent-10 shadow-raised hover:shadow-brand' },
-      { variant: 'solid', color: 'error',   className: 'bg-error-9 text-error-fg hover:bg-error-10 shadow-raised hover:shadow-error' },
-      { variant: 'solid', color: 'success', className: 'bg-success-9 text-success-fg hover:bg-success-10 shadow-raised hover:shadow-success' },
-      { variant: 'solid', color: 'warning', className: 'bg-warning-9 text-warning-fg hover:bg-warning-10 shadow-raised hover:shadow-warning' },
+      // ============ SOLID ============ (tonal raised shadow; fill deepens on hover — no coloured bloom)
+      { variant: 'solid', color: 'accent',  className: 'bg-accent-9 text-accent-fg hover:bg-accent-10 shadow-raised' },
+      { variant: 'solid', color: 'error',   className: 'bg-error-9 text-error-fg hover:bg-error-10 shadow-raised' },
+      { variant: 'solid', color: 'success', className: 'bg-success-9 text-success-fg hover:bg-success-10 shadow-raised' },
+      { variant: 'solid', color: 'warning', className: 'bg-warning-9 text-warning-fg hover:bg-warning-10 shadow-raised' },
       { variant: 'solid', color: 'neutral', className: 'bg-neutral-5 text-surface-fg hover:bg-neutral-7 shadow-raised' },
 
       // ============ SOFT ============

--- a/packages/core/src/ui/chat/message.tsx
+++ b/packages/core/src/ui/chat/message.tsx
@@ -70,7 +70,7 @@ const MessageRoot = React.forwardRef<HTMLDivElement, MessageProps>(
       return (
         <motion.div
           ref={ref}
-          initial={{ opacity: 0, y: 8 }}
+          initial={{ y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={springs.snappy}
           className={cn(
@@ -91,7 +91,7 @@ const MessageRoot = React.forwardRef<HTMLDivElement, MessageProps>(
           <motion.div
             ref={ref}
             data-highlight={highlight}
-            initial={{ opacity: 0, y: 8 }}
+            initial={{ y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={springs.snappy}
             className={cn(
@@ -125,7 +125,7 @@ const MessageRoot = React.forwardRef<HTMLDivElement, MessageProps>(
         <motion.div
           ref={ref}
           data-highlight={highlight}
-          initial={{ opacity: 0, y: 8 }}
+          initial={{ y: 8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={springs.snappy}
           className={cn(

--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -380,7 +380,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
                   {option.label}
                   <button
                     type="button"
-                    className="inline-flex items-center justify-center rounded-pill outline-hidden hover:scale-110 hover:bg-surface-raised-hover transition-transform duration-fast-01 ease-productive-standard"
+                    className="inline-flex items-center justify-center rounded-pill outline-hidden hover:bg-surface-raised-hover transition-colors duration-fast-01 ease-productive-standard"
                     onClick={(e) => handleRemovePill(e, val)}
                     aria-label={`Remove ${option.label}`}
                     tabIndex={-1}

--- a/packages/core/src/ui/dot.tsx
+++ b/packages/core/src/ui/dot.tsx
@@ -55,17 +55,6 @@ const OFF: Record<DotColor, string> = {
   current: 'border-current/40 bg-current/10',
 }
 
-// Pulse ripple — the fill colour at low opacity.
-const PULSE: Record<DotColor, string> = {
-  accent: 'bg-accent-9/40',
-  success: 'bg-success-9/40',
-  warning: 'bg-warning-9/40',
-  error: 'bg-error-9/40',
-  info: 'bg-info-9/40',
-  neutral: 'bg-neutral-8/40',
-  current: 'bg-current/40',
-}
-
 const TEXT: Record<DotColor, string> = {
   accent: 'text-accent-11',
   success: 'text-success-11',
@@ -179,14 +168,12 @@ const Dot = React.forwardRef<HTMLSpanElement, DotProps>(
       >
         {labelPosition === 'start' && labelEl}
         <span className="relative inline-flex shrink-0">
-          {showPulse && (
-            <span
-              data-pulse=""
-              style={{ animationDuration: PULSE_SPEED[pulseSpeed] }}
-              className={cn('absolute inset-0 inline-flex rounded-pill animate-ping motion-reduce:animate-none', PULSE[color])}
-            />
-          )}
-          <span className={disc} />
+          {/* Contained opacity breathe on the disc itself — never an expanding halo/ring. */}
+          <span
+            data-pulse={showPulse ? '' : undefined}
+            style={showPulse ? { animationDuration: PULSE_SPEED[pulseSpeed] } : undefined}
+            className={cn(disc, showPulse && 'animate-pulse motion-reduce:animate-none')}
+          />
         </span>
         {labelPosition === 'end' && labelEl}
       </span>

--- a/packages/core/src/ui/slider.tsx
+++ b/packages/core/src/ui/slider.tsx
@@ -22,7 +22,7 @@ const sliderTrackVariants = cva(
 )
 
 const sliderThumbVariants = cva(
-  'touch-target block rounded-pill bg-surface-overlay shadow-raised transition-[color,transform,box-shadow] duration-fast-02 ease-productive-standard hover:scale-110 hover:shadow-raised-hover active:scale-[1.15] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-action-disabled',
+  'touch-target block rounded-pill bg-surface-overlay shadow-raised transition-[color,transform,box-shadow] duration-fast-02 ease-productive-standard hover:shadow-raised-hover active:scale-[1.15] focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-action-disabled',
   {
     variants: {
       size: {

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -98,6 +98,8 @@ export interface StatCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   size?: CardSize
   /** How the brand accent reads: `none` (neutral — default), `icon` (accent chip around `icon`), or `tint` (subtle accent surface wash + accent value). */
   accentStyle?: 'none' | 'icon' | 'tint'
+  /** Animate value/label in on mount (subtle settle; content stays visible either way, never opacity-gated). @default false */
+  reveal?: boolean
   /** When `accentStyle="icon"`: `soft` (tinted chip) or `solid` (filled accent chip). @default 'soft' */
   iconFill?: 'soft' | 'solid'
   /**
@@ -231,6 +233,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       variant = 'default',
       size = 'md',
       accentStyle = 'none',
+      reveal = false,
       iconFill = 'soft',
       flash,
       flashSpeed,
@@ -307,14 +310,17 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
       </motion.div>
     ) : null
 
+    // reveal=false → static (content-safe default). reveal=true → subtle settle; opacity NEVER gated.
+    const revealProps = reveal
+      ? { initial: { y: 8 }, animate: { y: 0 }, transition: springs.smooth }
+      : { initial: false as const }
+
     const cardContent = (
       <>
         <div className="flex items-center justify-between">
           <motion.p
             className="text-ds-md font-medium text-surface-fg-muted"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={tweens.fade}
+            {...revealProps}
           >
             {resolvedLabel}
           </motion.p>
@@ -333,9 +339,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
                       ? 'bg-accent-9 text-accent-fg'
                       : 'bg-accent-3 text-accent-11',
                   )}
-                  initial={{ opacity: 0, scale: 0.96 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={springs.snappy}
+                  {...revealProps}
                   aria-hidden="true"
                 >
                   <IconProvider size="md">{normalizeIcon(icon, 'md')}</IconProvider>
@@ -343,9 +347,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
               ) : (
                 <motion.span
                   className="text-surface-fg-muted"
-                  initial={{ opacity: 0, scale: 0.96 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={springs.snappy}
+                  {...revealProps}
                   aria-hidden="true"
                 >
                   <IconProvider size="lg">{normalizeIcon(icon, 'lg')}</IconProvider>
@@ -363,9 +365,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
                   size === 'sm' ? 'text-ds-2xl' : 'text-ds-3xl',
                   accentStyle === 'tint' ? 'text-accent-11' : 'text-surface-fg',
                 )}
-                initial={{ opacity: 0, y: '100%' }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={springs.smooth}
+                {...revealProps}
               >
                 {prefix && (
                   <span className={cn('text-surface-fg-muted', size === 'sm' ? 'text-ds-md' : 'text-ds-lg')}>{prefix}</span>
@@ -381,9 +381,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
           {secondaryLabel && (
             <motion.p
               className="text-ds-sm text-surface-fg-subtle"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ ...tweens.fade, delay: 0.1 }}
+              {...revealProps}
             >
               {secondaryLabel}
             </motion.p>
@@ -391,9 +389,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
         </div>
         {progress != null && (
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ ...tweens.fade, delay: 0.15 }}
+            {...revealProps}
           >
             <ProgressBar progress={progress} label={resolvedLabel} />
           </motion.div>
@@ -416,7 +412,7 @@ const StatCard = React.forwardRef<HTMLDivElement, StatCardProps>(
             <CardFooter className="text-ds-sm">
               <motion.div
                 className="w-full"
-                initial={{ opacity: 0 }}
+                initial={false}
                 animate={{ opacity: 1 }}
                 transition={{ ...tweens.fade, delay: 0.25 }}
               >


### PR DESCRIPTION
Adversarial audit of the entire design system (tokens + ~140 components) against the [pols.dev anti-slop law](https://pols.dev/slop.md), cross-checked against Devalok's Setu visual anti-patterns (they agree). 18 component files touched; net −46 lines.

## Two dominant fixes

**1. Invisible-content trap (reliability).** Several components started at `opacity: 0` and only appeared once a Framer entrance fired — a backgrounded tab, hydration stall, or throttled engine could render them blank. Worst: `StatCard`'s primary value inside `overflow-hidden`. Content is now visible by default.
- `StatCard`: new opt-in **`reveal`** prop (default `false` = static; `true` = a settle that never hides content).
- `EmptyState`, `ActivityFeed`, chat `Message`, AI `Conversation`/`BlockRenderer`/stat-row, `Avatar` image: entrance reveals no longer gate opacity (fades → static; slides keep the slide, drop the opacity gating).

**2. Colored glow blooms.** Removed accent/status hover halo on `Button` solids, `Dot`'s expanding `animate-ping` ring (now a contained breathe), `DevadootIcon`'s blurred-shape-copy glow, and `CommandBar`'s `blur(8px)` outer-glow copy. **Kept** gradient brand-mark fills (endorsed) and the CommandBar animated border.

## Also
- Hover-grow removed on Combobox clear, Slider thumb (kept active/grab scale), ScheduleView events, AvatarGroup; BottomNavbar tap → press-shrink.
- `EmptyState` icon de-tiled + infinite bob removed.

## Behavior change (patch)
`Badge` status dot no longer pulses by default. New **`dotPulse`** prop (default `false`) restores it.

## Deliberately not changed
Press-shrink feedback (legit), Tabler icon pack (solid foundation), Inter/Manrope default font token (fallback; real path = ship the Setu brand face later).

## Verification
`pnpm verify` green — typecheck, lint (0 errors), full test suite, build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)