### PR TITLE
feat(install): auto-discover the docs MCP via a project .mcp.json

### DIFF
--- a/.changeset/mcp-auto-discovery.md
+++ b/.changeset/mcp-auto-discovery.md
@@ -1,0 +1,11 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Auto-discover the docs MCP on install.
+
+On install the package now writes a project-scoped `.mcp.json` declaring the hosted docs MCP (`https://shilp-sutra.devalok.in/mcp`), so an AI coding agent (Claude Code / Cursor / Codex) discovers it right after `install` and the client prompts to approve it — no manual wiring. The write runs even on piped / non-TTY installs (exactly when an agent runs the install), unlike the human-facing welcome banner.
+
+Safety: additive merge (never clobbers other servers or an existing `shilp-sutra` entry), skips CI and dev installs, write-once via sentinel (a user who deletes `.mcp.json` is not re-nagged), never throws, and opt-out via `SHILP_SUTRA_NO_MCP=1` (or the existing `SHILP_SUTRA_NO_WELCOME=1`).
+
+`AGENTS.md` also now gives the one-line manual wire — `claude mcp add --transport http shilp-sutra https://shilp-sutra.devalok.in/mcp` — for agents that read the docs instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ If you are a human, read [README.md](./README.md) instead.
 
 ## How to get details, in priority order
 
-1. **shilp-sutra MCP** — version-exact answers as JSON, cheapest on context. Hosted at `https://shilp-sutra.devalok.in/mcp` (connect it if it isn't already; it beats reading the frozen docs in `node_modules`). The tool surface is listed under "MCP tools" below. Always pass the consumer's installed version (from `node_modules/@devalok/shilp-sutra/package.json`) as `version`.
+1. **shilp-sutra MCP** — version-exact answers as JSON, cheapest on context. Hosted at `https://shilp-sutra.devalok.in/mcp`. On install the package writes a project-scoped `.mcp.json` declaring this server, so your client (Claude Code / Cursor / Codex) should prompt you to approve it — approve it. If it is not wired yet, add it in one command: `claude mcp add --transport http shilp-sutra https://shilp-sutra.devalok.in/mcp` (or the equivalent in your agent). It beats reading the frozen docs in `node_modules`. The tool surface is listed under "MCP tools" below. Always pass the consumer's installed version (from `node_modules/@devalok/shilp-sutra/package.json`) as `version`.
 2. **`packages/core/llms.txt`** — the ~3K-token router: what exists + where to get detail. Load this by default; it is deliberately tiny.
 3. **`packages/core/docs/components/<tier>/<name>.md`** — single-component doc (~3K tokens: props, examples, composability, gotchas). Read ONLY the components you're using — never bulk-read the directory or concatenate these.
 4. **`packages/core/mcp-manifest.json`** — everything machine-readable (props, tokens, composition; react-docgen shape). Prefer targeted reads over prose when you need structured data without the MCP.

--- a/packages/core/scripts/welcome.mjs
+++ b/packages/core/scripts/welcome.mjs
@@ -183,7 +183,7 @@ function buildFullBanner(version, prevVersion) {
   lines.push(row(`     ${colour('https://shilp-sutra.devalok.in/themer', DIM)}`))
   lines.push(colour(EMPTY, PINK_DIM))
   lines.push(row(`   ${colour('▸', PINK)} Wire your AI agent (Claude Code / Cursor / Codex):`))
-  lines.push(row(`     ${colour('connect the live docs MCP → https://shilp-sutra.devalok.in/mcp', DIM)}`))
+  lines.push(row(`     ${colour('live docs MCP added to .mcp.json — approve it to enable', DIM)}`))
   lines.push(row(`     ${colour('(version-exact setup + peer preflight; beats guessing)', DIM)}`))
   lines.push(row(`     ${colour('or copy the skill: cp -r node_modules/@devalok/shilp-sutra/skill \\', DIM)}`))
   lines.push(row(`        ${colour('~/.claude/skills/shilp-sutra', DIM)}`))
@@ -215,6 +215,59 @@ function buildCompactBanner(version, prevVersion) {
   ].join('\n')
 }
 
+// ── MCP auto-discovery ───────────────────────────────────────────────────────
+// Write a project-scoped `.mcp.json` pointing at the hosted docs MCP so an AI
+// coding agent DISCOVERS it right after install. This runs even when stdout is
+// piped (unlike the banner) — a config file is not console noise, and the agent
+// that just ran `install` is exactly who should find it. It is never silent-
+// forced: Claude Code (and peers) still PROMPT the user to approve a project
+// MCP server before enabling it. Safety: additive merge (never clobbers other
+// servers or an existing shilp-sutra entry), skips CI and dev installs, honours
+// opt-out, and a write-once sentinel so a user who deletes it is not re-nagged.
+const SEP = process.platform === 'win32' ? '\\' : '/'
+const MCP_URL = 'https://shilp-sutra.devalok.in/mcp'
+
+function tryWriteMcpConfig() {
+  try {
+    if (process.env.SHILP_SUTRA_NO_WELCOME === '1' || process.env.SHILP_SUTRA_NO_WELCOME === 'true') return
+    if (process.env.SHILP_SUTRA_NO_MCP === '1' || process.env.SHILP_SUTRA_NO_MCP === 'true') return
+    if (process.env.CI) return // writing agent config into a CI checkout is pointless/unwanted
+
+    const initCwd = process.env.INIT_CWD
+    const cwd = process.cwd()
+    const isInsideNodeModules = cwd.includes(`${SEP}node_modules${SEP}`) || cwd.includes('/node_modules/')
+    if (!isInsideNodeModules) return // dev install inside the DS repo itself
+    if (!initCwd || initCwd === cwd) return // no consumer root → unusual context
+
+    // Write-once-ever sentinel (survives re-installs; respects user deletion of .mcp.json)
+    const parts = PKG_DIR.split(/[/\\]/)
+    const nmIdx = parts.lastIndexOf('node_modules')
+    const sentinel = nmIdx === -1 ? null : join(parts.slice(0, nmIdx + 1).join(SEP), '.shilp-sutra-mcp-written')
+    if (sentinel && existsSync(sentinel)) return
+
+    const target = join(initCwd, '.mcp.json')
+    let config = { mcpServers: {} }
+    if (existsSync(target)) {
+      try {
+        config = JSON.parse(readFileSync(target, 'utf-8'))
+      } catch {
+        return // existing but unparseable — never clobber a hand-authored config
+      }
+      if (!config || typeof config !== 'object') return
+      if (!config.mcpServers || typeof config.mcpServers !== 'object') config.mcpServers = {}
+      if (config.mcpServers['shilp-sutra']) {
+        if (sentinel) writeFileSync(sentinel, MCP_URL + '\n')
+        return // already declared — leave the consumer's version untouched
+      }
+    }
+    config.mcpServers['shilp-sutra'] = { type: 'http', url: MCP_URL }
+    writeFileSync(target, JSON.stringify(config, null, 2) + '\n')
+    if (sentinel) writeFileSync(sentinel, MCP_URL + '\n')
+  } catch {
+    // Never break the consumer install — a failed config write is a no-op.
+  }
+}
+
 // ── Main ────────────────────────────────────────────────────────────────────
 function main() {
   // --preview / --compact bypass all guards. Used by maintainers + by the
@@ -222,6 +275,11 @@ function main() {
   // shipping a broken one. Compose only — never writes the sentinel.
   const preview = process.argv.includes('--preview')
   const forceCompact = process.argv.includes('--compact')
+
+  // MCP auto-discovery runs regardless of TTY — an agent-run (piped) install is
+  // precisely when the agent should discover the docs MCP. Must come before the
+  // TTY skip below, which only governs the human-facing banner.
+  if (!preview) tryWriteMcpConfig()
 
   if (!preview) {
     const skipReason = shouldSkip()


### PR DESCRIPTION
## Why
Founder ask: when someone installs shilp-sutra and tells their agent to use it, the agent should **genuinely auto-discover + use the hosted docs MCP** — not require the user to pre-wire it (that's faking it). Today it can't: the welcome banner is `isTTY`-gated OFF for piped/agent installs (the exact audience), AGENTS.md only says "connect it if it isn't already" with no command, and nothing machine-actionable is written.

## What
- **`welcome.mjs` writes a project `.mcp.json`** on install declaring the hosted MCP (`…/mcp`). Runs even on non-TTY/piped installs (a config artifact isn't console noise). Claude Code / Cursor / Codex then detect it and **prompt the user to approve** — real discovery, with consent, no silent force.
  - Safety: additive merge (never clobbers other servers or an existing `shilp-sutra` entry), skips CI + dev installs, **write-once sentinel** (deleting `.mcp.json` is respected, no re-nag), never throws, opt-out `SHILP_SUTRA_NO_MCP=1` / `SHILP_SUTRA_NO_WELCOME=1`.
- **AGENTS.md** now gives the one-line manual wire: `claude mcp add --transport http shilp-sutra https://shilp-sutra.devalok.in/mcp`.
- Banner line updated to say the MCP was added to `.mcp.json` — approve to enable.

## Verified locally
Simulated consumer installs (temp `node_modules` + `INIT_CWD`):
- fresh → writes correct `.mcp.json` ✅
- existing config with another server → **merges**, preserves it ✅
- re-run after user deletes the file → **no re-write** (sentinel) ✅
- `SHILP_SUTRA_NO_MCP=1` → no write ✅
- banner still renders; `--preview` writes nothing ✅

## Still needs live verification
Whether the target client picks up a **mid-session** `.mcp.json` or needs a reload/next-start to show the approve prompt — verify in a real Claude Code session before relying on it on camera.

## Note
Writing agent config into every consumer project is mildly opinionated; it's gated behind the client's own approval + opt-out. Worth a follow-up line in the troubleshoot recipe so consumers who spot a new `.mcp.json` know why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)