### PR TITLE
fix(segmented-control): use semantic radius roles (release-gate)

### DIFF
--- a/packages/core/src/tokens/semantic.css
+++ b/packages/core/src/tokens/semantic.css
@@ -384,8 +384,8 @@
      --radius-overlay-lg    rounded-overlay-lg    Dialog, AlertDialog, Sheet, BottomSheet, ColorInput picker
      --radius-pill          rounded-pill          Badge, Dot, Radio, Switch, Slider, Progress, Avatar circle
      --radius-bubble        rounded-bubble        ChatMessage bubble
-     (SegmentedControl is a rounded-RECT, not a pill: track rounded-ds-lg,
-      thumb rounded-ds-md — thumb inner radius sits tighter inside the track.)
+     (SegmentedControl is a rounded-RECT, not a pill: track rounded-surface,
+      thumb rounded-control — thumb inner radius sits tighter inside the track.)
      ─────────────────────────────────────────────────────────── */
   --radius-control:        6px;
   --radius-control-inner:  2px;

--- a/packages/core/src/ui/segmented-control.tsx
+++ b/packages/core/src/ui/segmented-control.tsx
@@ -202,7 +202,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
         aria-label={props['aria-label'] ?? 'Segmented control'}
         onKeyDown={handleKeyDown}
         className={cn(
-          'p-ds-01 rounded-ds-lg bg-segment-track',
+          'p-ds-01 rounded-surface bg-segment-track',
           fullWidth ? 'flex w-full' : 'inline-flex w-fit',
           disabled && 'opacity-action-disabled pointer-events-none',
           className,
@@ -224,7 +224,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
                 disabled={disabled}
                 onClick={() => emit(option.id)}
                 className={cn(
-                  'relative inline-flex items-center justify-center gap-ds-02 rounded-ds-md',
+                  'relative inline-flex items-center justify-center gap-ds-02 rounded-control',
                   'font-medium outline-hidden',
                   // `touch-target` adds a 44px min hit area via ::before without
                   // changing the visual (dense) height.
@@ -249,7 +249,7 @@ const SegmentedControl = React.forwardRef<HTMLDivElement, SegmentedControlProps>
                     layoutId="segment-thumb"
                     initial={false}
                     className={cn(
-                      'absolute inset-0 rounded-ds-md pointer-events-none',
+                      'absolute inset-0 rounded-control pointer-events-none',
                       thumbStyles[resolvedVariant],
                     )}
                     transition={thumbTransition}


### PR DESCRIPTION
0.52.0's release was blocked at the **pre-publish-audit "semantic radius roles" gate** — the SegmentedControl rebuild used `rounded-ds-lg`/`rounded-ds-md` directly, but components must use radius *role* tokens so `[data-shape]` presets can remap them.

Fix: map to role tokens with identical radii — track `rounded-surface` (10px), thumb/button `rounded-control` (6px). **No visual change.** No changeset (internal correction to the not-yet-published 0.52.0).

Verified: no `rounded-ds`/`rounded-full` remain · typecheck ✓ · 28 tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)