### PR TITLE
fix(motion,tokens): reduced-motion without provider + define border-card-strong

### DIFF
--- a/.changeset/systemic-finish-bar-sweeps.md
+++ b/.changeset/systemic-finish-bar-sweeps.md
@@ -1,0 +1,9 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Two DS-wide fixes from the finish-bar audit:
+
+- **Reduced motion respected without a provider.** `useMotion()` now falls back to the OS `prefers-reduced-motion` setting when no `<MotionProvider>` is mounted (previously the context default hardcoded `reducedMotion: false`, so components ignored the preference unless a provider wrapped them). Every shilp-sutra component that gates animation on `useMotion().reducedMotion` now honors reduced motion out of the box; a provider remains an explicit override.
+
+- **`border-card-strong` is now a real utility.** It was referenced by ~11 components (kbd caps, code blocks, skeleton/panel outlines, chips) but never defined — the border fell back to `currentColor`. Added `@utility border-card-strong` mapping to the dark-mode-aware `--color-surface-border`, restoring the intended hairline.

--- a/packages/core/src/motion/__tests__/motion-provider.test.tsx
+++ b/packages/core/src/motion/__tests__/motion-provider.test.tsx
@@ -86,10 +86,20 @@ describe('MotionProvider', () => {
     expect(screen.getByTestId('reduced')).toHaveTextContent('false')
   })
 
-  it('useMotion() without provider returns default context', () => {
+  it('useMotion() without provider falls back to OS preference (motion on)', () => {
+    mockUseReducedMotion.mockReturnValue(false)
     render(<MotionConsumer />)
     expect(screen.getByTestId('reduced')).toHaveTextContent('false')
     expect(screen.getByTestId('has-springs')).toHaveTextContent('yes')
     expect(screen.getByTestId('has-tweens')).toHaveTextContent('yes')
+  })
+
+  it('useMotion() without provider RESPECTS OS reduced motion (no provider required)', () => {
+    // Regression guard: prior to the fix the context default hardcoded
+    // reducedMotion:false, so components ignored prefers-reduced-motion unless
+    // a MotionProvider was mounted. Now the OS preference is honored by default.
+    mockUseReducedMotion.mockReturnValue(true)
+    render(<MotionConsumer />)
+    expect(screen.getByTestId('reduced')).toHaveTextContent('true')
   })
 })

--- a/packages/core/src/motion/motion-provider.tsx
+++ b/packages/core/src/motion/motion-provider.tsx
@@ -13,11 +13,10 @@ type MotionContextValue = {
   reducedMotion: boolean
 }
 
-const MotionContext = React.createContext<MotionContextValue>({
-  springs,
-  tweens,
-  reducedMotion: false,
-})
+// `null` default = "no MotionProvider mounted". `useMotion()` detects this and
+// falls back to the OS `prefers-reduced-motion` setting, so components respect
+// reduced motion out of the box — a provider is an override, not a requirement.
+const MotionContext = React.createContext<MotionContextValue | null>(null)
 
 type MotionProviderProps = {
   children: React.ReactNode
@@ -43,8 +42,12 @@ function MotionProvider({ children, reducedMotion = 'user' }: MotionProviderProp
   )
 }
 
-function useMotion() {
-  return React.useContext(MotionContext)
+function useMotion(): MotionContextValue {
+  const ctx = React.useContext(MotionContext)
+  // Always called (hook order stable); only used when no provider is mounted.
+  const osPreference = useFMReducedMotion() ?? false
+  if (ctx) return ctx
+  return { springs, tweens, reducedMotion: osPreference }
 }
 
 export { MotionProvider, type MotionProviderProps,useMotion }

--- a/packages/core/src/tokens/utilities.css
+++ b/packages/core/src/tokens/utilities.css
@@ -340,3 +340,9 @@
    ─────────────────────────────────────────────────────────────────── */
 
 @utility border-card { border-color: var(--color-surface-border-card); }
+/* Stronger card edge (kbd caps, code blocks, skeleton/panel outlines, chip
+   borders) — one step up from the faint `border-card` mix. Dark-mode aware via
+   the semantic token. Was referenced in ~11 components with no matching utility
+   (dead class → border fell back to currentColor); defined here to restore the
+   intended hairline. */
+@utility border-card-strong { border-color: var(--color-surface-border); }


### PR DESCRIPTION
The first two **systemic** fixes from the finish-bar audit (#181) — each fixed once, DS-wide.

## 1. Reduced motion respected without a provider
`useMotion()`'s context default hardcoded `reducedMotion: false`, so any component gating animation on `useMotion().reducedMotion` **ignored the OS `prefers-reduced-motion` setting** unless a `<MotionProvider>` wrapped the app. Now `useMotion()` falls back to the OS preference when no provider is mounted — reduced motion works out of the box; a provider stays an explicit override. Regression test added.

## 2. `border-card-strong` is now a real utility
Referenced by ~11 components (kbd caps, code blocks, skeleton/panel outlines, chips) but **never defined** — the border fell back to `currentColor` (wrong color / invisible). Added `@utility border-card-strong` → `--color-surface-border` (dark-mode aware), restoring the intended hairline. Zero churn in the 11 consumers.

## Verification
All **2266 tests pass** · typecheck ✓ · build ✓ · utility ships in `dist/tokens/utilities.css`.

Non-breaking (patch). Follow-ups (per-component improvements) tracked in the audit backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)