### PR TITLE
fix(analytics): audit follow-ups across site + MCP server

### DIFF
--- a/apps/site/components/code-block.tsx
+++ b/apps/site/components/code-block.tsx
@@ -3,14 +3,28 @@
 import { useState } from 'react'
 import { IconCheck, IconCopy } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
+import { track } from '@/lib/analytics'
 
-export function CodeBlock({ code, language = 'bash' }: { code: string; language?: string }) {
+export function CodeBlock({
+  code,
+  language = 'bash',
+  copyContext = 'snippet',
+  copyMeta,
+}: {
+  code: string
+  language?: string
+  /** What this block represents, sent as the `code_copied` event context (e.g. 'install'). */
+  copyContext?: string
+  /** Extra low-cardinality props merged into the `code_copied` event (e.g. { manager }). */
+  copyMeta?: Record<string, string>
+}) {
   const [copied, setCopied] = useState(false)
 
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(code)
       setCopied(true)
+      track('code_copied', { context: copyContext, language, ...copyMeta })
       setTimeout(() => setCopied(false), 1800)
     } catch {
       // ignore — older browsers without clipboard permission

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -4,6 +4,7 @@ import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Text } from '@devalok/shilp-sutra/ui/text'
 
 import { AuroraBloom } from '@devalok/shilp-sutra-brand/aurora'
+import { TrackedLink } from './tracked-link'
 
 export function Hero() {
   return (
@@ -34,14 +35,24 @@ export function Hero() {
           everywhere.
         </Text>
         <div className="w-full max-w-sm sm:max-w-none sm:w-auto flex flex-col sm:flex-row gap-ds-03 mt-ds-03">
-          <Link href="/theming" className="w-full sm:w-auto">
+          <TrackedLink
+            href="/theming"
+            className="w-full sm:w-auto"
+            event="cta_click"
+            eventProps={{ cta: 'try-it-on', location: 'hero' }}
+          >
             <Button size="lg" className="w-full sm:w-auto">Try it on</Button>
-          </Link>
-          <Link href="/components" className="w-full sm:w-auto">
+          </TrackedLink>
+          <TrackedLink
+            href="/components"
+            className="w-full sm:w-auto"
+            event="cta_click"
+            eventProps={{ cta: 'see-components', location: 'hero' }}
+          >
             <Button variant="soft" size="lg" className="w-full sm:w-auto" endIcon={<IconArrowRight size={18} />}>
               See what&apos;s inside
             </Button>
-          </Link>
+          </TrackedLink>
         </div>
         {/* Trust chips. Below sm: 2-col grid so chips align cleanly; sm+: inline wrap with dots.
             Three capability-led chips per docs/copy/shilp-sutra-copy-context.md §10. */}

--- a/apps/site/components/install-tabs.tsx
+++ b/apps/site/components/install-tabs.tsx
@@ -49,7 +49,7 @@ export function InstallTabs() {
           )
         })}
       </div>
-      <CodeBlock code={installCommands[active]} language="bash" />
+      <CodeBlock code={installCommands[active]} language="bash" copyContext="install" copyMeta={{ manager: active }} />
     </div>
   )
 }

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -6,6 +6,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { IconBrandGithub, IconMenu2, IconX } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { SHILP_SUTRA_MINOR } from '@/lib/version'
+import { track } from '@/lib/analytics'
 import { BrandSwitcher } from './brand-switcher'
 import { ThemeToggle } from './theme-toggle'
 
@@ -184,6 +185,7 @@ export function SiteHeader() {
               target="_blank"
               rel="noreferrer"
               aria-label="View on GitHub"
+              onClick={() => track('cta_click', { cta: 'github', location: 'header' })}
             >
               <Button variant="ghost" size="icon-md" aria-label="GitHub">
                 <IconBrandGithub size={18} />

--- a/apps/site/components/tracked-link.tsx
+++ b/apps/site/components/tracked-link.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import type { ComponentProps } from 'react'
+import { track } from '@/lib/analytics'
+
+type TrackedLinkProps = LinkProps &
+  Omit<ComponentProps<'a'>, keyof LinkProps> & {
+    /** Event name fired on click (e.g. 'cta_click'). */
+    event: string
+    /** Event props (e.g. { cta: 'try-it-on', location: 'hero' }). */
+    eventProps?: Record<string, unknown>
+  }
+
+/**
+ * `next/link` that fires a named analytics event on click before navigating.
+ * A thin client wrapper so server components (e.g. Hero) can instrument their
+ * CTAs without going client themselves.
+ */
+export function TrackedLink({ event, eventProps, onClick, ...props }: TrackedLinkProps) {
+  return (
+    <Link
+      {...props}
+      onClick={(e) => {
+        track(event, eventProps)
+        onClick?.(e)
+      }}
+    />
+  )
+}

--- a/apps/site/lib/analytics.ts
+++ b/apps/site/lib/analytics.ts
@@ -1,0 +1,18 @@
+import posthog from 'posthog-js'
+
+/**
+ * Fire a named product-analytics event.
+ *
+ * No-op when PostHog isn't loaded — during SSR, or in any environment where
+ * `NEXT_PUBLIC_POSTHOG_KEY` is unset (the provider never calls `init`, so
+ * `__loaded` stays false). Call sites never need to guard themselves.
+ *
+ * These are the site's *named* conversion events. Pageviews/pageleaves come
+ * from the provider; incidental clicks come from autocapture. Use `track` only
+ * for funnel-meaningful actions (install-command copy, primary CTAs, outbound).
+ */
+export function track(event: string, props?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return
+  if (!posthog.__loaded) return
+  posthog.capture(event, props)
+}

--- a/packages/mcp-server/src/analytics.mjs
+++ b/packages/mcp-server/src/analytics.mjs
@@ -13,20 +13,28 @@
  *
  * Env:
  *   POSTHOG_API_KEY   PostHog project API key (enables analytics)
- *   POSTHOG_HOST      ingestion host (default https://us.i.posthog.com)
+ *   POSTHOG_HOST      ingestion host (default https://eu.i.posthog.com)
  *   POSTHOG_IP_SALT   salt for the distinct_id hash (default: a constant)
  */
 
 import { createHash } from 'node:crypto'
 
 const API_KEY = process.env.POSTHOG_API_KEY
-const HOST = process.env.POSTHOG_HOST || 'https://us.i.posthog.com'
+const HOST = process.env.POSTHOG_HOST || 'https://eu.i.posthog.com'
 const SALT = process.env.POSTHOG_IP_SALT || 'shilp-sutra-mcp'
 
 export const configured = Boolean(API_KEY)
 
 let client = null
 if (configured) {
+  if (!process.env.POSTHOG_IP_SALT) {
+    // The default salt is public (it ships in this source file), so distinct_ids
+    // built from it are reversible to raw IPs by anyone with event access. Warn
+    // loudly so a real salt gets set in any environment that actually ingests.
+    console.warn(
+      '[analytics] POSTHOG_IP_SALT is unset — using the public default salt; IP-derived distinct_ids are reversible. Set POSTHOG_IP_SALT to a secret.'
+    )
+  }
   const { PostHog } = await import('posthog-node')
   // flushAt low + short interval: this is a long-running server with sparse,
   // bursty traffic — we'd rather ship events promptly than hold a big batch.

--- a/packages/mcp-server/src/index.mjs
+++ b/packages/mcp-server/src/index.mjs
@@ -100,13 +100,21 @@ function toolProps(name, args = {}) {
 function instrument(ctx, name, fn) {
   return async (args) => {
     let isError = false
+    const startedAt = Date.now()
     try {
       return text(await fn(args))
     } catch (e) {
       isError = true
       return errorText(e)
     } finally {
-      analytics.capture(analytics.anonId(ctx.ip), 'mcp_tool_call', { ...toolProps(name, args), isError })
+      // duration_ms doubles as a cache-behaviour signal: a cold version (cache
+      // miss → tarball fetch/extract) shows up as a high duration vs a warm hit.
+      const durationMs = Date.now() - startedAt
+      analytics.capture(analytics.anonId(ctx.ip), 'mcp_tool_call', {
+        ...toolProps(name, args),
+        isError,
+        duration_ms: durationMs,
+      })
     }
   }
 }


### PR DESCRIPTION
Follow-ups from the analytics audit (site / MCP / components). Both touched services are **private (unpublished)** → no changeset, no release.

## MCP server (`packages/mcp-server`)
- **Region default footgun** — `POSTHOG_HOST` defaulted to `us.i.posthog.com` while the project + key are **EU**. Env currently overrides to EU so it works today, but dropping the var would ship EU-project events to US and get them silently rejected. Default is now `eu.i.posthog.com`.
- **Weak-salt guard** — the IP pseudonymization salt defaults to a value that ships in this source file → IP-derived `distinct_id`s are reversible. Added a loud startup `console.warn` when analytics is configured but `POSTHOG_IP_SALT` is unset. (Setting the real salt is a Railway infra change — see below.)
- **Observability** — `mcp_tool_call` now carries `duration_ms`; a cache miss (cold tarball fetch) reads as high duration, so this doubles as a cache signal without invasive registry counters.

## Site (`apps/site`)
Named conversion events so the install funnel stops depending entirely on fragile autocapture:
- `lib/analytics.ts` — guarded `track()` helper (no-op during SSR / when the PostHog key is unset).
- `code_copied { context, language, ...meta }` from `CodeBlock`; `InstallTabs` tags `context="install"` + the package manager.
- `cta_click { cta, location }` on the two hero CTAs (via a tiny client `TrackedLink` so `Hero` stays a server component) and the header GitHub outbound link.

## Components (`packages/core`)
Ships **zero** telemetry — confirmed correct for a UI library. No change.

## Not in this PR (needs your hand)
Setting `POSTHOG_IP_SALT` on the `shilp-sutra-mcp` Railway service — the infra write was blocked by the auto-mode classifier. Command in the session.

## Verification
- MCP smoke: 20/20 pass
- Site: typecheck + lint + `next build` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)