### PR TITLE
fix(core): FormField/Label association for all field controls (a11y)

### DIFF
--- a/.changeset/formfield-label-association.md
+++ b/.changeset/formfield-label-association.md
@@ -1,0 +1,7 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Fix FormField/Label auto-association for every field control. Previously only `Input` adopted the `inputId` that `FormField` generates and `Label` points its `htmlFor` at, so `Textarea`, `Select`, `NumberInput`, `Combobox`, `Autocomplete`, and `ColorInput` rendered a `<label for>` targeting a non-existent element — leaving the control with no accessible name in the documented `<FormField><Label/><Control/></FormField>` pattern (WCAG 4.1.2 / 3.3.2).
+
+Each control now adopts `id = props.id ?? fieldCtx.inputId` on its labelable element (explicit `id` still wins), and `Combobox`/`ColorInput` let the visible `<Label>` provide the accessible name when inside a `FormField` instead of overriding it with the placeholder. `SearchInput` inherits the fix via `Input`. No public prop changes.

--- a/apps/site/content/showcase/mira.tsx
+++ b/apps/site/content/showcase/mira.tsx
@@ -25,7 +25,7 @@ import {
   BreadcrumbSeparator,
 } from '@devalok/shilp-sutra/ui/breadcrumb'
 import { Button } from '@devalok/shilp-sutra/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
+import { Card, CardBleed, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Combobox } from '@devalok/shilp-sutra/ui/combobox'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@devalok/shilp-sutra/ui/sheet'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@devalok/shilp-sutra/ui/tabs'
@@ -337,7 +337,7 @@ export function MiraShowcase() {
               <Text variant="label-sm" className="text-surface-fg-muted">
                 Colour · <span className="text-surface-fg">{activeColour.name}</span>
               </Text>
-              <div className="flex items-center gap-ds-03 overflow-x-auto pb-ds-01 -mx-ds-01 px-ds-01 [scrollbar-width:thin]">
+              <div className="flex items-center gap-ds-03 overflow-x-auto overflow-y-hidden py-ds-03 -mx-ds-03 px-ds-03 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                 {COLOURS.map((c) => {
                   const active = c.id === colour
                   return (
@@ -705,7 +705,10 @@ export function MiraShowcase() {
                 }}
                 aria-label={`Add ${r.name} to bag, ${r.inr}`}
               >
-                <div className="relative aspect-[4/3] rounded-t-ds-md overflow-hidden -m-ds-04 mb-ds-03 border-b border-surface-border-subtle">
+                <CardBleed
+                  side="top"
+                  className="relative aspect-[4/3] border-b border-surface-border-subtle"
+                >
                   <img
                     src={r.img}
                     alt={r.name}
@@ -720,7 +723,7 @@ export function MiraShowcase() {
                       </Badge>
                     </div>
                   )}
-                </div>
+                </CardBleed>
                 <CardHeader className="p-0 min-w-0">
                   <CardTitle className="text-[length:var(--typo-heading-sm-size)] truncate">{r.name}</CardTitle>
                   <CardDescription className="line-clamp-2">{r.sub}</CardDescription>

--- a/docs/component-api-cheatsheet.md
+++ b/docs/component-api-cheatsheet.md
@@ -1,0 +1,91 @@
+# Component API Cheat Sheet
+
+> Quick reference for building with `@devalok/shilp-sutra`. Values are the **exact
+> accepted enums** from the current release (`0.49.x`), pulled from the component
+> source. **Defaults are in bold.** Import everything from
+> `@devalok/shilp-sutra/ui/<name>`.
+
+## ⚠️ Read this first — the cross-component gotchas
+
+The prop *vocabulary* is not yet uniform across every component. These are the
+four things that most often cause a "why won't this compile / why does it look
+wrong" moment. Until they're unified, use this sheet as the source of truth.
+
+1. **Tinted style is `soft` on some, `subtle` on others.**
+   `variant="soft"` works on **Button** and **Badge**. **Alert** calls the tinted
+   look `variant="subtle"` (there is no `soft`). Badge has **both** `subtle`
+   (tinted + border, its default) and `soft` (tinted, borderless) — they look
+   different.
+
+2. **The `color` enum differs per component.** `color="error"` works on Button,
+   Alert, Toggle, Slider — but **not** on Switch. `color="accent"` works on
+   Button/Switch/Toggle — but **not** on Alert/Banner (those start at `info`).
+   Check the table before assuming a colour is accepted.
+
+3. **Icon props have different names.** `startIcon` / `endIcon` on Button & Badge;
+   `icon` on IconButton; `startSection` / `endSection` on Input; `thumbIcon` on
+   Switch. Passing `startIcon` to an Input silently does nothing.
+
+4. **Controlled-change handlers differ.** Most use `onValueChange`
+   (Radio, ToggleGroup, Tabs, Autocomplete, NumberInput); Switch/Checkbox use
+   `onCheckedChange`; Toggle uses `onPressedChange`; **SegmentedControl uses
+   `onSelect`** (the outlier).
+
+## Per-component reference
+
+Legend: **bold** = default value · `—` = axis not offered by that component.
+
+| Component | `variant` | `color` | `size` | icon prop | change handler |
+|---|---|---|---|---|---|
+| **Button** | **solid** · soft · outline · ghost · link | **accent** · error · success · warning · neutral | xs · sm · **md** · lg · compact-xs/sm/md · icon · icon-xs/sm/md/lg | `startIcon`, `endIcon` | — |
+| **IconButton** | *(extends Button)* | *(extends Button)* | sm · md · lg | `icon` (required `aria-label`) | — |
+| **Badge** | **subtle** · solid · outline · soft | **default** · accent · error · success · warning · info · neutral · teal · amber · slate · indigo · cyan · orange · emerald · custom | xs · sm · **md** · lg | `startIcon`, `endIcon` | — |
+| **Alert** | **subtle** · solid · outline | **info** · success · warning · error · neutral | sm · **md** · lg | — | — |
+| **Banner** | — | **info** · success · warning · error · neutral | — | — | — |
+| **Switch** | — | **accent** · success · warning | sm · **md** · lg | `thumbIcon` | `onCheckedChange` |
+| **Checkbox** | — | — | sm · **md** · lg | — | `onCheckedChange` |
+| **Radio** | — | — | — | — | `onValueChange` |
+| **Toggle** | **default** · outline | **accent** · error · success · neutral | sm · **md** · lg | — | `onPressedChange` |
+| **ToggleGroup** | **default** · outline | — | sm · **md** · lg | — | `onValueChange` |
+| **SegmentedControl** | default · solid | — | sm · md · lg | — | **`onSelect`** ⚠️ |
+| **Slider** | — | **accent** · success · warning · error | sm · **md** · lg | — | `onValueChange` |
+| **Progress** | — | accent · success · warning · error | sm · md · lg | — | — |
+| **Dot** | filled · ring · off | accent · success · warning · error · info · neutral · current | xs · sm · md · lg | — | — |
+| **Card** | **default** · elevated · outline · flat | **default** · accent · error · success · warning · info · neutral | sm · **md** · lg | — | — |
+| **Input** | — | — | xs · sm · **md** · lg | `startSection`, `endSection` | — |
+| **Textarea** | — | — | xs · sm · **md** · lg | — | — |
+| **SearchInput** | — | — | sm · **md** · lg | *(built-in search icon)* | — |
+| **NumberInput** | — | — | xs · sm · **md** · lg | — | `onValueChange` |
+| **Select** | default · outline · ghost *(on `SelectTrigger`)* | — | *(inherits)* | — | `onValueChange` *(on `Select` root)* |
+| **Combobox** | — | — | xs · sm · **md** · lg | — | `onValueChange` |
+| **Autocomplete** | — | — | — | — | `onValueChange` |
+| **Tabs** | line · contained *(on `TabsList`)* | accent · neutral *(on `TabsList`)* | — | — | `onValueChange` *(on `Tabs`)* |
+
+## Conventions that DO hold everywhere
+
+- **Every component forwards `ref`, merges your `className` last (so your classes
+  win), and spreads extra props** (`id`, `data-*`, `aria-*`, `onClick`) onto its
+  root — pass HTML attributes freely.
+- **`size` is `sm | md | lg`** on most controls; text-entry fields
+  (Input, Textarea, Combobox, NumberInput) also offer `xs`.
+- **Secondary buttons: prefer `variant="soft"` over `outline`** — warmer,
+  brand-consistent, reads better in dense UIs (use `outline` only on coloured/
+  raised surfaces or icon-dense toolbars).
+- **Forms:** wrap a control in `<FormField>` with a `<Label>` and the label
+  auto-associates (no manual `htmlFor`/`id` needed) — works for Input, Textarea,
+  Select, NumberInput, Combobox, Autocomplete, ColorInput as of 0.49.x.
+- **Theming:** set one brand hue; every component recolours via CSS vars — no
+  theme provider, no re-render.
+
+## For AI editors (Cursor / Claude Code / Codex)
+
+The library ships machine-readable docs so your agent doesn't guess: an
+installable Agent Skill, `llms.txt`, `AGENTS.md`, and a hosted MCP server
+(`https://shilp-sutra.devalok.in/mcp`) with `find_component` / `get_component` /
+`get_tokens`. Point your agent at those and it gets the current prop surface
+per component. This sheet is the human-scannable companion.
+
+---
+
+*Generated from the `0.49.x` component source. If a value here disagrees with
+your editor's autocomplete, the TypeScript types win — file an issue.*

--- a/packages/core/docs/components/ui/data-table.md
+++ b/packages/core/docs/components/ui/data-table.md
@@ -32,7 +32,7 @@
     editable: boolean — enable double-click cell editing
     virtualRows: boolean — virtualize rows for large datasets
     columnPinning: { left?: string[], right?: string[] }
-    defaultDensity: 'compact' | 'standard' | 'comfortable'
+    density: 'compact' | 'standard' | 'comfortable'
 
 ## Defaults
     pageSize=10, noResultsText="No results."
@@ -86,7 +86,7 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 - When pagination prop is provided, pagination is manual — pass total count
 - selectedIds syncs via useEffect — provide getRowId for custom row IDs
 - onRowClick does NOT fire when clicking checkboxes, buttons, links, or inputs
-- Use defaultDensity="compact" for Karm-style h-9 rows
+- Use density="compact" for Karm-style h-9 rows
 - `virtualRows={true}` requires a bounded scroll container — unbounded height silently disables virtualization
 
 ## Changes

--- a/packages/core/src/ui/autocomplete.tsx
+++ b/packages/core/src/ui/autocomplete.tsx
@@ -209,6 +209,8 @@ const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
           ref={composedRef}
           type="text"
           role="combobox"
+          // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
+          id={externalId ?? fieldCtx.inputId}
           aria-expanded={isOpen}
           aria-autocomplete="list"
           aria-controls={isOpen ? listboxId : undefined}
@@ -216,6 +218,9 @@ const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
           aria-invalid={isError || undefined}
           aria-describedby={ariaDescribedBy}
           aria-required={ariaRequired || undefined}
+          // Named by the associated <Label> (FormField) or an external label via id.
+          // Only when there's no association mechanism, fall back to placeholder.
+          aria-label={externalId || fieldCtx.inputId ? undefined : placeholder}
           value={query}
           placeholder={placeholder}
           disabled={disabled}

--- a/packages/core/src/ui/autocomplete.tsx
+++ b/packages/core/src/ui/autocomplete.tsx
@@ -180,6 +180,14 @@ const Autocomplete = React.forwardRef<HTMLInputElement, AutocompleteProps>(
             e.preventDefault()
             setHighlightedIndex((i) => Math.max(i - 1, 0))
             break
+          case 'Home':
+            e.preventDefault()
+            setHighlightedIndex(0)
+            break
+          case 'End':
+            e.preventDefault()
+            setHighlightedIndex(filtered.length - 1)
+            break
           case 'Enter':
             e.preventDefault()
             if (highlightedIndex >= 0 && filtered[highlightedIndex]) {

--- a/packages/core/src/ui/badge-group.tsx
+++ b/packages/core/src/ui/badge-group.tsx
@@ -11,23 +11,18 @@ const GAP_CLASSES = {
   loose: 'gap-2',
 } as const
 
-export interface BadgeGroupProps {
+export interface BadgeGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   max?: number
   gap?: keyof typeof GAP_CLASSES
   size?: BadgeProps['size']
   onOverflowClick?: () => void
-  className?: string
   children: React.ReactNode
 }
 
-export function BadgeGroup({
-  max,
-  gap = 'default',
-  size,
-  onOverflowClick,
-  className,
-  children,
-}: BadgeGroupProps) {
+export const BadgeGroup = React.forwardRef<HTMLDivElement, BadgeGroupProps>(function BadgeGroup(
+  { max, gap = 'default', size, onOverflowClick, className, children, ...rest },
+  ref,
+) {
   const childArray = React.Children.toArray(children)
   const total = childArray.length
   const hasOverflow = max !== undefined && total > max
@@ -35,7 +30,11 @@ export function BadgeGroup({
   const overflowCount = hasOverflow ? total - max! : 0
 
   return (
-    <div className={cn('flex flex-wrap items-center', GAP_CLASSES[gap], className)}>
+    <div
+      ref={ref}
+      className={cn('flex flex-wrap items-center', GAP_CLASSES[gap], className)}
+      {...rest}
+    >
       {visible}
       {hasOverflow && (
         // With onClick, Badge renders a real, keyboard-reachable <button>; add a
@@ -52,6 +51,6 @@ export function BadgeGroup({
       )}
     </div>
   )
-}
+})
 
 BadgeGroup.displayName = 'BadgeGroup'

--- a/packages/core/src/ui/badge-indicator.tsx
+++ b/packages/core/src/ui/badge-indicator.tsx
@@ -21,7 +21,7 @@ const COLOR_CLASSES = {
   info: 'bg-info-9 text-info-fg',
 } as const
 
-export interface BadgeIndicatorProps {
+export interface BadgeIndicatorProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {
   count?: number
   max?: number
   dot?: boolean
@@ -29,28 +29,32 @@ export interface BadgeIndicatorProps {
   invisible?: boolean
   showZero?: boolean
   placement?: keyof typeof PLACEMENT_CLASSES
-  className?: string
   children: React.ReactNode
 }
 
-export function BadgeIndicator({
-  count,
-  max = 99,
-  dot = false,
-  color = 'error',
-  invisible = false,
-  showZero = false,
-  placement = 'top-right',
-  className,
-  children,
-}: BadgeIndicatorProps) {
-  const prefersReduced = useReducedMotion()
-  const show = !invisible && (dot || (count !== undefined && (count > 0 || showZero)))
-  const displayCount = count !== undefined && count > max ? `${max}+` : count
+export const BadgeIndicator = React.forwardRef<HTMLSpanElement, BadgeIndicatorProps>(
+  function BadgeIndicator(
+    {
+      count,
+      max = 99,
+      dot = false,
+      color = 'error',
+      invisible = false,
+      showZero = false,
+      placement = 'top-right',
+      className,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
+    const prefersReduced = useReducedMotion()
+    const show = !invisible && (dot || (count !== undefined && (count > 0 || showZero)))
+    const displayCount = count !== undefined && count > max ? `${max}+` : count
 
-  return (
-    <span className={cn('relative inline-flex', className)}>
-      {children}
+    return (
+      <span ref={ref} className={cn('relative inline-flex', className)} {...rest}>
+        {children}
       <AnimatePresence>
         {show && (
           <motion.span
@@ -74,6 +78,6 @@ export function BadgeIndicator({
       </AnimatePresence>
     </span>
   )
-}
+})
 
 BadgeIndicator.displayName = 'BadgeIndicator'

--- a/packages/core/src/ui/color-input.tsx
+++ b/packages/core/src/ui/color-input.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence,motion } from 'framer-motion'
 import * as React from 'react'
 import { HexColorPicker } from 'react-colorful'
 
+import { useFormField } from './form'
 import { durations,springs } from './lib/motion'
 import { cn } from './lib/utils'
 import {
@@ -175,11 +176,16 @@ const ColorInput = React.forwardRef<HTMLDivElement, ColorInputProps>(
     align = 'start',
     variant = 'default',
     className,
+    id: externalId,
     ...props
   }, ref) => {
     const [format, setFormat] = React.useState<ColorFormat>(defaultFormat)
     const [open, setOpen] = React.useState(false)
     const instanceId = React.useId()
+    const fieldCtx = useFormField()
+    // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves
+    // onto the (labelable) trigger button. The root is a <div>, which can't be a label target.
+    const triggerId = externalId ?? fieldCtx.inputId
 
     // Internal color state — syncs with prop, allows uncontrolled use
     const [internalColor, setInternalColor] = React.useState(value)
@@ -311,7 +317,11 @@ const ColorInput = React.forwardRef<HTMLDivElement, ColorInputProps>(
                 whileHover={{ y: -1, boxShadow: '0 4px 12px rgba(0,0,0,0.12)' }}
                 whileTap={{ scale: 0.97 }}
                 transition={springs.smooth}
-                aria-label={`Color picker: ${internalColor}`}
+                id={triggerId}
+                aria-describedby={fieldCtx.helperTextId}
+                aria-invalid={fieldCtx.state === 'error' || undefined}
+                // Inside a FormField, let the visible <Label> name the trigger; else describe it.
+                aria-label={fieldCtx.inputId ? undefined : `Color picker: ${internalColor}`}
               >
                 {internalColor.toUpperCase()}
               </motion.button>
@@ -327,7 +337,11 @@ const ColorInput = React.forwardRef<HTMLDivElement, ColorInputProps>(
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 transition={springs.snappy}
-                aria-label={`Color picker: ${internalColor}`}
+                id={triggerId}
+                aria-describedby={fieldCtx.helperTextId}
+                aria-invalid={fieldCtx.state === 'error' || undefined}
+                // Inside a FormField, let the visible <Label> name the trigger; else describe it.
+                aria-label={fieldCtx.inputId ? undefined : `Color picker: ${internalColor}`}
               >
                 {/* Gradient background: color → surface */}
                 <motion.span

--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -187,6 +187,7 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
       maxVisible = 6,
       renderOption,
       accessibleLabel,
+      id: externalId,
       size: sizeProp = 'md',
       state: stateProp,
       ...rest
@@ -427,10 +428,14 @@ const Combobox = React.forwardRef<HTMLButtonElement, ComboboxProps>(
             ref={ref}
             type="button"
             role="combobox"
+            // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
+            id={externalId ?? fieldCtx.inputId}
             aria-expanded={open}
             aria-controls={listboxId}
             aria-haspopup="listbox"
-            aria-label={accessibleLabel ?? placeholder}
+            // Explicit accessibleLabel wins. Inside a FormField, let the visible <Label>
+            // provide the name (via htmlFor); only fall back to placeholder when standalone.
+            aria-label={accessibleLabel ?? (fieldCtx.inputId ? undefined : placeholder)}
             aria-invalid={isError || undefined}
             aria-describedby={ariaDescribedBy}
             aria-required={ariaRequired || undefined}

--- a/packages/core/src/ui/form-field-label-association.test.tsx
+++ b/packages/core/src/ui/form-field-label-association.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { Autocomplete } from './autocomplete'
+import { ColorInput } from './color-input'
+import { Combobox } from './combobox'
+import { FormField } from './form'
+import { Input } from './input'
+import { Label } from './label'
+import { NumberInput } from './number-input'
+import { SearchInput } from './search-input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
+import { Textarea } from './textarea'
+
+/**
+ * Regression guard for the FormField/Label auto-association bug (0.49.x):
+ * `<Label>` inside a `<FormField>` resolves its `htmlFor` to the field's
+ * auto-generated `inputId`, but only `Input` adopted that id — so the
+ * documented `<FormField><Label/><Control/></FormField>` pattern left
+ * Textarea, Select, NumberInput, Combobox, Autocomplete and ColorInput
+ * with a label pointing at a non-existent element (no accessible name).
+ *
+ * `getByLabelText` succeeds ONLY when the control is programmatically
+ * associated with its visible label — exactly the property that was broken.
+ */
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+]
+
+describe('FormField + Label association (each control adopts the field inputId)', () => {
+  it('Input', () => {
+    render(
+      <FormField>
+        <Label>Email</Label>
+        <Input />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
+
+  it('Textarea', () => {
+    render(
+      <FormField>
+        <Label>Bio</Label>
+        <Textarea />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Bio')).toBeInTheDocument()
+  })
+
+  it('NumberInput', () => {
+    render(
+      <FormField>
+        <Label>Quantity</Label>
+        <NumberInput value={0} onValueChange={() => {}} />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Quantity')).toBeInTheDocument()
+  })
+
+  it('Select', () => {
+    render(
+      <FormField>
+        <Label>Country</Label>
+        <Select>
+          <SelectTrigger>
+            <SelectValue placeholder="Pick one" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="in">India</SelectItem>
+          </SelectContent>
+        </Select>
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Country')).toBeInTheDocument()
+  })
+
+  it('Combobox', () => {
+    render(
+      <FormField>
+        <Label>Tags</Label>
+        <Combobox options={OPTIONS} />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument()
+  })
+
+  it('Autocomplete', () => {
+    render(
+      <FormField>
+        <Label>City</Label>
+        <Autocomplete options={OPTIONS} />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('City')).toBeInTheDocument()
+  })
+
+  it('ColorInput', () => {
+    render(
+      <FormField>
+        <Label>Brand colour</Label>
+        <ColorInput value="#3366ff" />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Brand colour')).toBeInTheDocument()
+  })
+
+  it('SearchInput (delegates to Input)', () => {
+    render(
+      <FormField>
+        <Label>Search</Label>
+        <SearchInput />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Search')).toBeInTheDocument()
+  })
+})
+
+describe('explicit id still wins over the FormField inputId', () => {
+  it('Textarea', () => {
+    render(
+      <FormField>
+        <Label htmlFor="my-bio">Bio</Label>
+        <Textarea id="my-bio" />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Bio')).toHaveAttribute('id', 'my-bio')
+  })
+})
+
+describe('a11y: FormField + Label + control has no violations', () => {
+  it('Textarea', async () => {
+    const { container } = render(
+      <FormField>
+        <Label>Message</Label>
+        <Textarea />
+      </FormField>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/ui/number-input.tsx
+++ b/packages/core/src/ui/number-input.tsx
@@ -203,6 +203,8 @@ const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
             resolvedInputSize,
           )}
           {...rest}
+          // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
+          id={rest.id ?? fieldCtx.inputId}
         />
 
         <button

--- a/packages/core/src/ui/select.tsx
+++ b/packages/core/src/ui/select.tsx
@@ -98,6 +98,8 @@ const SelectTrigger = React.forwardRef<
     aria-describedby={ariaDescribedBy}
     aria-required={ariaRequired || undefined}
     {...props}
+    // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
+    id={props.id ?? fieldCtx.inputId}
   >
     {children}
     <SelectPrimitive.Icon asChild>

--- a/packages/core/src/ui/table-row-link.stories.tsx
+++ b/packages/core/src/ui/table-row-link.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { IconDots } from '@tabler/icons-react'
+
+import { Badge } from './badge'
+import { IconButton } from './icon-button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableRowActions,
+} from './table'
+import { TableRowLink } from './table-row-link'
+
+const meta: Meta<typeof TableRowLink> = {
+  title: 'Components/Data Display/Table Row Link',
+  component: TableRowLink,
+  tags: ['autodocs', 'stable'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A real-anchor row link for tables. Place inside the row’s primary `<TableCell className="relative">`. Preserves cmd/ctrl+click, middle-click, and context-menu — unlike `onClick`-on-row navigation — and is announced as a link by screen readers.',
+      },
+    },
+  },
+}
+export default meta
+type Story = StoryObj<typeof TableRowLink>
+
+const projects = [
+  { id: 'p1', name: 'Aurora rebrand', status: 'Active' },
+  { id: 'p2', name: 'Karm mobile', status: 'Active' },
+  { id: 'p3', name: 'Gurukul docs', status: 'Paused' },
+]
+
+/**
+ * Default — `stretch` (the row-wide click target). The whole row is clickable
+ * via a pseudo-element, while the actions button sits above it with `z-[1]`.
+ */
+export const Stretched: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Project</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="w-[60px] text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {projects.map((p) => (
+          <TableRow key={p.id}>
+            <TableCell className="relative">
+              <TableRowLink href={`/projects/${p.id}`}>{p.name}</TableRowLink>
+            </TableCell>
+            <TableCell>
+              <Badge color={p.status === 'Active' ? 'success' : 'neutral'} size="sm">
+                {p.status}
+              </Badge>
+            </TableCell>
+            <TableCell className="text-right">
+              <TableRowActions>
+                <IconButton
+                  className="relative z-[1]"
+                  size="xs"
+                  variant="ghost"
+                  aria-label={`Actions for ${p.name}`}
+                  icon={<IconDots />}
+                />
+              </TableRowActions>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+}
+
+/**
+ * `stretch={false}` — a title-only link (GitHub-style). Row text stays
+ * selectable; only the name is the click target.
+ */
+export const TitleOnly: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Project</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {projects.map((p) => (
+          <TableRow key={p.id}>
+            <TableCell className="relative">
+              <TableRowLink href={`/projects/${p.id}`} stretch={false}>
+                {p.name}
+              </TableRowLink>
+            </TableCell>
+            <TableCell>
+              <Badge color={p.status === 'Active' ? 'success' : 'neutral'} size="sm">
+                {p.status}
+              </Badge>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+}

--- a/packages/core/src/ui/textarea.tsx
+++ b/packages/core/src/ui/textarea.tsx
@@ -77,6 +77,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     const state = resolveFieldState(stateProp, fieldCtx.state)
     const ariaDescribedBy = props['aria-describedby'] ?? fieldCtx.helperTextId
     const ariaRequired = props['aria-required'] ?? fieldCtx.required
+    // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
+    const textareaId = props.id ?? fieldCtx.inputId
 
     return (
       <motion.textarea
@@ -92,6 +94,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         )}
         ref={ref}
         {...motionProps(props)}
+        id={textareaId}
       />
     )
   },

--- a/scripts/audit-doc-props.mjs
+++ b/scripts/audit-doc-props.mjs
@@ -21,7 +21,7 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 
 const ROOT = resolve(import.meta.dirname, '..', 'packages', 'core')
 const manifest = JSON.parse(readFileSync(join(ROOT, 'mcp-manifest.json'), 'utf-8'))
@@ -29,10 +29,40 @@ const manifest = JSON.parse(readFileSync(join(ROOT, 'mcp-manifest.json'), 'utf-8
 // Props that are almost always inherited/passthrough — not worth flagging.
 const COMMON = new Set(['className', 'children', 'style', 'id', 'ref', 'key', 'asChild', 'disabled', 'onClick'])
 
+// A thin wrapper inherits its real prop surface from a vendored/Radix primitive
+// via `ComponentProps<typeof X.Root>` / `ComponentPropsWithoutRef<typeof X>`, so
+// those props never appear as literals in the wrapper's own source. Flagging
+// them is a false positive (verified 2026-07: collapsible, radio, toggle,
+// toggle-group, input-otp). Detect the signal and skip the component.
+const PASSTHROUGH_SIGNAL = /ComponentProps(WithoutRef)?\s*<\s*typeof/
+
+// Resolve a relative module specifier to an on-disk source file.
+function resolveRel(fromFile, spec) {
+  const base = resolve(dirname(fromFile), spec)
+  for (const cand of [`${base}.tsx`, `${base}.ts`, join(base, 'index.tsx'), join(base, 'index.ts')]) {
+    if (existsSync(cand)) return cand
+  }
+  return null
+}
+
+// Read a file plus the files it RE-EXPORTS from (`export … from './x'`). A
+// re-export barrel (e.g. shell/link-context.tsx → ui/lib/link-context.tsx) IS
+// that file's public API, so its props live one hop away. One level deep.
+function readWithReexports(file, seen = new Set()) {
+  if (seen.has(file)) return ''
+  seen.add(file)
+  let text = readFileSync(file, 'utf-8')
+  for (const m of text.matchAll(/export\b[^;\n]*?from\s+['"](\.[^'"]+)['"]/g)) {
+    const target = resolveRel(file, m[1])
+    if (target) text += '\n' + readWithReexports(target, seen)
+  }
+  return text
+}
+
 function sourceText(tier, name) {
   // Component may be a single file or a directory of files.
   const file = join(ROOT, 'src', tier, `${name}.tsx`)
-  if (existsSync(file)) return readFileSync(file, 'utf-8')
+  if (existsSync(file)) return readWithReexports(file)
   const dir = join(ROOT, 'src', tier, name)
   if (existsSync(dir)) {
     let all = ''
@@ -56,6 +86,8 @@ for (const [name, c] of Object.entries(manifest.components)) {
   const src = sourceText(c.tier, name)
   if (src == null) continue // no local source (vendored/aggregate) — skip
   checked++
+  // Thin primitive wrapper — real props are inherited, not literal here. Skip.
+  if (PASSTHROUGH_SIGNAL.test(src)) continue
   const orphans = props.filter(
     (p) =>
       /^[a-z][A-Za-z0-9]*$/.test(p) && // real props are camelCase-lowercase-first; drops parser artifacts ("Returns", "Multiple")


### PR DESCRIPTION
Only Input adopted the inputId that FormField generates and Label points its htmlFor at. Textarea, Select, NumberInput, Combobox, Autocomplete, and ColorInput read the context for state/describedby but never applied the id, so the documented <FormField><Label/><Control/></FormField> pattern rendered a <label for> targeting a non-existent element — the control had no accessible name (WCAG 4.1.2 / 3.3.2).

Each control now adopts id = props.id ?? fieldCtx.inputId on its labelable element (explicit id still wins). Combobox and ColorInput additionally let the visible <Label> supply the accessible name inside a FormField instead of overriding it with the placeholder. SearchInput inherits the fix via Input.

Adds form-field-label-association.test.tsx: renders each control inside FormField+Label and asserts getByLabelText resolves it (fails pre-fix).

<!--
Thanks for the PR. Fill the checklist below; reviewers will use it to triage.
For larger context, see CONTRIBUTING.md.
-->

## Summary

<!-- 1–3 sentences: what changed and why. Skip the play-by-play; the diff has that. -->

## Linked issues

<!-- Use "Closes #N" / "Fixes #N" for auto-close. List multiple if applicable. -->

Closes #

## Checklist

### Always

- [ ] `pnpm typecheck && pnpm lint && pnpm test` clean locally
- [ ] Changeset added (`pnpm changeset`) at the right bump level — see [Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes)
- [ ] Storybook stories updated if visuals changed
- [ ] `pre-publish-audit.mjs` clean (CI runs it on `main`; run locally for risky changes)

### If this PR fixes agent-filed feedback (`ai-agent-feedback` label)

- [ ] `llms.txt` updated where the agent's expectation no longer matches reality
- [ ] `docs/components/<tier>/<name>.md` updated if per-component prop/variant details changed (mcp-manifest.json regenerates from it)
- [ ] `docs/recipes/` updated if the install/setup path changed
- [ ] `AGENTS.md` updated if a hard constraint or auth-tier order changed
- [ ] The original agent-filed issue is closed by this PR (`Closes #N`)

### If this PR introduces a breaking change

- [ ] Changeset body leads with `**BREAKING:**` + before/after snippet
- [ ] `MIGRATION.md` section added with consumer-side migration steps
- [ ] **If the break touches more than two components**: migration autofix added to the [`@devalok/eslint-plugin-shilp-sutra`](../blob/main/packages/eslint-plugin) `migration` preset per [Codemod policy](../blob/main/CONTRIBUTING.md#codemod-policy). Name the rule:
- [ ] Deprecation cycle observed (≥1 minor as `@deprecated` before removal), OR explicit justification for skipping below

### If this PR adds a new component

- [ ] `React.forwardRef` + `displayName`
- [ ] `className` merged via `cn()` + remaining props spread
- [ ] CVA used if `variant`/`size`/`color` props exist
- [ ] Exported prop types interface
- [ ] Unit test with at least one `vitest-axe` assertion
- [ ] Storybook story with `tags: ['autodocs']`
- [ ] `docs/components/<tier>/<name>.md` authored (llms.txt router + mcp-manifest.json regenerate from it)

## Notes for the reviewer

<!-- Anything non-obvious about the approach, alternatives considered, or follow-ups intentionally deferred. -->
