### PR TITLE
feat(site): homepage wedge + stack sections, copy fixes, trim nav

### DIFF
--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -8,21 +8,27 @@ import { FeatureGrid } from '@/components/feature-grid'
 import { Hero } from '@/components/hero'
 import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
+import { StackSupport } from '@/components/stack-support'
 import { UnifiedCanvas } from '@/components/unified-canvas'
+import { WhyNotShadcn } from '@/components/why-not-shadcn'
 
 /**
  * Landing flow. Beta banner + built-with strip + Devalok block added per
- * docs/copy/shilp-sutra-copy-context.md §6 + §7 + §5.
+ * docs/copy/shilp-sutra-copy-context.md §6 + §7 + §5. Wedge row + stack strip
+ * added right under the hero per §2 — answer "why this, not shadcn?" and
+ * "does this fit my stack?" before the reader scrolls.
  *
  *   0. BetaBanner       — public-beta strip, dismissable, homepage only
  *   1. Hero              — what we are
- *   2. UnifiedCanvas     — six industries in one tabbed canvas, all live
- *   3. ButtonShowcase    — one component, ten worlds (close-up craft)
- *   4. BuiltWith         — Devalok's own products carrying shilp-sutra
- *   5. ComponentShowcase — curated grid of components in context
- *   6. FeatureGrid       — three pillars + builder promise
- *   7. AgentCallout      — teaser; full pitch at /agents
- *   8. DevalokBlock      — who's behind this, with a quiet link to devalok.in
+ *   2. WhyNotShadcn      — the wedge in one 10-second scan (§2)
+ *   3. StackSupport      — framework strip; kills the "my stack?" doubt (§6)
+ *   4. UnifiedCanvas     — six industries in one tabbed canvas, all live
+ *   5. ButtonShowcase    — one component, ten worlds (close-up craft)
+ *   6. BuiltWith         — Devalok's own products carrying shilp-sutra
+ *   7. ComponentShowcase — curated grid of components in context
+ *   8. FeatureGrid       — three pillars + builder promise
+ *   9. AgentCallout      — teaser; full pitch at /agents
+ *  10. DevalokBlock      — who's behind this, with a quiet link to devalok.in
  */
 export default function HomePage() {
   return (
@@ -31,6 +37,8 @@ export default function HomePage() {
       <SiteHeader />
       <main id="main" className="flex-1">
         <Hero />
+        <WhyNotShadcn />
+        <StackSupport />
         <UnifiedCanvas />
         <ButtonShowcase />
         <BuiltWith />

--- a/apps/site/components/component-showcase.tsx
+++ b/apps/site/components/component-showcase.tsx
@@ -22,7 +22,7 @@ import { Toaster } from '@devalok/shilp-sutra/ui/toaster'
 import { CommandPalette } from '@devalok/shilp-sutra/composed/command-palette'
 
 /**
- * "Same care, every component" — five hand-picked components on the
+ * "Same care, every component" — four hand-picked components on the
  * landing, each in a real-use-case demo. Picked first-principles, not
  * by alphabet: every demo answers a specific "what does this component
  * unlock for a real product" question.
@@ -31,7 +31,6 @@ import { CommandPalette } from '@devalok/shilp-sutra/composed/command-palette'
  * - Combobox: search-as-the-interface
  * - Toast: how the system answers back
  * - Chart: numbers that move
- * - Avatar stack: identity in dense lists
  */
 export function ComponentShowcase() {
   return (
@@ -46,7 +45,7 @@ export function ComponentShowcase() {
           Same care, every component.
         </Text>
         <Text variant="body-md" className="text-surface-fg-muted">
-          Five favourites from the 118 others. Each one picked because it changes the shape of
+          Four favourites from the 118 others. Each one picked because it changes the shape of
           what a real product can do, not because it ticks a box.
         </Text>
       </header>

--- a/apps/site/components/feature-grid.tsx
+++ b/apps/site/components/feature-grid.tsx
@@ -1,16 +1,22 @@
 import { IconLayoutGrid, IconPalette, IconShield, IconUsers } from '@tabler/icons-react'
 import { Text } from '@devalok/shilp-sutra/ui/text'
+import { CARD_RESTING } from '@/lib/card-recipe'
 
 /**
- * Three pillars + one builder card. Per docs/copy/shilp-sutra-copy-context.md §3.
- *  1. Be yourself — customisability is the headline
- *  2. Thought through — craft shown, not claimed
- *  3. Real-scale — full pages, not toys
- *  4. For builders, by builders — audience promise
+ * Three pillars + one builder promise. Per docs/copy/shilp-sutra-copy-context.md §3 + §14.
+ *
+ * Pillars (§3) — the three the doc names, and only these three:
+ *   1. Be yourself      — customisability is the headline
+ *   2. Thought through  — craft shown, not claimed
+ *   3. Real-scale       — full pages, not toys
+ *
+ * Promise (§4) — "For builders, by builders" is the audience line, NOT a
+ * pillar. It renders as a distinct card below the pillar row so the
+ * "Three pillars. One promise." heading counts true.
  *
  * Agent angle lives in <AgentCallout /> below this section, not here.
  */
-const features = [
+const pillars = [
   {
     icon: IconPalette,
     title: 'Your brand. Live.',
@@ -26,12 +32,13 @@ const features = [
     title: 'Real pages, not toys.',
     body: 'Dashboards. Settings. Pricing. Sign-up. Data tables. Five full blocks ship today, more this beta. Real spacing, real copy, real states. The stuff your users actually use.',
   },
-  {
-    icon: IconUsers,
-    title: 'For builders, by builders.',
-    body: 'Indie devs, studio teams, designers reaching for code, coding agents. One library, one install. Devalok ships on it; so do Karm, Devalok Hiring, BharatTools, and Gurukul.',
-  },
 ] as const
+
+const promise = {
+  icon: IconUsers,
+  title: 'For builders, by builders.',
+  body: 'Indie devs, studio teams, designers reaching for code, coding agents. One library, one install. Devalok ships on it; so do Karm, Devalok Hiring, BharatTools, and Gurukul.',
+} as const
 
 export function FeatureGrid() {
   return (
@@ -45,8 +52,10 @@ export function FeatureGrid() {
             Three pillars. One promise.
           </Text>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-x-ds-08 gap-y-ds-07">
-          {features.map((f) => (
+
+        {/* The three pillars — one clean row on desktop. */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-x-ds-08 gap-y-ds-07">
+          {pillars.map((f) => (
             <div key={f.title} className="flex flex-col gap-ds-02">
               <div className="flex items-center gap-ds-02">
                 <f.icon size={18} className="text-accent-11 shrink-0" />
@@ -55,6 +64,15 @@ export function FeatureGrid() {
               <p className="text-ds-sm text-surface-fg-subtle">{f.body}</p>
             </div>
           ))}
+        </div>
+
+        {/* The one promise — set apart from the pillars as its own card. */}
+        <div className={`${CARD_RESTING} flex flex-col gap-ds-03 sm:flex-row sm:items-center sm:gap-ds-06`}>
+          <div className="flex items-center gap-ds-02 sm:w-64 sm:shrink-0">
+            <promise.icon size={18} className="text-accent-11 shrink-0" />
+            <h3 className="text-ds-md text-surface-fg font-semibold">{promise.title}</h3>
+          </div>
+          <p className="text-ds-sm text-surface-fg-subtle sm:flex-1">{promise.body}</p>
         </div>
       </div>
     </section>

--- a/apps/site/components/framework-logos.tsx
+++ b/apps/site/components/framework-logos.tsx
@@ -1,0 +1,86 @@
+/**
+ * Monochrome framework marks for the "works with your stack" strip.
+ *
+ * These are simplified single-colour silhouettes drawn in `currentColor`, so
+ * they inherit the surrounding text colour and adapt to light/dark and to any
+ * brand accent — no per-logo colour to clash with the recolour story. They are
+ * evocative, not pixel-accurate trademarks; the name label beneath each does
+ * the identifying work. Swap in official SVGs later if we want exact marks.
+ *
+ * Size via className (e.g. `h-7 w-7`); colour via the parent's text colour.
+ */
+
+type LogoProps = { className?: string }
+
+export function NextjsMark({ className }: LogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10.25" />
+      <path d="M8.5 16.5V8l7 9.5" />
+      <path d="M15.5 8v4.5" />
+    </svg>
+  )
+}
+
+export function ViteMark({ className }: LogoProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M13.2 2 4.4 12.6h6.1l-1.1 9.4 9.9-13.2H13z" />
+    </svg>
+  )
+}
+
+export function AstroMark({ className }: LogoProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 2 6.8 20.3l5.2-3 5.2 3z" />
+      <path d="M9.4 18.8a3.6 3.6 0 0 0 5.2 0 3.6 3.6 0 0 1-5.2 0z" opacity="0.6" />
+    </svg>
+  )
+}
+
+export function RemixMark({ className }: LogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="5" />
+      <path d="M9 17V7.5h4.2a2.4 2.4 0 0 1 0 4.8H9m4.2 0 3.2 4.7" />
+    </svg>
+  )
+}
+
+export function TanStackMark({ className }: LogoProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M3 8.2 12 4l9 4.2-9 4.2z" />
+      <path d="M3 12.2 12 16.4l9-4.2" />
+      <path d="M3 16.2 12 20.4l9-4.2" />
+    </svg>
+  )
+}

--- a/apps/site/components/site-header.tsx
+++ b/apps/site/components/site-header.tsx
@@ -16,7 +16,6 @@ const navLinks = [
   { href: '/blocks', label: 'Blocks' },
   { href: '/theming', label: 'Theming' },
   { href: '/docs', label: 'Docs' },
-  { href: '/figma-make', label: 'Figma Make' },
   { href: '/agents', label: 'For AI editors', accent: true },
 ] as const
 

--- a/apps/site/components/stack-support.tsx
+++ b/apps/site/components/stack-support.tsx
@@ -1,0 +1,65 @@
+import { Text } from '@devalok/shilp-sutra/ui/text'
+import { TrackedLink } from './tracked-link'
+import {
+  AstroMark,
+  NextjsMark,
+  RemixMark,
+  TanStackMark,
+  ViteMark,
+} from './framework-logos'
+
+/**
+ * "Does this work with my stack?" — a logo strip under the wedge row, to kill
+ * the silent doubt before the reader scrolls on. Frameworks + doc slugs mirror
+ * the install-section list. Install path is stable on Next + Vite; Astro,
+ * Remix, and TanStack each ship a tested setup guide (copy-context §6).
+ *
+ * Server component; framework links are instrumented via TrackedLink (which is
+ * itself the client boundary, so this section stays server-rendered).
+ */
+const frameworks = [
+  { name: 'Next.js', slug: 'install-next-app-router', Mark: NextjsMark },
+  { name: 'Vite', slug: 'install-vite', Mark: ViteMark },
+  { name: 'Astro', slug: 'install-astro', Mark: AstroMark },
+  { name: 'Remix', slug: 'install-remix', Mark: RemixMark },
+  { name: 'TanStack', slug: 'install-tanstack-start', Mark: TanStackMark },
+] as const
+
+export function StackSupport() {
+  return (
+    <section className="mx-auto max-w-6xl px-page-x py-ds-12">
+      <div className="flex flex-col gap-ds-08">
+        <div className="flex flex-col gap-ds-03 max-w-3xl">
+          <Text variant="label-md" className="text-surface-fg-subtle">
+            Works with your stack
+          </Text>
+          <Text variant="heading-xl" className="text-surface-fg">
+            Fits the stack you already run.
+          </Text>
+          <Text variant="body-md" className="text-surface-fg-muted">
+            One install, one CSS import — then you&apos;re building. Each framework has a short
+            setup guide, tested on a real project.
+          </Text>
+        </div>
+
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-ds-04">
+          {frameworks.map((fw) => (
+            <li key={fw.slug}>
+              <TrackedLink
+                href={`/docs/${fw.slug}`}
+                event="framework_click"
+                eventProps={{ framework: fw.name, location: 'stack-support' }}
+                className="group flex flex-col items-center justify-center gap-ds-03 rounded-ds-lg border border-surface-border-subtle bg-surface-raised px-ds-04 py-ds-06 text-surface-fg-muted transition-[color,border-color,box-shadow] duration-fast-02 ease-productive-standard hover:border-surface-border-strong hover:text-surface-fg hover:shadow-raised focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-base"
+              >
+                <fw.Mark className="h-7 w-7" />
+                <Text variant="body-sm" className="text-current">
+                  {fw.name}
+                </Text>
+              </TrackedLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/site/components/why-not-shadcn.tsx
+++ b/apps/site/components/why-not-shadcn.tsx
@@ -1,0 +1,59 @@
+import { Text } from '@devalok/shilp-sutra/ui/text'
+
+/**
+ * "Why this, not shadcn" — the wedge, in one 10-second scan, sitting right
+ * under the hero. Content is the wedge from
+ * docs/copy/shilp-sutra-copy-context.md §2: shadcn ships you its look; this
+ * recolours to yours. Three concrete differentiators, no marketing verbs.
+ *
+ * Server component — no interactivity.
+ */
+const differences = [
+  {
+    index: '01',
+    title: 'One colour in, everything out.',
+    body: 'Set a single hue. Every component recolours across light, dark, hover, pressed, and focus. No theme provider, no re-render — CSS-vars carry it.',
+  },
+  {
+    index: '02',
+    title: 'OKLCH ramps, generated.',
+    body: 'Ramps build themselves from that one hue, perceptually even. A step-9 pink weighs the same as a step-9 indigo. No spreadsheet of hex codes.',
+  },
+  {
+    index: '03',
+    title: 'Surfaces that survive it.',
+    body: 'Semantic surface layers, checked by a CI audit on every PR. Cards never sit on the page background; dialogs never collide with cards.',
+  },
+] as const
+
+export function WhyNotShadcn() {
+  return (
+    <section className="mx-auto max-w-6xl px-page-x py-ds-12">
+      <div className="flex flex-col gap-ds-08">
+        <div className="flex flex-col gap-ds-03 max-w-3xl">
+          <Text variant="label-md" className="text-surface-fg-subtle">
+            Why this, not shadcn
+          </Text>
+          <Text variant="heading-xl" className="text-surface-fg">
+            shadcn looks like shadcn. This looks like you.
+          </Text>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-x-ds-08 gap-y-ds-07">
+          {differences.map((d) => (
+            <div
+              key={d.index}
+              className="flex flex-col gap-ds-02 border-t border-surface-border-subtle pt-ds-04"
+            >
+              <Text variant="label-sm" className="text-accent-11">
+                {d.index}
+              </Text>
+              <h3 className="text-ds-md text-surface-fg font-semibold">{d.title}</h3>
+              <p className="text-ds-sm text-surface-fg-subtle">{d.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Add two sections directly under the hero to answer the two questions a dev asks before staying:
- WhyNotShadcn: tight 3-column wedge row (copy-context §2)
- StackSupport: framework strip (Next.js/Vite/Astro/Remix/TanStack) with inline monochrome SVG marks, each linking to its install guide

Copy fixes:
- ComponentShowcase: "Five favourites" -> "Four" (4 demos rendered)
- FeatureGrid: keep "Three pillars. One promise." but render 3 pillars as a row and split the builder card out as the "one promise" (copy-context §3/§14), so the count reads true

Nav: pull "Figma Make" from navLinks for this launch; keep "For AI editors" standalone (direct-link destination for Cursor/Claude Code users).

<!--
Thanks for the PR. Fill the checklist below; reviewers will use it to triage.
For larger context, see CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what changed and why. Skip the play-by-play; the diff has that. -->

## Linked issues

<!-- Use "Closes #N" / "Fixes #N" for auto-close. List multiple if applicable. -->

Closes #

## Checklist

### Always

- [x] `pnpm typecheck && pnpm lint && pnpm test` clean locally
- [ ] Changeset added (`pnpm changeset`) at the right bump level — see [Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes)
- [ ] Storybook stories updated if visuals changed
- [ ] `pre-publish-audit.mjs` clean (CI runs it on `main`; run locally for risky changes)

### If this PR fixes agent-filed feedback (`ai-agent-feedback` label)

- [ ] `llms.txt` updated where the agent's expectation no longer matches reality
- [x] `docs/components/<tier>/<name>.md` updated if per-component prop/variant details changed (mcp-manifest.json regenerates from it)
- [ ] `docs/recipes/` updated if the install/setup path changed
- [ ] `AGENTS.md` updated if a hard constraint or auth-tier order changed
- [ ] The original agent-filed issue is closed by this PR (`Closes #N`)

### If this PR introduces a breaking change

- [ ] Changeset body leads with `**BREAKING:**` + before/after snippet
- [ ] `MIGRATION.md` section added with consumer-side migration steps
- [ ] **If the break touches more than two components**: migration autofix added to the [`@devalok/eslint-plugin-shilp-sutra`](../blob/main/packages/eslint-plugin) `migration` preset per [Codemod policy](../blob/main/CONTRIBUTING.md#codemod-policy). Name the rule:
- [ ] Deprecation cycle observed (≥1 minor as `@deprecated` before removal), OR explicit justification for skipping below

### If this PR adds a new component

- [x] `React.forwardRef` + `displayName`
- [x] `className` merged via `cn()` + remaining props spread
- [x] CVA used if `variant`/`size`/`color` props exist
- [x] Exported prop types interface
- [x] Unit test with at least one `vitest-axe` assertion
- [ ] Storybook story with `tags: ['autodocs']`
- [ ] `docs/components/<tier>/<name>.md` authored (llms.txt router + mcp-manifest.json regenerate from it)

## Notes for the reviewer

<!-- Anything non-obvious about the approach, alternatives considered, or follow-ups intentionally deferred. -->
