### PR TITLE
ci: split release into version/integration/publish workflows

### DIFF
--- a/.claude/commands/publish-release.md
+++ b/.claude/commands/publish-release.md
@@ -1,6 +1,6 @@
 ---
 name: publish-release
-description: Reviewer checklist and emergency manual-publish runbook. Day-to-day publishing happens automatically via `.github/workflows/release.yml` when a Version Packages PR merges — this skill is for reviewing that PR or for manual publishing when CI is broken.
+description: Reviewer checklist and emergency manual-publish runbook. Publishing is a deliberate manual dispatch of `.github/workflows/release.yml` AFTER the Version Packages PR merges (split 2026-07-22) — this skill is for reviewing that PR, dispatching the release, or manual publishing when CI is broken.
 ---
 
 # Publish Release
@@ -11,18 +11,21 @@ description: Reviewer checklist and emergency manual-publish runbook. Day-to-day
 
 Violating the letter of this rule IS violating the spirit. "Just this once" does not exist.
 
-## How publishing actually works (2026-04-21+)
+## How publishing actually works (release split 2026-07-22)
+
+Publishing is decoupled from merging so releases are *paced*, not churned out on every merge. Three workflows:
 
 1. Developer adds a `.changeset/*.md` file describing the change + bump type.
 2. Push / merge to `main`.
-3. `changesets/action` opens (or updates) a **Version Packages** PR that bumps `package.json` versions and regenerates `CHANGELOG.md`.
-4. **A human reviews that PR against the Reviewer Checklist below.**
-5. Merging the PR triggers `.github/workflows/release.yml`, which runs `pre-publish-audit.mjs` (45 hard gates + CVA-accuracy audit), builds, and publishes to npm via OIDC Trusted Publisher + sigstore provenance.
+3. **`version.yml`** runs `changesets/action`, opening (or updating) a **Version Packages** PR that bumps `package.json` versions and regenerates `CHANGELOG.md`. **`integration.yml`** runs the release-unique gates (pre-publish-audit, consumer-smoke, compiled-CSS coverage, skill-drift, Chromatic) as a post-merge net. **Neither publishes.**
+4. **A human reviews the Version PR against the Reviewer Checklist below**, then merges it (bumps versions, deletes changesets). Merging **no longer publishes**.
+5. **A maintainer dispatches `release.yml`** — Actions UI "Run workflow" or `gh workflow run release.yml`. It runs the full gauntlet (`pre-publish-audit.mjs` 45 hard gates + build + consumer-smoke + Chromatic) and publishes to npm via OIDC Trusted Publisher + sigstore provenance. A stable dispatch is **refused if unreleased changesets are still pending** (you forgot to merge the Version PR).
 6. Chromatic visual baseline snapshot + Storybook deploy run after publish.
 
-The skill has no role in the normal path. It exists for two moments:
+The skill has three moments:
 
 - **Reviewing the Version Packages PR** (use the checklist below).
+- **Dispatching the release** after the Version PR merges (step 5 — `gh workflow run release.yml`).
 - **Publishing manually when release.yml is broken** (use the runbook at the bottom).
 
 ## Reviewer Checklist for the Version Packages PR
@@ -49,7 +52,13 @@ You can trust these to be gated in CI — the checklist above is the stuff CI ca
 - git clean, version ↔ CHANGELOG match, docs coverage per component, CVA/doc prop accuracy, typecheck, lint, tests, build, SSR smoke, surface/shadow token hygiene, TW4 migration hygiene, per-component stories, bundle-size regression, published-exports ordering. See `scripts/pre-publish-audit.mjs`.
 
 ### Once every box is checked
-Approve + merge. `release.yml` publishes. Verify after:
+Approve + merge the Version PR (versions bump, changesets clear — **this does not publish**). Then dispatch the release:
+
+```bash
+gh workflow run release.yml   # or Actions UI → Release → Run workflow
+```
+
+Verify after:
 
 ```bash
 npm view @devalok/shilp-sutra version

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,141 @@
+name: Integration
+
+# Post-merge integration gates. Runs the RELEASE-UNIQUE gauntlet — the checks
+# that PR CI (ci.yml) does NOT run — on every main push, so a break is caught at
+# merge time (while the author is still around), NOT weeks later when someone
+# presses the publish button.
+#
+# This workflow NEVER publishes. It has no id-token permission and no publish
+# step. Publishing lives in release.yml (workflow_dispatch only).
+#
+# Division of labor:
+#   ci.yml (PRs)       → build, typecheck, lint, lint:props, test, ssr-smoke,
+#                        bundle-size, storybook browser tests (turbo remote cache)
+#   integration.yml    → the gates PR CI can't/doesn't run: pre-publish-audit,
+#     (this, on main)    consumer-smoke (Next+TW4), compiled-CSS coverage,
+#                        skill-ref drift, Chromatic. These caught the 0.49.0
+#                        breaks PR CI missed (4 hotfix PRs). Do not delete them.
+#   release.yml        → the FULL gauntlet + publish, dispatch-only, self-verifying.
+#
+# NOTE: the gate steps below are a subset of release.yml's. When you add or
+# change a release gate, keep this file in sync (or the net has a hole).
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'apps/site/**'
+      - 'packages/mcp-server/**'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      # Never serve release-integration builds from the remote cache — build fresh.
+      TURBO_FORCE: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Chromatic needs full history to compute visual baselines across
+          # commits (default depth 1 => "Found only one commit").
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Prerelease state controls whether Chromatic blocks on diffs. In pre-mode
+      # (@next line) we upload + auto-accept; on the stable line we block on any
+      # unreviewed diff. Mirrors release.yml's guard.
+      - name: Inspect prerelease state
+        id: guard
+        run: |
+          if [ -f .changeset/pre.json ]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Core-only gates (consumer-smoke, css-coverage, chromatic) don't apply to
+      # a brand/eslint-only push. Skip them there. Fail safe: anything ambiguous
+      # -> run full gates.
+      - name: Detect affected packages
+        id: affected
+        run: |
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          if [ "${{ github.event_name }}" != "push" ] || [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "core=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^packages/core/'; then
+            echo "core=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "core=false" >> "$GITHUB_OUTPUT"
+            echo "packages/core untouched -> skipping core-only integration gates."
+          fi
+
+      # Build is required for the dist-reading gates below (audit, consumer-smoke,
+      # css-coverage).
+      - name: Build
+        run: pnpm build
+
+      # Regenerate skill references before the audit's drift gate (build-skill.mjs
+      # copies from llms.txt / docs/recipes). Without this the audit fails on any
+      # push that edited a source but didn't commit the regenerated ref.
+      - name: Regenerate Agent Skill references
+        run: node scripts/build-skill.mjs
+
+      # Full HARD-gate audit. SS_AUDIT_SKIP_REDUNDANT=1 skips build/typecheck/
+      # test/ssr — those already ran in ci.yml on the PR; here we want the
+      # audit-UNIQUE gates (docs coverage, token hygiene, manifest, skill,
+      # breaking, bundle, exports order). Downstream dist-reading gates use the
+      # Build step above.
+      - name: Pre-publish audit
+        run: node scripts/pre-publish-audit.mjs
+        env:
+          SS_AUDIT_SKIP_REDUNDANT: '1'
+
+      # Dist-side net: packs the tarball into a throwaway Next 16 + TW4 +
+      # Turbopack app and runs `next build`. Catches RSC/CSS regressions no
+      # other gate exercises. THE gate that would have caught Karm's 0.34/0.36
+      # blockers.
+      - name: Consumer smoke (Next 16 + Turbopack + TW4)
+        if: steps.affected.outputs.core == 'true'
+        run: node scripts/consumer-smoke-test.mjs
+
+      - name: Compiled-CSS coverage (Turbopack)
+        if: steps.affected.outputs.core == 'true'
+        run: node scripts/audit-compiled-css.mjs
+
+      - name: Consumer smoke (Next 15 + Webpack)
+        if: ${{ steps.affected.outputs.core == 'true' && hashFiles('tests/smoke-consumer-next15/package.json') != '' }}
+        run: node scripts/consumer-smoke-test.mjs --variant next15-webpack
+
+      - name: Compiled-CSS coverage (Webpack)
+        if: ${{ steps.affected.outputs.core == 'true' && hashFiles('tests/smoke-consumer-next15/package.json') != '' }}
+        run: node scripts/audit-compiled-css.mjs --variant next15-webpack
+
+      # Chromatic visual regression on the stable line blocks on any unreviewed
+      # diff (binds the new baseline). Skipped when the token isn't configured
+      # so the workflow stays green until then.
+      - name: Chromatic visual review
+        if: ${{ steps.affected.outputs.core == 'true' && env.CHROMATIC_PROJECT_TOKEN != '' }}
+        uses: chromaui/action@v11
+        with:
+          projectToken: ${{ env.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: build-storybook
+          exitZeroOnChanges: ${{ steps.guard.outputs.prerelease == 'true' }}
+          autoAcceptChanges: ${{ steps.guard.outputs.prerelease == 'true' }}
+          onlyChanged: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,16 @@
 name: Release
 
+# PUBLISH is a deliberate, manual act — this workflow runs ONLY on
+# workflow_dispatch (Actions UI "Run workflow", or `gh workflow run release.yml`).
+#
+# It no longer fires on push to main (split out 2026-07-22). Merging a feature
+# PR opens/updates the Version PR (version.yml) and runs integration gates
+# (integration.yml); NEITHER publishes. To ship:
+#   1. Merge the "Version Packages" PR (bumps versions, deletes changesets).
+#   2. Dispatch THIS workflow. The guard below refuses if unreleased changesets
+#      are still pending (i.e. you forgot step 1).
+# See CLAUDE.md "Publishing".
 on:
-  push:
-    branches: [main]
-    # Site-only and mcp-server-only changes deploy via Railway and never touch
-    # the published npm packages — skip the release pipeline for them.
-    # (paths-ignore only skips when ALL changed paths match, so a mixed push
-    # that also touches packages/core still runs the release correctly.)
-    paths-ignore:
-      - 'apps/site/**'
-      - 'packages/mcp-server/**'
-  # Allow manual re-runs from the Actions UI / gh CLI without needing a new commit.
-  # Useful when a prior publish failed on a transient issue (auth, registry outage,
-  # token expiry) and we want to retry with the fix in place — as happened after
-  # 0.36.0's initial NPM_TOKEN setup. See 2026-04-19 retro.
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -43,6 +40,23 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
             echo "Release guard: no pre.json → stable release (@latest)"
           fi
+      # Refuse a stable dispatch while unreleased changesets are still pending —
+      # that means the Version PR wasn't merged, so main's versions are NOT bumped
+      # and changesets/action would silently open a PR instead of publishing.
+      # (In prerelease mode, pending changesets are expected — @next publishes
+      # them — so this check applies to the stable line only.)
+      - name: Guard — Version PR must be merged first (stable only)
+        if: steps.check.outputs.prerelease != 'true'
+        run: |
+          set -euo pipefail
+          # Any .changeset/*.md other than README.md is an unconsumed changeset.
+          PENDING=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l)
+          if [ "$PENDING" -gt 0 ]; then
+            echo "::error::$PENDING unreleased changeset(s) still present. Merge the 'Version Packages' PR before dispatching a release."
+            find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' -printf '  - %p\n'
+            exit 1
+          fi
+          echo "Guard: no pending changesets → versions are bumped, safe to publish."
 
   # ── Release job — gated on guard ───────────────────────────────────────────
   release:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,59 @@
+name: Version
+
+# Opens / updates the "Version Packages" PR whenever changesets land on main.
+# This workflow NEVER publishes — it only prepares the release PR. Publishing is
+# a deliberate, separate act: see release.yml (workflow_dispatch only).
+#
+# Why split (2026-07-22): with more contributors, coupling "merge to main" to
+# "publish to npm" churned releases out reactively. Now changesets accumulate
+# into one Version PR that a maintainer merges when ready, and publish is a
+# separate manual dispatch. See CLAUDE.md "Publishing".
+on:
+  push:
+    branches: [main]
+    # Site-only and mcp-server-only changes deploy via Railway and never touch
+    # published npm packages. paths-ignore only skips when ALL changed paths
+    # match, so a mixed push that also touches packages/core still runs.
+    paths-ignore:
+      - 'apps/site/**'
+      - 'packages/mcp-server/**'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: write + pull-requests: write let changesets/action open and
+      # update the Version Packages PR. NO id-token here — this job cannot and
+      # must not publish.
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # changesets/action with `version:` but NO `publish:` — when changesets
+      # exist it opens/updates the Version PR; when none exist it is a no-op.
+      # It can never publish because no publish command is configured and the
+      # job lacks id-token:write.
+      - name: Open or update Version Packages PR
+        uses: changesets/action@v1
+        with:
+          version: pnpm version-packages
+          title: "chore(release): version packages"
+          commit: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,9 +123,16 @@ To add a legitimate exception, add the filename to `SURFACE1_ALLOWLIST` in `scri
 
 ## Publishing
 
-**Day-to-day:** Add a `.changeset/*.md` file → push/merge to `main` → `changesets/action` opens a Version Packages PR → review + merge → `.github/workflows/release.yml` publishes via OIDC Trusted Publisher (sigstore provenance). **Do not run `npm publish` manually.**
+**Day-to-day (release split 2026-07-22):** Publishing is decoupled from merging so releases can be *paced*, not churned. Three workflows:
+- **`version.yml`** (push→main): `changesets/action` opens/updates the Version Packages PR. Never publishes.
+- **`integration.yml`** (push→main): runs the release-UNIQUE gates PR CI can't (pre-publish-audit, consumer-smoke, compiled-CSS coverage, skill-drift, Chromatic) as a post-merge net. Never publishes.
+- **`release.yml`** (`workflow_dispatch` ONLY): full gauntlet **+ publish** via OIDC Trusted Publisher (sigstore provenance).
 
-**Authority on gates:** `scripts/pre-publish-audit.mjs` is the single source of truth — 45 hard gates (git clean, version ↔ CHANGELOG match, per-component docs coverage, CVA/doc prop accuracy, typecheck, lint, tests, build, SSR smoke, surface/shadow token hygiene, TW4 migration hygiene, published-exports ordering, bundle size). It runs in release.yml's Audit step before publish AND can be invoked locally (`node scripts/pre-publish-audit.mjs`) for pre-flight checks.
+**Flow:** land changesets → they accumulate in the Version PR → merge the Version PR when ready to ship (bumps versions, deletes changesets; **no longer auto-publishes**) → a maintainer dispatches `release.yml` (Actions UI "Run workflow" or `gh workflow run release.yml`). A stable dispatch is **refused if unreleased changesets are still pending** (you forgot to merge the Version PR). **Do not run `npm publish` manually.**
+
+> Gate steps in `integration.yml` are a subset of `release.yml`'s — when you add/change a release gate, keep both in sync or the post-merge net has a hole.
+
+**Authority on gates:** `scripts/pre-publish-audit.mjs` is the single source of truth — 45 hard gates (git clean, version ↔ CHANGELOG match, per-component docs coverage, CVA/doc prop accuracy, typecheck, lint, tests, build, SSR smoke, surface/shadow token hygiene, TW4 migration hygiene, published-exports ordering, bundle size). It runs in `integration.yml` (every main push) AND `release.yml`'s Audit step before publish, AND can be invoked locally (`node scripts/pre-publish-audit.mjs`) for pre-flight checks.
 
 **Human judgment lives on the Version Packages PR.** See `/publish-release` for the reviewer checklist (changeset body quality, bump magnitude, Chromatic review, Storybook spot-check). CI can't evaluate these — they gate on merge.
 


### PR DESCRIPTION
## Summary

Decouples **publishing** from **merging** so releases can be *paced* rather than churned out on every merge — motivated by the growing contributor count in shilp-sutra.

### Before
A single `release.yml` fired on every push to `main` and, via `changesets/action`, either opened the Version PR *or* published (when the merged push carried no changesets). Publishing was frictionless — merge the Version PR and it shipped. Fine solo; churns releases with more contributors.

### After — three workflows

| Workflow | Trigger | Role |
|----------|---------|------|
| **`version.yml`** | push → main | `changesets/action` opens/updates the **Version Packages** PR. Never publishes (no publish cmd, no `id-token`). |
| **`integration.yml`** | push → main | Runs the release-**unique** gates PR CI can't (`pre-publish-audit`, consumer-smoke, compiled-CSS coverage, skill-drift, Chromatic) as a **post-merge net** — breaks surface at merge, not at publish. Never publishes. |
| **`release.yml`** | `workflow_dispatch` **only** | Full gauntlet **+ publish**. New guard **refuses a stable dispatch while unreleased changesets are still pending** (Version PR not merged). |

### New flow
1. Land changesets → they accumulate in the Version PR (`version.yml`); `integration.yml` gates run each merge.
2. Merge the Version PR when ready to ship (bumps versions, deletes changesets). **No longer auto-publishes.**
3. Maintainer dispatches: `gh workflow run release.yml` (or Actions UI). Guard blocks if you skipped step 2.

### Why integration.yml is not "waste"
Those gates are precisely the ones PR CI (`ci.yml`, scoped + turbo-cached) does **not** run — the same class that caught the 0.49.0 breaks PR CI missed (4 hotfix PRs). Kept as a post-merge net, just decoupled from the publish action. Affected-detection skips them on brand/eslint-only pushes.

## Testing notes
- YAML validated; index blobs confirmed pure LF (no CRLF in `run:` blocks).
- `version.yml`/`integration.yml` are `push:main`-triggered — they first run **on merge of this PR**, non-publishing, so a failure is visible + fixable without shipping anything.
- Post-merge I'll dispatch `release.yml` to verify the pending-changeset **guard refuses** (the formfield changeset from #160 is still pending) — a safe end-to-end check of the dispatch path that cannot publish.

## Docs
`CLAUDE.md` Publishing section + `/publish-release` skill rewritten to the new flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)