### PR TITLE
fix(themer): stop nested comment silently dropping the pasted brand override

### DIFF
--- a/.changeset/themer-nested-comment-dropped-override.md
+++ b/.changeset/themer-nested-comment-dropped-override.md
@@ -1,0 +1,9 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Fix Themer output silently dropping the pasted brand override, and harden the agent theming contract.
+
+- **Themer CSS output no longer emits a nested `/* */` comment in its header.** CSS comments do not nest, so the inner `*/` closed the header early and the stray `*/` corrupted the `:root{}` block right after it — the entire accent ramp + radius override was silently dropped at build (a warning only, exit 0), so the fetched brand color never applied. Masked whenever the chosen color happened to match the package default.
+- **AGENTS.md theming recipe is explicit about the contract.** The `result.json` endpoint accepts only `archetype` or numeric `hue`/`chroma` — there is no `hex`/`color` param, and passing one is silently ignored (you get the default theme, wrong color, no error). The recipe now tells agents to convert a hex to OKLCH first, sanity-check the echoed `hue`/`chroma`, and verify the accent actually changed.
+- **`verify_setup` now flags nested CSS comments** so a dropped override is caught before it ships instead of failing silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,12 +176,16 @@ Set up shilp-sutra theming for this project via the Themer.
 My brand: <hex OR archetype name>
 
 Steps:
-1. Map my brand input to query params (archetype=<name>, or hue=<0-360>&chroma=<0.10-0.20>, or default archetype=devalok&hue=340&chroma=0.19).
+1. Map my brand input to query params. The endpoint accepts ONLY these — pick the case that fits:
+   - Archetype name  → `archetype=<name>`
+   - A hex color     → CONVERT the hex to OKLCH first, then pass `hue=<0-360>&chroma=<0.10-0.20>` (numeric). There is NO `hex` or `color` param — passing one is silently ignored and you get the default devalok theme (wrong color, no error). Example: `#D33163` → hue 8, chroma 0.198 → `hue=8&chroma=0.198`.
+   - Nothing given   → `archetype=devalok`
 2. Fetch GET https://shilp-sutra.devalok.in/themer/result.json?<params>
    Response: { archetype, density, shape, motion, hue, chroma, css, pasteAfter, pasteLocation, doNotPasteInside }
-3. Paste the response `css` field AFTER the line in `pasteAfter` in the project's global stylesheet. Not inside any `@layer`.
+   Sanity-check the echoed `hue`/`chroma` in the response match what you sent — if they came back null, your params didn't parse.
+3. Paste the response `css` field AFTER the line in `pasteAfter` in the project's global stylesheet. Not inside any `@layer`. Paste it verbatim, unmodified.
 4. If @devalok/shilp-sutra isn't installed, install it first per the matching install-<framework>.md recipe.
-5. Verify with a Button or Card on any page — radius + accent should match https://shilp-sutra.devalok.in/themer/result?<params>.
+5. Verify with a Button or Card on any page — radius + accent should match https://shilp-sutra.devalok.in/themer/result?<params>. If the accent DIDN'T change, the override was dropped at build: check the pasted block sits at the stylesheet top level (not inside `@layer`) and the build log has no CSS-parse warning near it.
 ````
 
 When the user has already been to the Themer, they may paste a *filled-in* version with the JSON URL pre-built — skip step 1, go straight to fetch.

--- a/apps/site/lib/themer-css.ts
+++ b/apps/site/lib/themer-css.ts
@@ -42,7 +42,7 @@ export function generateThemerCss(state: ThemerState): string {
     ` * Paste into your global stylesheet, AFTER the shilp-sutra import:`,
     ` *   @import "tailwindcss";`,
     ` *   @import "@devalok/shilp-sutra/css";`,
-    ` *   /* this block here */`,
+    ` *   ...then this block, right here`,
     ` */`,
   ]
     .filter(Boolean)

--- a/packages/mcp-server/scripts/smoke.mjs
+++ b/packages/mcp-server/scripts/smoke.mjs
@@ -131,6 +131,9 @@ try {
   const ver = await call('verify_setup', { globalsCss: '@import "@devalok/shilp-sutra/css";\n@import "tailwindcss";' }, 15)
   check('verify_setup catches CSS import order', (ver.result?.content?.[0]?.text ?? '').includes('CSS import order'))
 
+  const nest = await call('verify_setup', { globalsCss: '@import "tailwindcss";\n@import "@devalok/shilp-sutra/css";\n/* head /* nested */\n */\n:root{--color-accent-9:oklch(0.55 0.198 8)}' }, 16)
+  check('verify_setup catches nested CSS comment (dropped override)', (nest.result?.content?.[0]?.text ?? '').includes('nested'))
+
   // report_issue: without GITHUB_APP_* configured (as in smoke/local), it must
   // fail gracefully — a clear "not enabled" error, never a crash or a write.
   const rep = await call('report_issue', { category: 'bug', title: 'smoke test — should not file', body: 'smoke' }, 16)

--- a/packages/mcp-server/src/tools.mjs
+++ b/packages/mcp-server/src/tools.mjs
@@ -491,6 +491,22 @@ export async function detectFramework({ packageJson, hasAppDir, hasPagesDir, ver
 
 // ── verify_setup ───────────────────────────────────────────────────────────────
 
+// CSS comments do NOT nest: in `/* a /* b */ c */` the first `*/` closes the
+// comment and ` c */` becomes stray tokens that corrupt the following rule, which
+// the build then silently drops (warning only, exit 0). A pasted Themer block
+// whose header carries a nested comment loses its entire `:root{}` accent/radius
+// override this way — the brand color never applies. Flag it here.
+function hasNestedComment(css) {
+  let inComment = false
+  for (let i = 0; i < css.length - 1; i++) {
+    const two = css[i] + css[i + 1]
+    if (!inComment && two === '/*') { inComment = true; i++; continue }
+    if (inComment && two === '/*') return true // second open before the first close
+    if (inComment && two === '*/') { inComment = false; i++; continue }
+  }
+  return false
+}
+
 export async function verifySetup({ framework, globalsCss, nextConfig, imports = [], installedDeps, version }) {
   const d = await load(version)
   if (d.redirect) return d.redirect
@@ -510,6 +526,8 @@ export async function verifySetup({ framework, globalsCss, nextConfig, imports =
       if (twIdx < ssIdx) pass('CSS import order (tailwindcss before shilp-sutra)')
       else fail('CSS import order', '`@import "tailwindcss"` MUST come before `@import "@devalok/shilp-sutra/css"`, or no DS utilities generate.')
     }
+    if (hasNestedComment(css)) fail('CSS has no nested comments', 'A block in your CSS contains a nested `/* ... */` comment. CSS comments do not nest — the first `*/` closes early and the rule that follows (often your pasted accent/token override) is silently dropped at build, so the brand color never applies. Remove the inner comment.')
+    else pass('CSS comment hygiene')
   } else {
     checks.push({ check: 'CSS', status: 'skipped', note: 'Pass `globalsCss` to verify the two imports + order.' })
   }


### PR DESCRIPTION
## What & why

Found while dry-running the **shilp-sutra launch demo** (agent types brand color → UI recolors). The core premise was silently broken.

The Themer's `result.json` `css` field led with a header comment containing a **nested** `/* this block here */`. CSS comments don't nest → the inner `*/` closes the header early → the stray `*/` corrupts the `:root{}` block immediately after → **the entire accent ramp + radius override is dropped at build** (Lightning CSS warns, exits 0). The fetched brand color never applies.

**It was masked**: devalok's package-default accent is hue-8 pink ≈ `#D33163` (the demo color), so the UI *looked* correctly branded while the mechanism was dead. Any other color (e.g. teal) exposes it — i.e. every buildathon participant.

## Changes
- **`apps/site/lib/themer-css.ts`** — header no longer emits a nested comment (the fix). Fixes both `result.json` and the web-UI copy block (both render this).
- **`AGENTS.md`** — theming recipe now: converts hex→OKLCH (the endpoint has **no** `hex`/`color` param — passing one is silently ignored → default theme), sanity-checks the echoed `hue`/`chroma`, and verifies the accent actually changed.
- **`packages/mcp-server` `verify_setup`** — flags nested CSS comments so a dropped override is caught, not shipped silently (+ smoke assertion). Closes the gate hole that let the Jul-18 dogfood "validate" a broken flow.

## Verification (realistic, published `@0.49.5`)
Fresh Vite+React+TS app, real npm install, followed the shipped recipe + AGENTS contract:
- **Broken:** teal (hue 195) override **absent** from compiled CSS; `Unexpected token Colon` warning.
- **Fixed:** `--color-accent-9:oklch(55% .12 195)` **lands**, no warning. Build clean.
- mcp-server smoke: all checks pass incl. new nested-comment assertion.

## ⏱ Urgency
Launch reveal is **Jul 24 13:20 IST**. The demo records against the **live** endpoint, so `apps/site` needs to redeploy with this fix **before recording**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)