### PR TITLE
feat(card): default variant is tonal (border-card hairline), not shadow

### DIFF
--- a/.changeset/card-default-tonal.md
+++ b/.changeset/card-default-tonal.md
@@ -1,0 +1,7 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Card `default` variant is now **tonal** — depth from a surface-tone shift plus a whisper `border-card` hairline, no drop shadow. Previously `default` led with `shadow-raised`. This aligns the base `Card` primitive with the tonal card-edge direction the rest of the DS adopted in 0.50.0 (Setu `tonal-elevation`: depth from tone, not a shadow).
+
+**Visual change, not an API change.** No props, types, DOM structure, or ARIA changed — a `<Card>` with no `variant` now renders with a tonal hairline instead of a shadow. Cards that want the old floated look should pass `variant="elevated"` (shadow, no border). `outline` (strong border) and `flat` (no edge) are unchanged. `StatCard` inherits this via its delegated `variant`.

--- a/packages/core/docs/components/ui/stat-card.md
+++ b/packages/core/docs/components/ui/stat-card.md
@@ -17,7 +17,7 @@
     comparisonLabel: string (shown after delta, e.g. "vs last month")
     secondaryLabel: string (below main value, e.g. "of $50,000 target")
     progress: number (0-100, renders thin progress bar below value)
-    variant: "default" | "elevated" | "outline" | "flat" (default = ring-in-shadow, no border; elevated = stronger shadow; outline = border, no shadow; flat = filled, no edge) — delegated to Card
+    variant: "default" | "elevated" | "outline" | "flat" (default = tonal border-card hairline, no shadow; elevated = shadow, no border; outline = strong border, no shadow; flat = filled, no edge) — delegated to Card
     size: "sm" | "md" (default) | "lg" — delegated to Card's size axis; sm tightens padding to 16px and steps the value down to text-ds-2xl (use for dense KPI rows / narrow stat grids)
     accentStyle: "none" | "icon" | "tint" (none [default]; icon = accent chip around icon; tint = accent surface wash + accent value)
     iconFill: "soft" | "solid" (chip style when accentStyle="icon"; default soft)

--- a/packages/core/make-kit/components/card.md
+++ b/packages/core/make-kit/components/card.md
@@ -22,15 +22,15 @@ import {
 - Header / actions / footer are built in as slots (`CardHeader`, `CardAction`, `CardFooter`) — don't reach for a wrapper. (`<ContentCard>` is deprecated; use Card slots.)
 - Need just a tinted region with no card affordance? Use a `<div className="bg-surface-raised">` (rare; usually Card is right).
 
-Card renders on `surface-raised` with `shadow-raised`. **Never** override its background or border.
+Card renders on `surface-raised`. The `default` variant is tonal — a surface-tone shift plus a whisper hairline (`border-card`), no shadow. **Never** override its background or border.
 
 ## Variants
 
 | Variant | Use |
 |---|---|
-| `default` (default) | `surface-raised` + `shadow-raised`. Standard card. |
-| `elevated` | Slightly stronger shadow. Use for hero / hovered emphasis. |
-| `outline` | `surface-raised` + border-only (no shadow). Dense lists where 12 cards stacked together would feel too lifted. |
+| `default` (default) | `surface-raised` + tonal `border-card` hairline, no shadow. Standard card — depth from tone, not a drop shadow. |
+| `elevated` | `shadow-raised-hover`, no border. Use when a card must visibly pop (hero, dragged tile, spotlight panel). |
+| `outline` | `surface-raised` + strong border-only (no shadow). Dense lists where stacked shadowed cards would feel too lifted. |
 | `flat` | `surface-raised` + no shadow, no border. For cards inside an already-elevated container. |
 
 ## Colors

--- a/packages/core/src/ui/card.tsx
+++ b/packages/core/src/ui/card.tsx
@@ -26,12 +26,16 @@ const cardVariants = cva(
   {
     variants: {
       variant: {
+        // Tonal (default): depth from a surface-tone shift + a whisper hairline in the
+        // surface's own colour (`border-card`), NO shadow — the DS-wide anti-slop edge
+        // (Setu tonal-elevation). The `color` prop overrides the hairline colour to paint
+        // a deliberate accent/status edge.
+        default: 'bg-surface-raised border border-card shadow-none',
         // Elevation-led: the shadow's own ring is the edge (make-kit rule #6 — no
-        // border+shadow double-edge). border-transparent keeps the `color` prop able to
-        // paint a deliberate colored edge without a grey one by default.
-        default: 'bg-surface-raised border border-transparent shadow-raised',
+        // border+shadow double-edge). Reach for it when a card should visibly pop
+        // (a dragged tile, a spotlight panel). border-transparent keeps `color` paintable.
         elevated: 'bg-surface-raised border border-transparent shadow-raised-hover',
-        // Border-led: a visible edge, no shadow.
+        // Border-led, strong: a firmly visible edge, no shadow.
         outline: 'bg-transparent border border-surface-border-strong shadow-none',
         flat: 'bg-surface-raised border-none shadow-none',
       },
@@ -67,10 +71,11 @@ const cardVariants = cva(
  * Props for Card — a general-purpose content container with 4 elevation/style variants and
  * an optional interactive hover state.
  *
- * **Variants (elevation-led vs border-led — never both):** `default` (ring-in-shadow, no border) |
- * `elevated` (stronger shadow-raised-hover, no border) | `outline` (visible border, no shadow) |
- * `flat` (filled background, no edge). The shadow tokens carry their own 1px ring, so elevated
- * variants need no explicit border (make-kit rule #6).
+ * **Variants (tonal, elevation-led, or border-led — never border+shadow together):** `default`
+ * (tonal — surface shift + `border-card` hairline, no shadow) | `elevated` (shadow-raised-hover,
+ * no border — use when a card should visibly pop) | `outline` (strong visible border, no shadow) |
+ * `flat` (filled background, no edge). The shadow tokens carry their own 1px ring, so `elevated`
+ * needs no explicit border (make-kit rule #6).
  *
  * **Composition:** Use sub-components `<CardHeader>`, `<CardTitle>`, `<CardDescription>`,
  * `<CardContent>`, and `<CardFooter>` for consistent internal spacing. Text content must live

--- a/packages/core/src/ui/stat-card.tsx
+++ b/packages/core/src/ui/stat-card.tsx
@@ -20,8 +20,8 @@ import { type FlashPreset, type FlashSpec, type FlashSpeed,StatFlash } from './s
  * Props for StatCard — a dashboard metric tile displaying a label, a large numeric value,
  * an optional trend delta (with directional arrow icon), and an optional header icon.
  *
- * **Surface:** delegated to `Card` via `variant` — `default` (ring-in-shadow, no border) |
- * `elevated` | `outline` (border, no shadow) | `flat`. StatCard composes `<Card>`, so the surface,
+ * **Surface:** delegated to `Card` via `variant` — `default` (tonal hairline, no shadow) |
+ * `elevated` (shadow) | `outline` (strong border, no shadow) | `flat`. StatCard composes `<Card>`, so the surface,
  * padding (gap model), and elevation all live in one place.
  *
  * **Accent:** `accentStyle="none"` (default) is neutral; `"icon"` wraps `icon` in an accent chip
@@ -88,7 +88,7 @@ export interface StatCardProps extends Omit<React.HTMLAttributes<HTMLDivElement>
   secondaryLabel?: string
   /** Progress toward a target (0-100). Renders a thin progress bar below the value. */
   progress?: number
-  /** Surface variant, delegated to Card: `default` (ring-in-shadow) | `elevated` | `outline` (border, no shadow) | `flat`. @default 'default' */
+  /** Surface variant, delegated to Card: `default` (tonal hairline, no shadow) | `elevated` (shadow) | `outline` (strong border, no shadow) | `flat`. @default 'default' */
   variant?: 'default' | 'elevated' | 'outline' | 'flat'
   /**
    * Tile density, delegated to Card's size axis. `sm` tightens padding to 16px and steps


### PR DESCRIPTION
## What

The base `Card` `default` variant now uses the **tonal** card edge — a surface-tone shift + a whisper `border-card` hairline, **no drop shadow**. Previously it led with `shadow-raised`.

## Why

0.50.0's anti-slop sweep moved DS panels to the tonal edge (depth from tone, per Setu `tonal-elevation`), but the base primitive's `default` still reached for the shadow — the `default-shadow` reflex Setu flags. This was finding #1 of the whole-DS audit. Aligns the primitive with where the system already went.

## Variant ladder after this

| variant | edge |
|---|---|
| `default` | tonal `border-card` hairline, no shadow |
| `elevated` | `shadow-raised-hover`, no border — the "pop" |
| `outline` | strong border, no shadow |
| `flat` | none |

## Scope

- **Visual change only** — no props, types, DOM structure, or ARIA changed. A `<Card>` with no `variant` renders tonal instead of shadowed. Old floated look → `variant="elevated"`.
- `StatCard` inherits via delegated `variant`.
- Docs in sync: `card.tsx` + `stat-card.tsx` JSDoc, make-kit `card.md`, generated component docs.

## Gates (local)

typecheck ✅ · lint ✅ · lint:props (130 types) ✅ · Card+StatCard tests (49) ✅ · check-slop DS-wide (0) ✅

Changeset: **minor**. `visual-review` label set so Chromatic captures the shadow→tonal diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
