### PR TITLE
fix(audit): compiled-CSS regex mis-splits text-label-plain (unblocks 0.50.0 release)

### DIFF
--- a/scripts/audit-compiled-css.mjs
+++ b/scripts/audit-compiled-css.mjs
@@ -109,7 +109,10 @@ const MUST_EMIT = [
   /\bduration-(instant|fast-[0-9]+|moderate-[0-9a-z]+|slow-[0-9]+)\b/g,
   /\bease-(productive|expressive)-[a-z]+/g,
   /\bz-(base|raised|dropdown|sticky|overlay|modal|popover|toast|tooltip)\b/g,
-  /\b(text-heading|text-body|text-label|text-label-plain)-[a-z0-9]+/g,
+  // `text-label-plain` MUST precede `text-label`, and `text-label` carries a
+  // negative lookahead, so `text-label-plain[-tier]` isn't mis-split into a bare
+  // `text-label-plain` (which has no CSS) — e.g. from the tw-merge classGroup config.
+  /\b(text-heading|text-body|text-label-plain|text-label(?!-plain))-[a-z0-9]+/g,
   /\btext-(caption|overline|code)\b/g,
   /\bfocus-ring(?:-inset|-sm)?\b/g,
   /\btouch-target\b/g,


### PR DESCRIPTION
@
`release.yml` failed on **Compiled-CSS coverage**: the ramp-usage regex in `scripts/audit-compiled-css.mjs` matched `text-label` before `text-label-plain` (no lookahead), so `text-label-plain-md` — and the new tw-merge classGroup key `text-label-plain` (0.50.0) — got mis-extracted as a bare `text-label-plain`, which emits no CSS → false "missing class" failure.

Fix: order `text-label-plain` first + a `text-label(?!-plain)` lookahead. Verified: config string → no match; `text-label-plain-md` → matched; `text-label-sm` / `text-body-md` unaffected.

Integration was green because it built cached; the fresh release build surfaced it. Unblocks 0.50.0 (already merged, versions bumped, not yet published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@