### PR TITLE
test: add unit tests for BadgeGroup and BadgeIndicator

### DIFF
--- a/packages/core/src/ui/__tests__/badge-group.test.tsx
+++ b/packages/core/src/ui/__tests__/badge-group.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { Badge } from '../badge'
+import { BadgeGroup } from '../badge-group'
+
+describe('BadgeGroup', () => {
+  it('renders all children when under max', () => {
+    render(
+      <BadgeGroup>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+  })
+
+  it('truncates to max and shows +N overflow badge', () => {
+    render(
+      <BadgeGroup max={2}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+        <Badge>C</Badge>
+      </BadgeGroup>,
+    )
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+    expect(screen.queryByText('C')).not.toBeInTheDocument()
+    expect(screen.getByText('+1')).toBeInTheDocument()
+  })
+
+  it('does not render overflow badge when exactly at max', () => {
+    render(
+      <BadgeGroup max={2}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+  })
+
+  it('does not render overflow badge when max is undefined', () => {
+    render(
+      <BadgeGroup>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+        <Badge>C</Badge>
+      </BadgeGroup>,
+    )
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument()
+  })
+
+  it('overflow badge has aria-label when onOverflowClick is provided', () => {
+    const fn = vi.fn()
+    render(
+      <BadgeGroup max={1} onOverflowClick={fn}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    expect(screen.getByLabelText('Show 1 more')).toBeInTheDocument()
+  })
+
+  it('calls onOverflowClick when overflow badge is clicked', async () => {
+    const user = userEvent.setup()
+    const fn = vi.fn()
+    render(
+      <BadgeGroup max={1} onOverflowClick={fn}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    await user.click(screen.getByText('+1'))
+    expect(fn).toHaveBeenCalledOnce()
+  })
+
+  it('overflow badge has no aria-label when onOverflowClick is absent', () => {
+    render(
+      <BadgeGroup max={1}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    const overflow = screen.getByText('+1')
+    expect(overflow).not.toHaveAttribute('aria-label')
+  })
+
+  it('passes axe audit with overflow and click handler', async () => {
+    const { container } = render(
+      <BadgeGroup max={1} onOverflowClick={vi.fn()}>
+        <Badge>A</Badge>
+        <Badge>B</Badge>
+      </BadgeGroup>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/ui/__tests__/badge-indicator.test.tsx
+++ b/packages/core/src/ui/__tests__/badge-indicator.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { BadgeIndicator } from '../badge-indicator'
+
+describe('BadgeIndicator', () => {
+  it('renders children', () => {
+    render(
+      <BadgeIndicator>
+        <span>icon</span>
+      </BadgeIndicator>,
+    )
+    expect(screen.getByText('icon')).toBeInTheDocument()
+  })
+
+  it('shows count', () => {
+    render(
+      <BadgeIndicator count={5}>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('clamps count above max to "{max}+"', () => {
+    render(
+      <BadgeIndicator count={150} max={99}>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(screen.getByText('99+')).toBeInTheDocument()
+  })
+
+  it('uses default max of 99 when max is not provided', () => {
+    render(
+      <BadgeIndicator count={120}>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(screen.getByText('99+')).toBeInTheDocument()
+  })
+
+  it('does not render indicator when count is 0 and showZero is false', () => {
+    const { container } = render(
+      <BadgeIndicator count={0}>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(container.querySelector('.absolute')).not.toBeInTheDocument()
+  })
+
+  it('shows "0" when showZero is true', () => {
+    render(
+      <BadgeIndicator count={0} showZero>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('renders dot with no count text', () => {
+    render(
+      <BadgeIndicator dot>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(screen.queryByText(/\d/)).not.toBeInTheDocument()
+  })
+
+  it('invisible prop hides the indicator even with a count', () => {
+    const { container } = render(
+      <BadgeIndicator count={5} invisible>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(container.querySelector('.absolute')).not.toBeInTheDocument()
+  })
+
+  it('does not render indicator when count is undefined and dot is false', () => {
+    const { container } = render(
+      <BadgeIndicator>
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(container.querySelector('.absolute')).not.toBeInTheDocument()
+  })
+
+  it('applies placement classes', () => {
+    const { container } = render(
+      <BadgeIndicator count={1} placement="bottom-left">
+        <span />
+      </BadgeIndicator>,
+    )
+    expect(container.querySelector('.absolute')).toHaveClass('-bottom-1', '-left-1')
+  })
+
+  it('passes axe audit when visible', async () => {
+    const { container } = render(
+      <BadgeIndicator count={3}>
+        <span>icon</span>
+      </BadgeIndicator>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary
Adds missing unit tests for `BadgeGroup` and `BadgeIndicator`. Both shipped with non-trivial conditional logic (overflow truncation, count clamping, visibility rules) that was previously only verified visually via Storybook.

## Linked issues
Refs #151

(Not using "Closes" — #151 also claimed Breadcrumb and ProcessingOverlay lacked tests; see note below. This PR only resolves the part of the issue that was accurate.)

## Checklist
### Always
- [x] `pnpm typecheck && pnpm lint && pnpm test` clean locally
- [ ] Changeset added — N/A, test-only change, no publishable code change
- [ ] Storybook stories updated — N/A, no visual/behavior change
- [ ] `pre-publish-audit.mjs` clean — N/A, no package output changed

### If this PR fixes agent-filed feedback
N/A — not labeled `ai-agent-feedback`

### If this PR introduces a breaking change
N/A — no breaking change

### If this PR adds a new component
N/A — no new component; both components already existed

## Notes for the reviewer
Issue #151 claimed 4 components lacked test coverage. On inspection, `Breadcrumb` and `ProcessingOverlay` already have full coverage (including `vitest-axe` checks) in `__tests__/breadcrumb.test.tsx` and `__tests__/button-processing.test.tsx`. This PR only adds tests for the two components genuinely untested: `BadgeGroup` and `BadgeIndicator`.

New test files follow the existing `__tests__/` folder convention and include `vitest-axe` accessibility assertions, matching the pattern in the existing test files.