### PR TITLE
fix(core): de-hoist block-scoped fns in vendored primitives (minify collision, #146)

### DIFF
--- a/.changeset/fix-minify-hoist-collision.md
+++ b/.changeset/fix-minify-hoist-collision.md
@@ -1,0 +1,11 @@
+---
+'@devalok/shilp-sutra': patch
+---
+
+Fix a runtime crash in consumer production builds caused by a minify-hoisting collision in the bundled Radix primitives (issue #146).
+
+The shipped `dist/_chunks/primitives.js` contained a **block-scoped function declaration** inside the `usePointerDownOutside` handler (vendored `react-dismissable-layer`). Our own minifier gave that function the same mangled identifier as the `isPointerInsideReactTreeRef` ref. Under block scoping this is fine, but when a consumer's build downlevels the chunk, Annex-B semantics hoist the block-level function declaration to a function-scoped `var`, shadowing the ref for the whole handler — so the guard read `!ref.current` resolves to the hoisted-undefined function and throws `TypeError: Cannot read properties of undefined (reading 'current')` from a `document` pointerdown listener. Symptom: outside-click dismiss stops closing overlays (Dialog/Sheet/DropdownMenu/Popover/Select/etc.), producing rage-clicks. Reproduced across esbuild and terser; consumers could not fix it from their own config.
+
+Fix: emit the affected handlers as non-hoisting `const` arrows instead of block-level function declarations, in `react-dismissable-layer` and — defensively, same hazard class — `react-focus-scope`. Arrows are never Annex-B hoisted, so no consumer downlevel can alias them to a ref. Verified: the pre-fix minified shape throws the exact `#146` error under sloppy/downlevel execution; the post-fix shape runs clean, and the rebuilt chunk gives the inner handler a distinct identifier after downlevel.
+
+No public API change.

--- a/packages/core/src/primitives/_internal/react-dismissable-layer.js
+++ b/packages/core/src/primitives/_internal/react-dismissable-layer.js
@@ -128,9 +128,13 @@ function usePointerDownOutside(onPointerDownOutside, ownerDocument = globalThis?
         const handlePointerDown = (event) => {
             if (event.target && !isPointerInsideReactTreeRef.current) {
                 const eventDetail = { originalEvent: event };
-                function handleAndDispatchPointerDownOutsideEvent() {
+                // const arrow (not a block-scoped function declaration): a fn declaration
+                // here gets hoisted to a function-scoped `var` when a consumer minifier
+                // downlevels this shipped chunk, letting it collide with the mangled name
+                // of `isPointerInsideReactTreeRef` and throw "reading 'current'" (issue #146).
+                const handleAndDispatchPointerDownOutsideEvent = () => {
                     handleAndDispatchCustomEvent(POINTER_DOWN_OUTSIDE, handlePointerDownOutside, eventDetail, { discrete: true });
-                }
+                };
                 if (event.pointerType === 'touch') {
                     ownerDocument.removeEventListener('click', handleClickRef.current);
                     handleClickRef.current = handleAndDispatchPointerDownOutsideEvent;

--- a/packages/core/src/primitives/_internal/react-dismissable-layer.tsx
+++ b/packages/core/src/primitives/_internal/react-dismissable-layer.tsx
@@ -189,14 +189,18 @@ function usePointerDownOutside(
       if (event.target && !isPointerInsideReactTreeRef.current) {
         const eventDetail = { originalEvent: event };
 
-        function handleAndDispatchPointerDownOutsideEvent() {
+        // const arrow (not a block-scoped function declaration): a fn declaration
+        // here gets hoisted to a function-scoped `var` when a consumer minifier
+        // downlevels this shipped chunk, letting it collide with the mangled name
+        // of `isPointerInsideReactTreeRef` and throw "reading 'current'" (issue #146).
+        const handleAndDispatchPointerDownOutsideEvent = () => {
           handleAndDispatchCustomEvent(
             POINTER_DOWN_OUTSIDE,
             handlePointerDownOutside,
             eventDetail,
             { discrete: true },
           );
-        }
+        };
 
         if (event.pointerType === 'touch') {
           ownerDocument.removeEventListener('click', handleClickRef.current);

--- a/packages/core/src/primitives/_internal/react-focus-scope.tsx
+++ b/packages/core/src/primitives/_internal/react-focus-scope.tsx
@@ -47,7 +47,11 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
 
   React.useEffect(() => {
     if (trapped) {
-      function handleFocusIn(event: FocusEvent) {
+      // const arrows (not block-scoped function declarations): a fn declaration inside
+      // this block gets hoisted to a function-scoped `var` when a consumer minifier
+      // downlevels this shipped chunk, which can collide with a mangled identifier and
+      // throw a "reading '…'" runtime error. See issue #146 (same class in dismissable-layer).
+      const handleFocusIn = (event: FocusEvent) => {
         if (focusScope.paused || !container) return;
         const target = event.target as HTMLElement | null;
         if (container.contains(target)) {
@@ -55,24 +59,24 @@ const FocusScope = React.forwardRef<FocusScopeElement, FocusScopeProps>((props, 
         } else {
           focus(lastFocusedElementRef.current, { select: true });
         }
-      }
+      };
 
-      function handleFocusOut(event: FocusEvent) {
+      const handleFocusOut = (event: FocusEvent) => {
         if (focusScope.paused || !container) return;
         const relatedTarget = event.relatedTarget as HTMLElement | null;
         if (relatedTarget === null) return;
         if (!container.contains(relatedTarget)) {
           focus(lastFocusedElementRef.current, { select: true });
         }
-      }
+      };
 
-      function handleMutations(mutations: MutationRecord[]) {
+      const handleMutations = (mutations: MutationRecord[]) => {
         const focusedElement = document.activeElement as HTMLElement | null;
         if (focusedElement !== document.body) return;
         for (const mutation of mutations) {
           if (mutation.removedNodes.length > 0) focus(container);
         }
-      }
+      };
 
       document.addEventListener('focusin', handleFocusIn);
       document.addEventListener('focusout', handleFocusOut);


### PR DESCRIPTION
## What & why

Fixes #146 — the single most frequent client error in a Vite consumer (Muhurat): **1,584 occurrences hitting ~63% of users**. Outside-click dismiss throws, so overlays don't close on tap-outside → rage-clicks.

`dist/_chunks/primitives.js` shipped a **block-scoped function declaration** inside `usePointerDownOutside` (vendored `react-dismissable-layer`). Our minifier gave it the same mangled name as the `isPointerInsideReactTreeRef` ref. Safe under block scoping — but when a consumer build **downlevels** the chunk, Annex-B semantics hoist the block-level function declaration to a function-scoped `var`, shadowing the ref for the whole handler. The guard `!ref.current` then reads the hoisted-undefined function → `TypeError: Cannot read properties of undefined (reading 'current')` from a `document` pointerdown listener. Reproduced across esbuild + terser; consumers can't fix it from their own config.

Same family as #140 (reserved-word minify) and 0.49.1 (`minifyInternalExports:false`).

## Fix

Emit the affected handlers as non-hoisting `const` arrows instead of block-level function declarations:
- `react-dismissable-layer` — the shipping `.js` + its shadowed `.tsx` (the actual #146 site)
- `react-focus-scope` — the three focus-trap handlers, **defensively** (same hazard class; not colliding today but latent)

Arrows are never Annex-B hoisted, so no consumer downlevel can alias them to a ref.

## Audit

Swept the whole repo for the hazard class (block-**nested** function declarations). Only these two sites qualify. Everything else (`react-context` factory, `react-slider`/`command-bar`/file-preview handlers, all `function Component(...)` defs) are function-body-top-level → already function-scoped → downlevel-safe. Left untouched.

## Verification

- A/B: pre-fix minified shape throws the **exact #146 error** under sloppy/downlevel execution; post-fix shape runs clean in both modes.
- Rebuilt chunk downleveled to es2015 → inner handler gets a **distinct** identifier from the ref.
- Typecheck clean · lint 0 errors · **2209/2209 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)