### PR TITLE
feat(segmented-control): rebuild visuals + motion, add value/fullWidth API, a11y

### DIFF
--- a/.changeset/segmented-control-rebuild.md
+++ b/.changeset/segmented-control-rebuild.md
@@ -1,0 +1,19 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+**SegmentedControl visual rebuild.** Reconstructed to match the modern segmented-control pattern (iOS / shadcn / Radix), fixing the muddy "edge-soup" look (a bordered + inset-shadowed track under a ring-carrying pill thumb).
+
+- **Rounded-rect, not full pill** — track `rounded-ds-lg`, thumb `rounded-ds-md` (inner radius sits tighter inside the track).
+- **Single edge treatment** — track is a translucent recess (`--color-segment-track`) with no border and no inset shadow; the thumb defines its own edge with one ring-less soft shadow (`--shadow-segment`). New tokens added to `semantic.css`.
+- **Dark-mode fix** — elevation inverts in dark (faint lighter track fill), so the groove reads on near-black surfaces where a "sunken" darker track vanished.
+- **`fullWidth` prop (new)** — segments split the container equally instead of hugging content; use for full-width toggles and view switchers.
+- **Motion** — crisp bounce-free thumb glide (~300ms, reduced-motion aware) plus a `motion-safe` press-scale on each segment for tactile feedback.
+- **Canonical controlled/uncontrolled API (new)** — `value` / `defaultValue` / `onValueChange`, matching Tabs/ToggleGroup. Uncontrolled mode works with `defaultValue` (falls back to the first option).
+- **44px touch targets** — each segment now meets the WCAG touch minimum (`touch-target`) while keeping its dense visual height.
+- **Option `text` widened `string` → `ReactNode`** and made optional — segments can hold a count badge/custom node, or be icon-only.
+- **Icon-only segments** — set `ariaLabel` per option for the accessible name when `text` is omitted.
+- **RTL** — Arrow-key navigation tracks reading order (ArrowLeft → next, ArrowRight → previous) in a right-to-left context.
+- **Deprecated aliases** — `variant="default"` → `"soft"`, `selectedId` → `value`, `onSelect` → `onValueChange`. All old names still accepted at runtime; update call sites (removed in a future major).
+
+New tokens: `--color-segment-track`, `--color-segment-thumb`, `--shadow-segment`.

--- a/apps/site/components/aurora-playground.tsx
+++ b/apps/site/components/aurora-playground.tsx
@@ -251,32 +251,32 @@ export function AuroraPlayground() {
             <SegmentedControl
               size="sm"
               options={INTENSITY_OPTIONS}
-              selectedId={s.intensity}
-              onSelect={(id) => update('intensity', id as AuroraIntensity)}
+              value={s.intensity}
+              onValueChange={(id) => update('intensity', id as AuroraIntensity)}
             />
           </ControlRow>
           <ControlRow label="Shape">
             <SegmentedControl
               size="sm"
               options={SHAPE_OPTIONS}
-              selectedId={s.shape}
-              onSelect={(id) => update('shape', id as AuroraShape)}
+              value={s.shape}
+              onValueChange={(id) => update('shape', id as AuroraShape)}
             />
           </ControlRow>
           <ControlRow label="Position">
             <SegmentedControl
               size="sm"
               options={POSITION_OPTIONS}
-              selectedId={s.position}
-              onSelect={(id) => update('position', id as AuroraPosition)}
+              value={s.position}
+              onValueChange={(id) => update('position', id as AuroraPosition)}
             />
           </ControlRow>
           <ControlRow label="Layers">
             <SegmentedControl
               size="sm"
               options={LAYER_OPTIONS}
-              selectedId={String(s.layers)}
-              onSelect={(id) => update('layers', Number(id) as AuroraLayers)}
+              value={String(s.layers)}
+              onValueChange={(id) => update('layers', Number(id) as AuroraLayers)}
             />
           </ControlRow>
           <ControlRow label={`Speed · ${s.speed.toFixed(2)}`}>
@@ -292,16 +292,16 @@ export function AuroraPlayground() {
             <SegmentedControl
               size="sm"
               options={PARALLAX_OPTIONS}
-              selectedId={s.parallax}
-              onSelect={(id) => update('parallax', id as AuroraParallax)}
+              value={s.parallax}
+              onValueChange={(id) => update('parallax', id as AuroraParallax)}
             />
           </ControlRow>
           <ControlRow label="Grain">
             <SegmentedControl
               size="sm"
               options={GRAIN_OPTIONS}
-              selectedId={s.grain}
-              onSelect={(id) => update('grain', id as AuroraGrain)}
+              value={s.grain}
+              onValueChange={(id) => update('grain', id as AuroraGrain)}
             />
           </ControlRow>
 

--- a/packages/core/docs/components/ui/segmented-control.md
+++ b/packages/core/docs/components/ui/segmented-control.md
@@ -6,32 +6,37 @@
 
 ## Props
     size: "sm" | "md" | "lg"
-    variant: "default" | "solid"
+    variant: "soft" | "solid"
     options: SegmentedControlOption[] (REQUIRED)
-    selectedId: string (REQUIRED)
-    onSelect: (id: string) => void (REQUIRED)
+    value: string                          // controlled
+    defaultValue: string                   // uncontrolled initial
+    onValueChange: (id: string) => void
     disabled: boolean
+    fullWidth: boolean
+    selectedId: string                     // @deprecated — use value
+    onSelect: (id: string) => void         // @deprecated — use onValueChange
 
 ## Types
-    SegmentedControlOption = { id: string, text: string, icon?: ComponentType<{ className?: string }> }
+    SegmentedControlOption = { id: string, text?: React.ReactNode, icon?: IconInput, ariaLabel?: string }
     SegmentedControlSize = 'sm' | 'md' | 'lg'
-    SegmentedControlVariant = 'default' | 'solid'
+    SegmentedControlVariant = 'soft' | 'solid'
 
 ## Defaults
     size: "md"
-    variant: "default"
+    variant: "soft"
+    fullWidth: false
 
 ## Example
 ```jsx
 <SegmentedControl
   size="md"
-  variant="default"
+  variant="soft"
   options={[
     { id: 'list', text: 'List' },
     { id: 'grid', text: 'Grid' },
   ]}
-  selectedId={viewMode}
-  onSelect={setViewMode}
+  value={viewMode}
+  onValueChange={setViewMode}
 />
 ```
 
@@ -39,15 +44,30 @@
 - **Data-driven, not compound** — unlike Tabs/ToggleGroup, SegmentedControl takes an `options` array rather than children. This makes it easier to render from a list but harder to customize per-option styling; use Tabs if you need compound children.
 - **When to use vs Tabs:** SegmentedControl is for mutually-exclusive VIEW-MODE toggles (List/Grid/Kanban) — short labels, no associated content panel. Tabs is for content switching where each tab has a corresponding TabsContent. SegmentedControl renders `role="radiogroup"` with `role="radio"` segments (a panel-less single-select); Tabs renders `role="tablist"`.
 - **Option icons** auto-size based on the `size` prop — don't set explicit icon sizes.
-- Fully controlled — there's no `defaultSelectedId`. Manage state in parent.
+- **`fullWidth`** switches segments from content-hug (default) to equal-fill: each segment takes an equal share of the container (a 2-item toggle splits 50/50, a 3-item switcher gives each a third). Use for view switchers and toolbar toggles that should fill their column; leave off for compact inline toolbars.
+- **Visual model:** a rounded-rect track (not a full pill) — a translucent recessed groove with a single soft-shadowed sliding thumb. The track has no border/inset shadow; the thumb carries the only edge. Elevation inverts in dark so the groove stays visible.
+- **Controlled or uncontrolled** — pass `value` + `onValueChange` to control it, or `defaultValue` (optional; falls back to the first option) to let it own state. Matches the Tabs/ToggleGroup vocabulary. `selectedId`/`onSelect` are deprecated aliases that still work.
+- **Option labels accept `ReactNode`** — a segment can hold a count badge or custom node, not just a string. `text` is optional: omit it for an **icon-only** segment and set `ariaLabel` so the segment still has an accessible name.
+- **Touch targets** — each segment has a 44px minimum hit area (via `touch-target`) even though the visual height stays dense.
+- **RTL** — Arrow-key navigation tracks reading order: in a right-to-left context `ArrowLeft` moves to the next option and `ArrowRight` to the previous (detected from the nearest `dir` attribute).
 - Built from scratch (no Radix primitive) — standard HTML buttons with `role="radio"` + `aria-checked` and roving tabindex.
 
 ## Gotchas
-- Controlled only — selectedId + onSelect are required
+- Controlled (`value`) or uncontrolled (`defaultValue`) — `selectedId`/`onSelect` are deprecated aliases
 - Uses data-driven API (options prop), not compound children
 - Use Tabs (not SegmentedControl) when you need associated content panels per option
 
 ## Changes
+### v0.52.0
+- **Changed** Visual rebuild — rounded-rect track (was full pill), translucent recessed track with no border/inset, single ring-less soft-shadow thumb. Dark-mode elevation inverts so the groove stays visible. New tokens: `--color-segment-track`, `--color-segment-thumb`, `--shadow-segment`.
+- **Added** `value` / `defaultValue` / `onValueChange` — canonical controlled+uncontrolled API (aligns with Tabs/ToggleGroup).
+- **Added** `fullWidth` prop — segments split the container equally.
+- **Added** 44px minimum touch targets (`touch-target`), keeping dense visual height.
+- **Added** Crisp bounce-free thumb motion (reduced-motion aware) + `motion-safe` press-scale feedback.
+- **Changed** Option `text` widened from `string` to `ReactNode`, and made optional (omit for icon-only segments).
+- **Added** `ariaLabel` per option for icon-only segments; RTL-aware Arrow-key navigation.
+- **Deprecated** `variant="default"` → `variant="soft"`; `selectedId` → `value`; `onSelect` → `onValueChange`. All old names still accepted as aliases; update call sites.
+
 ### v0.38.0
 - **Removed** (BREAKING) deprecated `variant="accent"` alias. Use `variant="solid"`.
 

--- a/packages/core/src/tokens/semantic.css
+++ b/packages/core/src/tokens/semantic.css
@@ -188,6 +188,14 @@
   --color-surface-border-card:   color-mix(in oklch, var(--neutral-5) 30%, transparent);
   --color-backdrop:              oklch(0 0 0 / 0.4);
 
+  /* Segmented control — translucent recess + raised thumb. Alpha, NOT a fixed
+     neutral tier: the track must read as a groove on ANY parent (page, card,
+     chrome), and a fixed lightness loses contrast against an unknown surface.
+     Elevation inverts in dark (see .dark override): recess in light, faint
+     lift in dark, thumb always a step toward the foreground. */
+  --color-segment-track: color-mix(in oklch, var(--neutral-12) 6%, transparent);
+  --color-segment-thumb: var(--neutral-1);
+
   /* Overlay + disabled — promoted from internal :root into @theme so
      `bg-overlay`, `text-overlay`, `bg-disabled`, `text-disabled` emit. */
   --color-overlay:  oklch(0 0 0 / 0.50);
@@ -374,8 +382,10 @@
      --radius-overlay-sm    rounded-overlay-sm    Tooltip, Toast
      --radius-overlay       rounded-overlay       Popover, HoverCard, DropdownMenu / ContextMenu / Menubar content, listboxes, NavigationMenu viewport
      --radius-overlay-lg    rounded-overlay-lg    Dialog, AlertDialog, Sheet, BottomSheet, ColorInput picker
-     --radius-pill          rounded-pill          Badge, Dot, Radio, Switch, Slider, Progress, Avatar circle, SegmentedControl item
+     --radius-pill          rounded-pill          Badge, Dot, Radio, Switch, Slider, Progress, Avatar circle
      --radius-bubble        rounded-bubble        ChatMessage bubble
+     (SegmentedControl is a rounded-RECT, not a pill: track rounded-ds-lg,
+      thumb rounded-ds-md — thumb inner radius sits tighter inside the track.)
      ─────────────────────────────────────────────────────────── */
   --radius-control:        6px;
   --radius-control-inner:  2px;
@@ -418,6 +428,10 @@
      ─────────────────────────────────────────────────────────── */
   --shadow-raised:       var(--shadow-xs-internal);
   --shadow-raised-hover: var(--shadow-sm-internal);
+  /* Segmented-control thumb — soft float, deliberately RING-LESS (the track
+     carries no border/inset, so the thumb defines its own edge with shadow
+     alone). Uses --shadow-color/strength so it deepens in dark (strength 2.5). */
+  --shadow-segment:      0 1px 2px -0.5px oklch(var(--shadow-color) / calc(0.10 * var(--shadow-strength))), 0 3px 8px -2px oklch(var(--shadow-color) / calc(0.09 * var(--shadow-strength)));
   --shadow-floating:     var(--shadow-md-internal);
   --shadow-overlay:      var(--shadow-lg-internal);
 
@@ -600,6 +614,11 @@
   /* Card edge in dark: a hair stronger so it still reads on the near-black base. */
   --color-surface-border-card:   color-mix(in oklch, var(--neutral-6) 45%, transparent);
   --color-backdrop:              oklch(0 0 0 / 0.6);
+
+  /* Segmented control — inverted elevation in dark: track is a faint LIGHTER
+     fill (can't go darker than a near-black page), thumb steps lighter still. */
+  --color-segment-track: color-mix(in oklch, oklch(1 0 0) 7%, transparent);
+  --color-segment-thumb: var(--neutral-3);
 
   /* Overlay */
   --color-overlay: oklch(0 0 0 / 0.70);

--- a/packages/core/src/ui/segmented-control.stories.tsx
+++ b/packages/core/src/ui/segmented-control.stories.tsx
@@ -34,6 +34,12 @@ const twoOptions: SegmentedControlOption[] = [
   { id: 'archived', text: 'Archived' },
 ]
 
+const iconOnlyOptions: SegmentedControlOption[] = [
+  { id: 'board', icon: IconLayoutGrid, ariaLabel: 'Board' },
+  { id: 'list', icon: IconList, ariaLabel: 'List' },
+  { id: 'calendar', icon: IconCalendar, ariaLabel: 'Calendar' },
+]
+
 // -- Meta ----
 
 const meta: Meta<typeof SegmentedControl> = {
@@ -50,12 +56,15 @@ const meta: Meta<typeof SegmentedControl> = {
     },
     variant: {
       control: 'select',
-      options: ['default', 'solid', 'accent'],
+      options: ['soft', 'solid'],
+    },
+    fullWidth: {
+      control: 'boolean',
     },
     disabled: {
       control: 'boolean',
     },
-    onSelect: { action: 'onSelect' },
+    onValueChange: { action: 'onValueChange' },
   },
 }
 export default meta
@@ -65,15 +74,17 @@ type Story = StoryObj<typeof SegmentedControl>
 
 function ControlledDemo({
   size = 'md',
-  variant = 'default',
+  variant = 'soft',
   options = textOptions,
   disabled = false,
+  fullWidth = false,
   defaultId,
 }: {
   size?: SegmentedControlSize
   variant?: SegmentedControlVariant
   options?: SegmentedControlOption[]
   disabled?: boolean
+  fullWidth?: boolean
   defaultId?: string
 }) {
   const [selectedId, setSelectedId] = useState(defaultId ?? options[0].id)
@@ -83,9 +94,10 @@ function ControlledDemo({
       size={size}
       variant={variant}
       options={options}
-      selectedId={selectedId}
-      onSelect={setSelectedId}
+      value={selectedId}
+      onValueChange={setSelectedId}
       disabled={disabled}
+      fullWidth={fullWidth}
     />
   )
 }
@@ -95,9 +107,9 @@ function ControlledDemo({
 export const Default: Story = {
   args: {
     size: 'md',
-    variant: 'default',
+    variant: 'soft',
     options: textOptions,
-    selectedId: 'board',
+    value: 'board',
   },
 }
 
@@ -106,7 +118,7 @@ export const Solid: Story = {
     size: 'md',
     variant: 'solid',
     options: textOptions,
-    selectedId: 'board',
+    value: 'board',
   },
 }
 
@@ -115,7 +127,7 @@ export const Small: Story = {
     size: 'sm',
     variant: 'solid',
     options: textOptions,
-    selectedId: 'list',
+    value: 'list',
   },
 }
 
@@ -124,7 +136,7 @@ export const Large: Story = {
     size: 'lg',
     variant: 'solid',
     options: textOptions,
-    selectedId: 'calendar',
+    value: 'calendar',
   },
 }
 
@@ -133,16 +145,16 @@ export const WithIcons: Story = {
     size: 'md',
     variant: 'solid',
     options: iconOptions,
-    selectedId: 'board',
+    value: 'board',
   },
 }
 
 export const WithIconsDefault: Story = {
   args: {
     size: 'md',
-    variant: 'default',
+    variant: 'soft',
     options: iconOptions,
-    selectedId: 'list',
+    value: 'list',
   },
 }
 
@@ -151,7 +163,7 @@ export const MixedIconsAndText: Story = {
     size: 'md',
     variant: 'solid',
     options: mixedOptions,
-    selectedId: 'overview',
+    value: 'overview',
   },
 }
 
@@ -160,7 +172,52 @@ export const TwoOptions: Story = {
     size: 'md',
     variant: 'solid',
     options: twoOptions,
-    selectedId: 'active',
+    value: 'active',
+  },
+}
+
+export const FullWidth: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16, maxWidth: 360 }}>
+      <ControlledDemo variant="soft" options={textOptions} fullWidth />
+      <ControlledDemo variant="solid" options={twoOptions} fullWidth />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `fullWidth`, segments split the container equally instead of hugging their content — a 3-item switcher gives each a third, a 2-item toggle splits 50/50. Use for view switchers and toolbar toggles that should fill their column.',
+      },
+    },
+  },
+}
+
+export const IconOnly: Story = {
+  render: () => <ControlledDemo options={iconOnlyOptions} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only segments: omit `text` and set `ariaLabel` on each option so screen readers still announce a meaningful name.',
+      },
+    },
+  },
+}
+
+export const RTL: Story = {
+  render: () => (
+    <div dir="rtl">
+      <ControlledDemo options={iconOptions} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Right-to-left: Arrow keys track reading order (ArrowLeft moves to the next option, ArrowRight to the previous). The thumb slides accordingly.',
+      },
+    },
   },
 }
 
@@ -169,7 +226,7 @@ export const Disabled: Story = {
     size: 'md',
     variant: 'solid',
     options: textOptions,
-    selectedId: 'board',
+    value: 'board',
     disabled: true,
   },
 }
@@ -177,9 +234,9 @@ export const Disabled: Story = {
 export const DisabledDefault: Story = {
   args: {
     size: 'md',
-    variant: 'default',
+    variant: 'soft',
     options: iconOptions,
-    selectedId: 'list',
+    value: 'list',
     disabled: true,
   },
 }
@@ -231,15 +288,15 @@ export const AllSizes: Story = {
 export const AllVariants: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-      {/* Default variant */}
+      {/* Soft variant */}
       <div>
         <p className="mb-ds-04 text-ds-md font-accent font-semibold text-surface-fg">
-          Default
+          Soft
         </p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <ControlledDemo size="sm" variant="default" options={iconOptions} />
-          <ControlledDemo size="md" variant="default" options={iconOptions} />
-          <ControlledDemo size="lg" variant="default" options={iconOptions} />
+          <ControlledDemo size="sm" variant="soft" options={iconOptions} />
+          <ControlledDemo size="md" variant="soft" options={iconOptions} />
+          <ControlledDemo size="lg" variant="soft" options={iconOptions} />
         </div>
       </div>
 
@@ -262,7 +319,7 @@ export const AllVariants: Story = {
         </p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <ControlledDemo size="md" variant="solid" options={textOptions} />
-          <ControlledDemo size="md" variant="default" options={textOptions} />
+          <ControlledDemo size="md" variant="soft" options={textOptions} />
         </div>
       </div>
 
@@ -273,7 +330,7 @@ export const AllVariants: Story = {
         </p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <ControlledDemo size="md" variant="solid" options={iconOptions} disabled />
-          <ControlledDemo size="md" variant="default" options={iconOptions} disabled />
+          <ControlledDemo size="md" variant="soft" options={iconOptions} disabled />
         </div>
       </div>
     </div>

--- a/packages/core/src/ui/segmented-control.test.tsx
+++ b/packages/core/src/ui/segmented-control.test.tsx
@@ -15,13 +15,13 @@ const options: SegmentedControlOption[] = [
 describeConformance(
   'SegmentedControl',
   (props) => (
-    <SegmentedControl options={options} selectedId="a" onSelect={vi.fn()} {...props} />
+    <SegmentedControl options={options} value="a" onValueChange={vi.fn()} {...props} />
   ),
 )
 
 describe('SegmentedControl', () => {
   it('renders all options', () => {
-    render(<SegmentedControl options={options} selectedId="a" onSelect={() => {}} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} />)
     expect(screen.getByRole('radio', { name: 'Alpha' })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'Beta' })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: 'Gamma' })).toBeInTheDocument()
@@ -30,14 +30,14 @@ describe('SegmentedControl', () => {
   it('calls onSelect when an option is clicked', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} />)
 
     await user.click(screen.getByRole('radio', { name: 'Beta' }))
     expect(onSelect).toHaveBeenCalledWith('b')
   })
 
   it('marks the selected option with aria-checked (radio semantics)', () => {
-    render(<SegmentedControl options={options} selectedId="b" onSelect={() => {}} />)
+    render(<SegmentedControl options={options} value="b" onValueChange={() => {}} />)
     expect(screen.getByRole('radio', { name: 'Beta' })).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByRole('radio', { name: 'Alpha' })).toHaveAttribute('aria-checked', 'false')
     expect(screen.getByRole('radio', { name: 'Gamma' })).toHaveAttribute('aria-checked', 'false')
@@ -46,7 +46,7 @@ describe('SegmentedControl', () => {
   it('disabled prevents click interaction', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} disabled />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} disabled />)
 
     const tab = screen.getByRole('radio', { name: 'Beta' })
     expect(tab).toBeDisabled()
@@ -58,7 +58,7 @@ describe('SegmentedControl', () => {
   it('ArrowRight moves selection to next option', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} />)
 
     // Focus the selected tab then press ArrowRight
     screen.getByRole('radio', { name: 'Alpha' }).focus()
@@ -69,7 +69,7 @@ describe('SegmentedControl', () => {
   it('ArrowLeft wraps from first to last', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} />)
 
     screen.getByRole('radio', { name: 'Alpha' }).focus()
     await user.keyboard('{ArrowLeft}')
@@ -79,7 +79,7 @@ describe('SegmentedControl', () => {
   it('ArrowRight wraps from last to first', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="c" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="c" onValueChange={onSelect} />)
 
     screen.getByRole('radio', { name: 'Gamma' }).focus()
     await user.keyboard('{ArrowRight}')
@@ -89,7 +89,7 @@ describe('SegmentedControl', () => {
   it('Home moves selection to first option', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="c" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="c" onValueChange={onSelect} />)
 
     screen.getByRole('radio', { name: 'Gamma' }).focus()
     await user.keyboard('{Home}')
@@ -99,7 +99,7 @@ describe('SegmentedControl', () => {
   it('End moves selection to last option', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} />)
 
     screen.getByRole('radio', { name: 'Alpha' }).focus()
     await user.keyboard('{End}')
@@ -107,27 +107,64 @@ describe('SegmentedControl', () => {
   })
 
   it('has role="radiogroup" on the container', () => {
-    render(<SegmentedControl options={options} selectedId="a" onSelect={() => {}} />)
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} />)
     expect(screen.getByRole('radiogroup')).toBeInTheDocument()
   })
 
   it('selected radio has tabIndex=0, others have tabIndex=-1', () => {
-    render(<SegmentedControl options={options} selectedId="b" onSelect={() => {}} />)
+    render(<SegmentedControl options={options} value="b" onValueChange={() => {}} />)
     expect(screen.getByRole('radio', { name: 'Beta' })).toHaveAttribute('tabindex', '0')
     expect(screen.getByRole('radio', { name: 'Alpha' })).toHaveAttribute('tabindex', '-1')
     expect(screen.getByRole('radio', { name: 'Gamma' })).toHaveAttribute('tabindex', '-1')
   })
 
   it('variant="solid" applies accent selected text style', () => {
-    render(<SegmentedControl options={options} selectedId="a" onSelect={() => {}} variant="solid" />)
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} variant="solid" />)
     const tab = screen.getByRole('radio', { name: 'Alpha' })
     expect(tab.className).toContain('text-accent-fg')
   })
 
-  it('variant="default" applies default selected text style', () => {
-    render(<SegmentedControl options={options} selectedId="a" onSelect={() => {}} variant="default" />)
+  it('variant="soft" applies the surface-fg selected text style', () => {
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} variant="soft" />)
     const tab = screen.getByRole('radio', { name: 'Alpha' })
     expect(tab.className).toContain('text-surface-fg')
+  })
+
+  it('back-compat: variant="default" maps to soft', () => {
+    // @ts-expect-error 'default' is the deprecated alias, not in the public union
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} variant="default" />)
+    const tab = screen.getByRole('radio', { name: 'Alpha' })
+    expect(tab.className).toContain('text-surface-fg')
+  })
+
+  it('back-compat: selectedId + onSelect (deprecated) still work', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    // @ts-expect-error selectedId/onSelect are the deprecated alias props
+    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} />)
+    expect(screen.getByRole('radio', { name: 'Alpha' })).toHaveAttribute('aria-checked', 'true')
+    await user.click(screen.getByRole('radio', { name: 'Beta' }))
+    expect(onSelect).toHaveBeenCalledWith('b')
+  })
+
+  it('uncontrolled: defaultValue seeds selection and clicking updates it', async () => {
+    const user = userEvent.setup()
+    render(<SegmentedControl options={options} defaultValue="b" />)
+    expect(screen.getByRole('radio', { name: 'Beta' })).toHaveAttribute('aria-checked', 'true')
+    await user.click(screen.getByRole('radio', { name: 'Gamma' }))
+    expect(screen.getByRole('radio', { name: 'Gamma' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: 'Beta' })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('uncontrolled with no defaultValue selects the first option', () => {
+    render(<SegmentedControl options={options} />)
+    expect(screen.getByRole('radio', { name: 'Alpha' })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('fullWidth makes segments flex-fill the container', () => {
+    render(<SegmentedControl options={options} value="a" onValueChange={() => {}} fullWidth />)
+    expect(screen.getByRole('radiogroup').className).toContain('w-full')
+    expect(screen.getByRole('radio', { name: 'Alpha' }).className).toContain('flex-1')
   })
 
   it('renders option icon when provided', () => {
@@ -137,14 +174,14 @@ describe('SegmentedControl', () => {
     const optionsWithIcon: SegmentedControlOption[] = [
       { id: 'x', text: 'With Icon', icon: IconMock },
     ]
-    render(<SegmentedControl options={optionsWithIcon} selectedId="x" onSelect={() => {}} />)
+    render(<SegmentedControl options={optionsWithIcon} value="x" onValueChange={() => {}} />)
     expect(screen.getByTestId('test-icon')).toBeInTheDocument()
   })
 
   it('disabled prevents keyboard navigation', async () => {
     const user = userEvent.setup()
     const onSelect = vi.fn()
-    render(<SegmentedControl options={options} selectedId="a" onSelect={onSelect} disabled />)
+    render(<SegmentedControl options={options} value="a" onValueChange={onSelect} disabled />)
 
     const group = screen.getByRole('radiogroup')
     group.focus()
@@ -152,9 +189,48 @@ describe('SegmentedControl', () => {
     expect(onSelect).not.toHaveBeenCalled()
   })
 
+  it('RTL: ArrowRight moves to the previous option (reading-order aware)', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(
+      <div dir="rtl">
+        <SegmentedControl options={options} value="b" onValueChange={onSelect} />
+      </div>,
+    )
+    screen.getByRole('radio', { name: 'Beta' }).focus()
+    await user.keyboard('{ArrowRight}')
+    expect(onSelect).toHaveBeenCalledWith('a')
+  })
+
+  it('RTL: ArrowLeft moves to the next option', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(
+      <div dir="rtl">
+        <SegmentedControl options={options} value="b" onValueChange={onSelect} />
+      </div>,
+    )
+    screen.getByRole('radio', { name: 'Beta' }).focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(onSelect).toHaveBeenCalledWith('c')
+  })
+
+  it('icon-only segment uses ariaLabel as its accessible name', () => {
+    const IconMock = ({ className }: { className?: string }) => (
+      <svg data-testid="ico" className={className}><rect /></svg>
+    )
+    const iconOnly: SegmentedControlOption[] = [
+      { id: 'grid', icon: IconMock, ariaLabel: 'Grid view' },
+      { id: 'list', icon: IconMock, ariaLabel: 'List view' },
+    ]
+    render(<SegmentedControl options={iconOnly} defaultValue="grid" />)
+    expect(screen.getByRole('radio', { name: 'Grid view' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'List view' })).toBeInTheDocument()
+  })
+
   it('has no accessibility violations', async () => {
     const { container } = render(
-      <SegmentedControl options={options} selectedId="a" onSelect={() => {}} aria-label="View mode" />,
+      <SegmentedControl options={options} value="a" onValueChange={() => {}} aria-label="View mode" />,
     )
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/packages/core/src/ui/segmented-control.tsx
+++ b/packages/core/src/ui/segmented-control.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { LayoutGroup,motion } from 'framer-motion'
+import { LayoutGroup, motion, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 
 import { IconProvider } from './icon-context'
@@ -11,22 +11,62 @@ import { cn } from './lib/utils'
 /* ── Types ─────────────────────────────────────────────────── */
 
 export type SegmentedControlSize = 'sm' | 'md' | 'lg'
-export type SegmentedControlVariant = 'default' | 'solid'
+export type SegmentedControlVariant = 'soft' | 'solid'
+
+/** @deprecated `variant="default"` was renamed to `"soft"`. Still accepted at
+ *  runtime (maps to `"soft"`); update call sites — the alias is removed in a
+ *  future major. */
+type DeprecatedVariant = 'default'
 
 export interface SegmentedControlOption {
   id: string
-  text: string
+  /** Visible label. Accepts a `ReactNode` so an option can carry a count badge
+   *  or custom node, not just a string. Optional — omit for an icon-only
+   *  segment, in which case set `ariaLabel`. */
+  text?: React.ReactNode
   /** Optional icon rendered before the text label. Accepts any `IconInput`. */
   icon?: IconInput
+  /** Accessible name for the segment. Required for icon-only segments (no
+   *  `text`); otherwise the visible text provides the name. */
+  ariaLabel?: string
 }
 
-export interface SegmentedControlProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+export interface SegmentedControlProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect' | 'defaultValue'> {
   size?: SegmentedControlSize
-  variant?: SegmentedControlVariant
+  variant?: SegmentedControlVariant | DeprecatedVariant
   options: SegmentedControlOption[]
-  selectedId: string
-  onSelect: (id: string) => void
+  /** Selected option id (controlled). Aligns with Tabs/ToggleGroup. */
+  value?: string
+  /** Initial selected id for uncontrolled mode. Ignored when `value` is set;
+   *  defaults to the first option. */
+  defaultValue?: string
+  /** Fires with the newly-selected id (both modes). */
+  onValueChange?: (id: string) => void
   disabled?: boolean
+  /** Fill the container: segments split the available width equally instead of
+   *  hugging their content. Use for full-width toggles and view switchers. */
+  fullWidth?: boolean
+
+  /** @deprecated Use `value`. Still accepted; kept for back-compat. */
+  selectedId?: string
+  /** @deprecated Use `onValueChange`. Still accepted; kept for back-compat. */
+  onSelect?: (id: string) => void
+}
+
+/* ── RTL detection ─────────────────────────────────────────────
+ * Reads the nearest `dir` attribute (testable, the common case), falling
+ * back to the computed style for CSS-set direction. In RTL the horizontal
+ * arrow keys invert so Arrow keys always track reading order. */
+
+function isRtl(el: HTMLElement | null): boolean {
+  if (!el) return false
+  const dirEl = el.closest('[dir]') as HTMLElement | null
+  if (dirEl) return (dirEl.getAttribute('dir') ?? '').toLowerCase() === 'rtl'
+  try {
+    return getComputedStyle(el).direction === 'rtl'
+  } catch {
+    return false
+  }
 }
 
 /* ── Size config ───────────────────────────────────────────── */
@@ -37,22 +77,20 @@ const sizeConfig = {
   lg: { button: 'h-10 px-ds-06 text-body-md', icon: 'h-4 w-4' },
 } as const
 
-/* ── Pill styles per variant ───────────────────────────────── */
+/* ── Thumb (sliding indicator) styles per variant ──────────────
+ * The track carries no border/inset (see tokens/semantic.css
+ * --color-segment-track), so the thumb defines its own edge with a
+ * single ring-less soft shadow (--shadow-segment). */
 
-const pillStyles = {
-  default: 'bg-surface-overlay shadow-raised',
-  solid: 'bg-accent-9',
+const thumbStyles = {
+  soft: 'bg-segment-thumb shadow-segment',
+  solid: 'bg-accent-9 shadow-segment',
 } as const
 
 const selectedTextStyles = {
-  default: 'text-surface-fg',
+  soft: 'text-surface-fg',
   solid: 'text-accent-fg',
 } as const
-
-/* ── Spring config (snappy, minimal overshoot) ─────────────── */
-/* Intentionally softer than springs.snappy (500/30/0.5) for pill slide feel */
-
-const pillSpring = { type: 'spring' as const, stiffness: 400, damping: 30 }
 
 /* ── SegmentedControl ──────────────────────────────────────── */
 
@@ -60,11 +98,15 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
   function SegmentedControl(
     {
       size = 'md',
-      variant = 'default',
+      variant = 'soft',
       options,
+      value,
+      defaultValue,
+      onValueChange,
       selectedId,
       onSelect,
       disabled = false,
+      fullWidth = false,
       className,
       ...props
     },
@@ -72,6 +114,34 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
   ) {
     const instanceId = React.useId()
     const tablistRef = React.useRef<HTMLDivElement | null>(null)
+    const reduceMotion = useReducedMotion()
+
+    // Back-compat: 'default' was renamed to 'soft'. Map silently.
+    const resolvedVariant: SegmentedControlVariant = variant === 'default' ? 'soft' : variant
+
+    // Controlled/uncontrolled resolution. `value` is canonical; `selectedId` is
+    // the deprecated alias. Controlled when either is provided; otherwise the
+    // hook owns state, seeded from `defaultValue` (or the first option).
+    const controlledValue = value ?? selectedId
+    const isControlled = controlledValue !== undefined
+    const [uncontrolled, setUncontrolled] = React.useState(defaultValue ?? options[0]?.id)
+    const selected = isControlled ? controlledValue : uncontrolled
+
+    const emit = React.useCallback(
+      (id: string) => {
+        if (!isControlled) setUncontrolled(id)
+        ;(onValueChange ?? onSelect)?.(id)
+      },
+      [isControlled, onValueChange, onSelect],
+    )
+
+    // Thumb glide. This is a frequent, functional toggle, so the motion is
+    // crisp and bounce-free (Apple spring notation: settles ~300ms, no
+    // overshoot) rather than playful. Snaps instantly under reduced motion —
+    // the slide is the only movement here.
+    const thumbTransition = reduceMotion
+      ? { duration: 0 }
+      : { type: 'spring' as const, duration: 0.3, bounce: 0 }
 
     // Compose refs
     const mergedRef = React.useCallback(
@@ -87,17 +157,21 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (disabled) return
 
-      const currentIndex = options.findIndex((o) => o.id === selectedId)
+      const currentIndex = options.findIndex((o) => o.id === selected)
       let nextIndex = currentIndex
+
+      const prev = currentIndex > 0 ? currentIndex - 1 : options.length - 1
+      const next = currentIndex < options.length - 1 ? currentIndex + 1 : 0
+      const rtl = isRtl(tablistRef.current)
 
       switch (e.key) {
         case 'ArrowLeft':
           e.preventDefault()
-          nextIndex = currentIndex > 0 ? currentIndex - 1 : options.length - 1
+          nextIndex = rtl ? next : prev
           break
         case 'ArrowRight':
           e.preventDefault()
-          nextIndex = currentIndex < options.length - 1 ? currentIndex + 1 : 0
+          nextIndex = rtl ? prev : next
           break
         case 'Home':
           e.preventDefault()
@@ -111,7 +185,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
           return
       }
 
-      onSelect(options[nextIndex].id)
+      emit(options[nextIndex].id)
       requestAnimationFrame(() => {
         const buttons = tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="radio"]')
         buttons?.[nextIndex]?.focus()
@@ -128,8 +202,8 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
         aria-label={props['aria-label'] ?? 'Segmented control'}
         onKeyDown={handleKeyDown}
         className={cn(
-          'inline-flex p-[3px] rounded-pill',
-          'bg-surface-raised-hover border border-surface-border-subtle shadow-inset',
+          'p-ds-01 rounded-ds-lg bg-segment-track',
+          fullWidth ? 'flex w-full' : 'inline-flex w-fit',
           disabled && 'opacity-action-disabled pointer-events-none',
           className,
         )}
@@ -137,7 +211,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
       >
         <LayoutGroup id={instanceId}>
           {options.map((option) => {
-            const isSelected = option.id === selectedId
+            const isSelected = option.id === selected
 
             return (
               <button
@@ -145,40 +219,52 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
                 type="button"
                 role="radio"
                 aria-checked={isSelected}
+                aria-label={option.ariaLabel}
                 tabIndex={isSelected ? 0 : -1}
                 disabled={disabled}
-                onClick={() => onSelect(option.id)}
+                onClick={() => emit(option.id)}
                 className={cn(
-                  'relative inline-flex items-center justify-center gap-ds-02 rounded-pill',
-                  'font-medium transition-colors duration-fast-02 ease-productive-standard',
-                  'outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2',
+                  'relative inline-flex items-center justify-center gap-ds-02 rounded-ds-md',
+                  'font-medium outline-hidden',
+                  // `touch-target` adds a 44px min hit area via ::before without
+                  // changing the visual (dense) height.
+                  'touch-target',
+                  // Exact properties (not `all`); press-scale gives instant
+                  // tactile feedback, gated to motion-safe so reduced-motion
+                  // users keep only the color change.
+                  'transition-[color,transform] duration-fast-02 ease-productive-standard',
+                  'motion-safe:active:scale-[0.97]',
+                  'focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                   buttonSize,
+                  fullWidth && 'flex-1 min-w-16',
                   isSelected
-                    ? selectedTextStyles[variant]
+                    ? selectedTextStyles[resolvedVariant]
                     : 'text-surface-fg-muted hover:text-surface-fg',
                 )}
               >
-                {/* Sliding pill indicator */}
+                {/* Sliding thumb indicator. Rendered before the content so the
+                    positioned content siblings paint above it (no z-index). */}
                 {isSelected && (
                   <motion.span
-                    layoutId="segment-pill"
+                    layoutId="segment-thumb"
+                    initial={false}
                     className={cn(
-                      'absolute inset-0 rounded-pill pointer-events-none',
-                      pillStyles[variant],
+                      'absolute inset-0 rounded-ds-md pointer-events-none',
+                      thumbStyles[resolvedVariant],
                     )}
-                    transition={pillSpring}
+                    transition={thumbTransition}
                   />
                 )}
 
-                {/* Content (above pill via z-index) */}
+                {/* Content — `relative` so it paints over the thumb */}
                 {option.icon && (
-                  <span className={cn('relative z-[1] shrink-0 inline-flex items-center justify-center', iconSize)}>
+                  <span className={cn('relative shrink-0 inline-flex items-center justify-center', iconSize)}>
                     <IconProvider size={size === 'lg' ? 'sm' : 'xs'}>
                       {normalizeIcon(option.icon)}
                     </IconProvider>
                   </span>
                 )}
-                <span className="relative z-[1]">{option.text}</span>
+                {option.text != null && <span className="relative">{option.text}</span>}
               </button>
             )
           })}


### PR DESCRIPTION
Reconstructs SegmentedControl to the modern pattern (iOS / shadcn / Radix), fixing the muddy "edge-soup" look (bordered + inset-shadowed pill track under a ring-carrying thumb).

## What changed
- **Rounded-rect track** (`rounded-ds-lg`), translucent recessed fill (no border/inset); single ring-less soft-shadow thumb (`rounded-ds-md`). New tokens: `--color-segment-track`, `--color-segment-thumb`, `--shadow-segment`. Dark-mode elevation inverts so the groove stays visible on near-black surfaces.
- **`fullWidth`** — segments split the container equally.
- **Canonical API** — `value` / `defaultValue` / `onValueChange` (controlled + uncontrolled). `selectedId` / `onSelect` kept as deprecated aliases.
- **44px touch targets** (`touch-target`) at dense visual height.
- **Option `text` → `ReactNode`, optional**; `ariaLabel` per option for icon-only segments.
- **RTL-aware** Arrow-key navigation.
- **Motion** — crisp bounce-free thumb glide (Apple spring, reduced-motion aware) + `motion-safe` press-scale.
- Rename `variant="default"` → `"soft"` (deprecated alias kept). Site `aurora-playground` migrated to the new API.

## Verification
typecheck ✓ · 28 unit tests ✓ · lint ✓ · build ✓ · doc-audit ✓ · arbitrary-sizing gate ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)