### PR TITLE
feat(bottom-navbar): rebuild overflow on Sheet + composable role gating

### DIFF
--- a/.changeset/bottom-navbar-rebuild.md
+++ b/.changeset/bottom-navbar-rebuild.md
@@ -7,6 +7,7 @@
 - **Role gating (new):** `BottomNavItem` gains `roles?: string[]` (visible only when `user.role` matches) and `canView?: (user) => boolean` (arbitrary logic, wins over `roles`). The previously-inert `user` prop now drives this. Non-breaking — items with neither field are always visible.
 - **`indicator` (new):** `'underline'` (default) or Material-3 `'pill'` behind the active icon.
 - **`labelVisibility` (new):** `'always'` (default) or `'selected'` (labels only for the active item, for narrow viewports).
+- **`activeIcon` (new):** a per-item filled/alternate icon shown while the route is active (falls back to `icon`) — the iOS/Material filled-when-selected affordance. Icon lozenge padding tightened so icon-only items (e.g. `labelVisibility="selected"`) read less airy.
 - Composes `Badge` for notification counts (was re-rolled); Sheet's built-in close replaces the sub-44px hand-rolled one.
 - Label truncation + logical (RTL-safe) properties; overflow grid adapts to item count instead of a fixed 4 columns.
 - Notification-badge `zoom-in` animation is now reduced-motion gated.

--- a/.changeset/bottom-navbar-rebuild.md
+++ b/.changeset/bottom-navbar-rebuild.md
@@ -5,7 +5,7 @@
 **BottomNavbar rebuild (finish-bar).** The overflow "More" menu is now the DS `Sheet` (`side="bottom"`) instead of a hand-rolled `role="dialog"`, so it inherits focus trap, scroll lock, return-focus, `aria-modal`, and `aria-haspopup`/`aria-controls` trigger wiring — closing a real accessibility gap in primary mobile navigation.
 
 - **Role gating (new):** `BottomNavItem` gains `roles?: string[]` (visible only when `user.role` matches) and `canView?: (user) => boolean` (arbitrary logic, wins over `roles`). The previously-inert `user` prop now drives this. Non-breaking — items with neither field are always visible.
-- **`indicator` (new):** `'underline'` (default) or Material-3 `'pill'` behind the active icon.
+- **`indicator` (new):** default **`pill`** (Material-3 tonal pill behind the icon), plus `underline`, `tint` (whole-cell), and `none` (no shape — pair with `activeIcon` for the iOS filled look). The active indicator **animates** — a shared-element (`layoutId`) that slides to the selected item and fades in on first appearance.
 - **`labelVisibility` (new):** `'always'` (default) or `'selected'` (labels only for the active item, for narrow viewports).
 - **`activeIcon` (new):** a per-item filled/alternate icon shown while the route is active (falls back to `icon`) — the iOS/Material filled-when-selected affordance. Icon lozenge padding tightened so icon-only items (e.g. `labelVisibility="selected"`) read less airy.
 - Composes `Badge` for notification counts (was re-rolled); Sheet's built-in close replaces the sub-44px hand-rolled one.

--- a/.changeset/bottom-navbar-rebuild.md
+++ b/.changeset/bottom-navbar-rebuild.md
@@ -1,0 +1,13 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+**BottomNavbar rebuild (finish-bar).** The overflow "More" menu is now the DS `Sheet` (`side="bottom"`) instead of a hand-rolled `role="dialog"`, so it inherits focus trap, scroll lock, return-focus, `aria-modal`, and `aria-haspopup`/`aria-controls` trigger wiring — closing a real accessibility gap in primary mobile navigation.
+
+- **Role gating (new):** `BottomNavItem` gains `roles?: string[]` (visible only when `user.role` matches) and `canView?: (user) => boolean` (arbitrary logic, wins over `roles`). The previously-inert `user` prop now drives this. Non-breaking — items with neither field are always visible.
+- **`indicator` (new):** `'underline'` (default) or Material-3 `'pill'` behind the active icon.
+- **`labelVisibility` (new):** `'always'` (default) or `'selected'` (labels only for the active item, for narrow viewports).
+- Composes `Badge` for notification counts (was re-rolled); Sheet's built-in close replaces the sub-44px hand-rolled one.
+- Label truncation + logical (RTL-safe) properties; overflow grid adapts to item count instead of a fixed 4 columns.
+- Notification-badge `zoom-in` animation is now reduced-motion gated.
+- Restored test coverage (RTL + vitest-axe: active state, badges, role gating, More-sheet open/close).

--- a/docs/plans/2026-07-24-finish-bar-rebuilds.md
+++ b/docs/plans/2026-07-24-finish-bar-rebuilds.md
@@ -1,0 +1,165 @@
+# Finish-Bar Rebuilds — Detailed Plan (4 components)
+
+From the 2026-07-24 finish-bar audit. Order by urgency: bottom-navbar (a11y P0)
+→ priority-indicator (small, 2×P0) → autocomplete (composition) → schedule-view
+(largest). Each is a **scoped structural** rebuild, not a visual redo — the
+common thread is *compose the DS primitive instead of re-rolling it*.
+
+Shared rules for all four: preserve public API where possible; any rename ships
+a `@deprecated` alias + changeset (never a hard break); role radius tokens only;
+reduced-motion self-guarded; RTL logical properties; add/restore tests
+(RTL + vitest-axe); update the doc to match source.
+
+---
+
+## 1. shell/bottom-navbar — 2/5 → target 4/5 (a11y P0)
+
+**Problem:** the "More" overflow menu is a hand-rolled `role="dialog"` (raw
+`<div onClick>` backdrop, manual Escape, manual focus `useEffect`) with **no
+focus trap, no scroll lock, no return-focus, no `aria-modal`, no
+`aria-haspopup`/`aria-controls`**. Sub-44px close button. Dead `user` prop
+(accepted + documented, never read). Re-rolls Badge. No test file. Magic numbers.
+
+**Rebuild:**
+1. **Re-found the More menu on the DS `Sheet side="bottom"`.** Deletes the raw
+   backdrop, manual focus effect, manual Escape, and the `jsx-a11y` disable;
+   inherits focus-trap + scroll-lock + return-focus + `aria-modal`. Wire the
+   trigger with `aria-haspopup="dialog"` + `aria-controls` (Sheet gives the id).
+2. **Compose `Badge`/`Dot`** for `NavBadge` (kills the re-roll + raw values).
+3. **Close control → `IconButton`** (≥44px `touch-target`).
+4. Detokenize magic numbers: derive sheet offset from bar height (not
+   `bottom-[72px]`), `h-[3px]`/`max-w-[70px]`/badge `text-[10px]` → tokens.
+5. Label truncation + logical properties (RTL); overflow grid responsive to
+   item count (not hard `grid-cols-4`).
+6. Backdrop fades with the sheet (Sheet handles); reduced-motion-gate NavBadge
+   `zoom-in-75`.
+7. **Restore tests**: RTL + vitest-axe — `aria-current`, badge render/cap,
+   More open/close + focus return, axe.
+
+**API change (breaking → staged):** the dead `user`/`BottomNavbarUser` prop.
+Recommend **deprecate + no-op** (JSDoc `@deprecated`, keep accepting it, delete
+the misleading `NoUser`/`AssociateRole` stories) rather than hard-remove.
+→ **DECISION 1.**
+
+**Improvements (adoption):** optional Material-3 **pill-behind-icon** indicator
+variant + **label-visibility mode** (always / selected-only) for narrow
+viewports. Additive. → **DECISION 2** (include now vs defer).
+
+**Effort:** M. **Risk:** low (Sheet is battle-tested). **Breaking:** only the
+`user` prop (staged).
+
+---
+
+## 2. composed/priority-indicator — 2/5 → target 4/5 (2×P0, ~50 lines)
+
+**Problem:** infinite URGENT pulse with **no reduced-motion guard** (WCAG
+2.2.2); compact chip's only name is `title=` on a `<div>` (SR-unreliable);
+re-rolls the chip 3× instead of composing Badge; dead CVA `display` axis (both
+branches emit `''`); HIGH and URGENT are visually identical when static; doc
+says "LOW=success" (source: slate) and "Server-safe: Yes" (has `'use client'`);
+unknown `priority` string crashes at runtime.
+
+**Rebuild (body rewrite, API preserved):**
+1. **Recompose as `<Badge variant="soft" color=… startIcon={config.icon}>`** —
+   inherits `rounded-pill`, color semantics, accessible labeling, and Badge's
+   already-reduced-motion-gated pulse. Compact = icon-only Badge with
+   `aria-label={config.label}` + `role="img"`, Icon `aria-hidden`.
+2. **URGENT static differentiation** — solid `bg-error-9`/`text-error-fg` (or a
+   border) so severity reads without motion. → **DECISION 3** (solid vs border).
+3. Drop the dead CVA `display` axis; replace with a boolean **`iconOnly`** (or
+   keep `display` as a deprecated alias). → **DECISION 4.**
+4. Add a `label`/`children` escape hatch for i18n.
+5. Defensive fallback for unknown `priority` (no runtime throw).
+6. Fix the doc (LOW=slate, not server-safe) + refresh changelog.
+7. Tests: reduced-motion (static render), compact accessible-name, unknown-priority fallback.
+
+**Effort:** S. **Risk:** low. **Breaking:** none if `display` kept as alias.
+
+---
+
+## 3. ui/autocomplete — 2/5 → target 4/5 (composition re-parent)
+
+**Problem:** re-rolls the `<input>` and has **drifted from `Input`**
+(`ring-offset` mismatch, `focus-visible` vs Input's `focus-within`, no
+hover/read-only, hardcoded height); **controlled-only** (no `defaultValue`); no
+`size`/`state` axes; reads FormField `isError` but **never paints it**; no
+loading state; option labels untruncated; stagger on a keystroke-frequency
+dropdown; dead no-op cleanup effect; AI-filler JSDoc.
+
+**Rebuild (re-parent onto Input — behavior layer kept wholesale):**
+1. **Render the field through `<Input role="combobox" state={isError?'error':undefined} size={size} … />`** instead of a hand-rolled input. One move fixes
+   cohesion drift, paints the error border, inherits `size`/`state`/read-only/
+   hover, standardizes the disabled guard.
+2. **Uncontrolled mode**: `defaultValue?: AutocompleteOption | null`.
+3. Forward **`size`/`state`** through the composed Input.
+4. **`touch-target`** on input + min-height on option rows (44px).
+5. **Matched-substring highlighting** — bold the query span in each option
+   (cheap, the most recognizable "good autocomplete" cue). → include.
+6. **`renderOption` slot** for icons/secondary text. → **DECISION 5** (include now vs defer).
+7. **`isLoading` + `loadingText`** async contract (spinner endSection). → **DECISION 6** (include now vs defer).
+8. Drop `staggerChildren` (or gate to first-open); delete dead cleanup effect + AI-filler JSDoc.
+9. Fix doc (FormField consumption); `truncate` + `title` on options.
+10. Tests: add `describeConformance`, ArrowUp/Home/End, disabled-blocks-keyboard, uncontrolled.
+- **Deferred:** virtualization (niche; the known-list use case doesn't need it — document the limit).
+
+**Effort:** M. **Risk:** medium (re-parenting the field — visual regressions possible; Storybook + Chromatic check). **Breaking:** none (additive; controlled path unchanged).
+
+---
+
+## 4. composed/schedule-view — 3/5 → target 4/5 (largest, targeted structural)
+
+**Problem:** **~140 individually-tabbable slot buttons** in week view (no
+`grid`/`gridcell`, no roving tabindex, no arrow nav); sub-24px targets;
+**overlapping events stack directly on top of each other** (illegible); dead
+`border-card-strong` (fixed DS-wide in #182 — verify here); `bg-surface-raised`
+where the panel tier should be `surface-2`; **now-line never ticks** (mount-time
+`Date`, no interval); no overlapping layout; not RTL-safe; magic numbers
+(`h-[480px]`, `w-[60px]`, negative-px now-dot); no `renderEvent`/header slot; no
+selected-event or real empty state.
+
+**Rebuild (targeted structural):**
+1. **Grid a11y**: re-architect to `role="grid"` / `row` / `gridcell` with
+   **roving tabindex + arrow/Home/End** nav. When `onSlotClick` is absent,
+   render slots as **non-interactive `aria-hidden` grid lines** (kills the ~140
+   phantom tab stops). Enforce min interactive height (≥24px WCAG 2.5.8).
+2. **Overlapping-event column layout**: an overlap-resolution pass over
+   `dayEvents` → partition width across concurrent events (side-by-side columns)
+   instead of full-width `absolute` stacking.
+3. **Compose `<Card>`** for the shell (surface/radius/border from one place);
+   fixes the `surface-raised`→`surface-2` tier + the (now-fixed) border.
+4. **Live now-line**: `setInterval` re-render (1 min) + initial
+   `scrollIntoView` on the now-line. Guard interval cleanup.
+5. **RTL**: physical → logical properties throughout
+   (`border-r`→`border-e`, `text-right`→`text-end`, `left/right-ds-01`→`inset-*`,
+   transform-based now-dot centering instead of `-left-[5px]`/`-top-[4px]`).
+6. Detokenize `h-[480px]`/`w-[60px]`/negatives; make height a prop (or intrinsic
+   + scroll) so it doesn't trip `check-arbitrary-sizing`.
+7. **`renderEvent` render prop** + optional header/toolbar slot.
+8. Selected-event state + a real empty-state affordance; `active:scale` press feedback.
+9. Tests: vitest-axe, `onSlotClick`, keyboard-nav.
+- **Deferred:** month view, drag-to-create/resize (documented out of scope).
+
+**Scope fork → DECISION 7:** full pass (all of 1–8 in one PR) vs **MVP-structural**
+(1 grid-a11y + 2 overlap + 3 Card + 4 now-tick this PR; RTL/renderEvent/selected
+in a follow-up). Recommend **MVP-structural** — the two P0/P1 structural items
+(grid a11y + overlap) are the finish-bar blockers; the rest is additive polish.
+
+**Effort:** L. **Risk:** medium (grid re-architecture + event-layout math).
+**Breaking:** none (additive; display-grid API preserved).
+
+---
+
+## Sequencing & delivery
+- One PR per component (each with changeset + tests + Storybook). Land in
+  urgency order. bottom-navbar first (real a11y defect in production mobile nav).
+- Each verified locally: typecheck + full test + build + `pnpm verify` before push.
+- Group the eventual release once all four (or a chosen subset) land.
+
+## Decisions (RESOLVED 2026-07-24)
+1. **bottom-navbar `user`:** implement **general, composable role-gating** (not just admin). Per-item `roles?: string[]` (visible when the user's role matches; no roles = always visible) **plus** a `canView?: (user) => boolean` predicate escape hatch for arbitrary logic. `user` becomes real (additive, non-breaking). Delete the misleading stories, add role-gating stories.
+2. **bottom-navbar M3 indicator + label-visibility:** INCLUDE now. Plus general "make it best-in-class" polish (truncation, responsive overflow grid, logical/RTL, motion) since it's high-traffic.
+3. **priority URGENT:** solid `error-9`/`error-fg` static treatment. (rec accepted)
+4. **priority `display`:** replace with `iconOnly` boolean; keep `display` as a deprecated alias. (rec accepted)
+5. **autocomplete `renderOption`:** INCLUDE now.
+6. **autocomplete `isLoading`/async:** INCLUDE now.
+7. **schedule-view:** FULL pass in one PR (grid a11y + overlap columns + Card + live now-line + RTL + renderEvent/header + selected-event + empty state + detokenize).

--- a/packages/core/docs/components/shell/bottom-navbar.md
+++ b/packages/core/docs/components/shell/bottom-navbar.md
@@ -9,7 +9,7 @@
     user?: BottomNavbarUser | null (drives per-item role gating, optional)
     primaryItems?: BottomNavItem[] (max 4 recommended, optional)
     moreItems?: BottomNavItem[] (overflow items in "More" sheet, optional)
-    indicator?: 'underline' | 'pill' (active-item indicator style)
+    indicator?: 'pill' | 'underline' | 'tint' | 'none' (active-item indicator; default 'pill')
     labelVisibility?: 'always' | 'selected'
     className?: string
 
@@ -21,7 +21,7 @@ BottomNavbarUser: { name: string, role?: string }
     user: null
     primaryItems: []
     moreItems: []
-    indicator: 'underline'
+    indicator: 'pill'
     labelVisibility: 'always'
 
 ## Example
@@ -47,7 +47,7 @@ BottomNavbarUser: { name: string, role?: string }
 - **Badge numbers** cap at 99+ (composes the `Badge` primitive).
 - **Role gating:** each item may declare `roles: string[]` (shown only when `user.role` matches) or a `canView(user)` predicate for arbitrary logic (`canView` wins). Items with neither are always visible. Gating applies to both `primaryItems` and `moreItems`.
 - **Overflow sheet:** the "More" surface is the DS `Sheet` (`side="bottom"`) — it inherits focus trap, scroll lock, return-focus, and `aria-modal`; the trigger is wired with `aria-haspopup`/`aria-controls` automatically.
-- **Indicator + labels:** `indicator="pill"` gives a Material-3 pill behind the active icon (vs the default top underline); `labelVisibility="selected"` shows labels only for the active item (narrow viewports).
+- **Indicator (animated):** the active indicator slides to the selected item (shared-element `layoutId`) and fades in on first appearance. Modes: `pill` (default, Material-3 tonal pill behind the icon), `underline` (top accent bar), `tint` (subtle bg on the whole active cell), `none` (no shape — pair with `activeIcon` for the iOS filled-icon look). `labelVisibility="selected"` shows labels only for the active item.
 - **Filled-when-active:** set `activeIcon` on an item (e.g. a Tabler `*Filled` variant) to swap the icon for a filled version while it's the active route; falls back to `icon`.
 - **Not for desktop:** The viewport-fixed positioning + touch-optimized sizing don't translate well to desktop. Hide behind `md:hidden`.
 
@@ -62,7 +62,7 @@ BottomNavbarUser: { name: string, role?: string }
 - **Changed** Overflow "More" menu re-founded on the DS `Sheet` primitive — inherits focus trap, scroll lock, return-focus, `aria-modal`, and trigger↔panel ARIA wiring (was a hand-rolled `role="dialog"` with none of these). Composes `Badge` for notification counts and the Sheet's built-in close (≥ touch target).
 - **Added** Per-item role gating: `roles?: string[]` and `canView?: (user) => boolean` on `BottomNavItem`. The previously-inert `user` prop now drives it.
 - **Added** `activeIcon` per item — a filled/alternate icon shown while active (falls back to `icon`). Tightened the icon lozenge padding so icon-only items read less airy.
-- **Added** `indicator` ('underline' | 'pill') and `labelVisibility` ('always' | 'selected').
+- **Added** `indicator` (default **`pill`** — Material-3; plus `underline`, `tint`, `none`) and `labelVisibility` ('always' | 'selected'). The active indicator animates (slides) between items via a shared-element `layoutId`.
 - **Added** Label truncation + logical (RTL-safe) properties; overflow grid adapts to item count.
 - **Fixed** Notification badge `zoom-in` animation now reduced-motion gated.
 

--- a/packages/core/docs/components/shell/bottom-navbar.md
+++ b/packages/core/docs/components/shell/bottom-navbar.md
@@ -13,7 +13,7 @@
     labelVisibility?: 'always' | 'selected'
     className?: string
 
-BottomNavItem: { title: string, href: string, icon: IconInput, exact?: boolean, badge?: number, roles?: string[], canView?: (user: BottomNavbarUser | null) => boolean }
+BottomNavItem: { title: string, href: string, icon: IconInput, activeIcon?: IconInput, exact?: boolean, badge?: number, roles?: string[], canView?: (user: BottomNavbarUser | null) => boolean }
 BottomNavbarUser: { name: string, role?: string }
 
 ## Defaults
@@ -48,6 +48,7 @@ BottomNavbarUser: { name: string, role?: string }
 - **Role gating:** each item may declare `roles: string[]` (shown only when `user.role` matches) or a `canView(user)` predicate for arbitrary logic (`canView` wins). Items with neither are always visible. Gating applies to both `primaryItems` and `moreItems`.
 - **Overflow sheet:** the "More" surface is the DS `Sheet` (`side="bottom"`) — it inherits focus trap, scroll lock, return-focus, and `aria-modal`; the trigger is wired with `aria-haspopup`/`aria-controls` automatically.
 - **Indicator + labels:** `indicator="pill"` gives a Material-3 pill behind the active icon (vs the default top underline); `labelVisibility="selected"` shows labels only for the active item (narrow viewports).
+- **Filled-when-active:** set `activeIcon` on an item (e.g. a Tabler `*Filled` variant) to swap the icon for a filled version while it's the active route; falls back to `icon`.
 - **Not for desktop:** The viewport-fixed positioning + touch-optimized sizing don't translate well to desktop. Hide behind `md:hidden`.
 
 ## Gotchas
@@ -60,6 +61,7 @@ BottomNavbarUser: { name: string, role?: string }
 ### v0.53.0
 - **Changed** Overflow "More" menu re-founded on the DS `Sheet` primitive — inherits focus trap, scroll lock, return-focus, `aria-modal`, and trigger↔panel ARIA wiring (was a hand-rolled `role="dialog"` with none of these). Composes `Badge` for notification counts and the Sheet's built-in close (≥ touch target).
 - **Added** Per-item role gating: `roles?: string[]` and `canView?: (user) => boolean` on `BottomNavItem`. The previously-inert `user` prop now drives it.
+- **Added** `activeIcon` per item — a filled/alternate icon shown while active (falls back to `icon`). Tightened the icon lozenge padding so icon-only items read less airy.
 - **Added** `indicator` ('underline' | 'pill') and `labelVisibility` ('always' | 'selected').
 - **Added** Label truncation + logical (RTL-safe) properties; overflow grid adapts to item count.
 - **Fixed** Notification badge `zoom-in` animation now reduced-motion gated.

--- a/packages/core/docs/components/shell/bottom-navbar.md
+++ b/packages/core/docs/components/shell/bottom-navbar.md
@@ -6,16 +6,23 @@
 
 ## Props
     currentPath?: string (optional)
-    user?: BottomNavbarUser | null (optional)
+    user?: BottomNavbarUser | null (drives per-item role gating, optional)
     primaryItems?: BottomNavItem[] (max 4 recommended, optional)
-    moreItems?: BottomNavItem[] (overflow items in "More" menu, optional)
+    moreItems?: BottomNavItem[] (overflow items in "More" sheet, optional)
+    indicator?: 'underline' | 'pill' (active-item indicator style)
+    labelVisibility?: 'always' | 'selected'
     className?: string
 
-BottomNavItem: { title: string, href: string, icon: ReactNode, exact?: boolean, badge?: number }
+BottomNavItem: { title: string, href: string, icon: IconInput, exact?: boolean, badge?: number, roles?: string[], canView?: (user: BottomNavbarUser | null) => boolean }
 BottomNavbarUser: { name: string, role?: string }
 
 ## Defaults
-    None
+    currentPath: '/'
+    user: null
+    primaryItems: []
+    moreItems: []
+    indicator: 'underline'
+    labelVisibility: 'always'
 
 ## Example
 ```jsx
@@ -37,7 +44,10 @@ BottomNavbarUser: { name: string, role?: string }
   ```
 - **Primary vs overflow:** `primaryItems` (max 4) for the always-visible slots; `moreItems` go into a "More" sheet that opens on tap. Don't exceed 4 primary — the bar becomes cramped.
 - **Router integration via LinkProvider:** Each nav item is rendered using the framework-specific Link component registered in LinkProvider. Without LinkProvider, you get full-page reloads on tap.
-- **Badge numbers** cap at 99+ (same as BadgeIndicator pattern).
+- **Badge numbers** cap at 99+ (composes the `Badge` primitive).
+- **Role gating:** each item may declare `roles: string[]` (shown only when `user.role` matches) or a `canView(user)` predicate for arbitrary logic (`canView` wins). Items with neither are always visible. Gating applies to both `primaryItems` and `moreItems`.
+- **Overflow sheet:** the "More" surface is the DS `Sheet` (`side="bottom"`) — it inherits focus trap, scroll lock, return-focus, and `aria-modal`; the trigger is wired with `aria-haspopup`/`aria-controls` automatically.
+- **Indicator + labels:** `indicator="pill"` gives a Material-3 pill behind the active icon (vs the default top underline); `labelVisibility="selected"` shows labels only for the active item (narrow viewports).
 - **Not for desktop:** The viewport-fixed positioning + touch-optimized sizing don't translate well to desktop. Hide behind `md:hidden`.
 
 ## Gotchas
@@ -47,6 +57,13 @@ BottomNavbarUser: { name: string, role?: string }
 - Requires LinkProvider for framework-specific link components (e.g., Next.js Link)
 
 ## Changes
+### v0.53.0
+- **Changed** Overflow "More" menu re-founded on the DS `Sheet` primitive — inherits focus trap, scroll lock, return-focus, `aria-modal`, and trigger↔panel ARIA wiring (was a hand-rolled `role="dialog"` with none of these). Composes `Badge` for notification counts and the Sheet's built-in close (≥ touch target).
+- **Added** Per-item role gating: `roles?: string[]` and `canView?: (user) => boolean` on `BottomNavItem`. The previously-inert `user` prop now drives it.
+- **Added** `indicator` ('underline' | 'pill') and `labelVisibility` ('always' | 'selected').
+- **Added** Label truncation + logical (RTL-safe) properties; overflow grid adapts to item count.
+- **Fixed** Notification badge `zoom-in` animation now reduced-motion gated.
+
 ### v0.19.0
 - **Changed** Background elevated from `bg-surface-1` to `bg-surface-2` for visual hierarchy above app background
 - **Changed** "More" menu and interactive items bumped accordingly

--- a/packages/core/src/shell/bottom-navbar.stories.tsx
+++ b/packages/core/src/shell/bottom-navbar.stories.tsx
@@ -11,8 +11,23 @@ import {
   IconUserCircle,
   IconShieldCheck,
   IconSettings,
+  IconHome,
+  IconHomeFilled,
+  IconBell,
+  IconBellFilled,
+  IconMessage,
+  IconMessageFilled,
+  IconUser,
+  IconUserFilled,
 } from '@tabler/icons-react'
 import type { BottomNavItem, BottomNavbarUser } from './bottom-navbar'
+
+const filledItems: BottomNavItem[] = [
+  { title: 'Home', href: '/', icon: <IconHome />, activeIcon: <IconHomeFilled />, exact: true },
+  { title: 'Messages', href: '/messages', icon: <IconMessage />, activeIcon: <IconMessageFilled />, badge: 3 },
+  { title: 'Alerts', href: '/alerts', icon: <IconBell />, activeIcon: <IconBellFilled /> },
+  { title: 'Profile', href: '/profile', icon: <IconUser />, activeIcon: <IconUserFilled /> },
+]
 
 // ── Mock Data ────────────────────────────────────────────────
 
@@ -236,5 +251,27 @@ export const WithBadges: Story = {
       { title: 'Tasks', href: '/my-tasks', icon: <IconListCheck />, badge: 147 },
     ],
     moreItems,
+  },
+}
+
+export const FilledWhenSelected: Story = {
+  name: 'Filled icon when selected',
+  args: {
+    currentPath: '/',
+    user: mockUser,
+    primaryItems: filledItems,
+    moreItems: [],
+    indicator: 'pill',
+  },
+}
+
+export const FilledLabelsOnSelected: Story = {
+  name: 'Filled + labels on selected',
+  args: {
+    currentPath: '/messages',
+    user: mockUser,
+    primaryItems: filledItems,
+    moreItems: [],
+    labelVisibility: 'selected',
   },
 }

--- a/packages/core/src/shell/bottom-navbar.stories.tsx
+++ b/packages/core/src/shell/bottom-navbar.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import * as React from 'react'
 import { BottomNavbar } from './bottom-navbar'
+import { LinkProvider } from './link-context'
 import {
   IconLayoutDashboard,
   IconCalendarCheck,
@@ -273,5 +275,63 @@ export const FilledLabelsOnSelected: Story = {
     primaryItems: filledItems,
     moreItems: [],
     labelVisibility: 'selected',
+  },
+}
+
+export const IndicatorNone: Story = {
+  name: 'Indicator: none (iOS filled + tint)',
+  args: {
+    currentPath: '/messages',
+    user: mockUser,
+    primaryItems: filledItems,
+    moreItems: [],
+    indicator: 'none',
+  },
+}
+
+export const IndicatorTint: Story = {
+  name: 'Indicator: tint (whole cell)',
+  args: {
+    currentPath: '/alerts',
+    user: mockUser,
+    primaryItems: filledItems,
+    moreItems: [],
+    indicator: 'tint',
+  },
+}
+
+/**
+ * Interactive — clicking a tab updates `currentPath`, so the active indicator
+ * animates (slides) to the tapped item. This is the motion you can't see in the
+ * static stories (where `currentPath` is a fixed prop).
+ */
+export const Interactive: Story = {
+  render: function InteractiveNav() {
+    const [path, setPath] = React.useState('/')
+    const NavLink = React.useMemo(
+      () =>
+        React.forwardRef<HTMLAnchorElement, React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }>(
+          function NavLink({ href, onClick, ...props }, ref) {
+            return (
+              <a
+                ref={ref}
+                href={href}
+                onClick={(e) => {
+                  e.preventDefault()
+                  setPath(href)
+                  onClick?.(e)
+                }}
+                {...props}
+              />
+            )
+          },
+        ),
+      [],
+    )
+    return (
+      <LinkProvider component={NavLink}>
+        <BottomNavbar currentPath={path} user={mockUser} primaryItems={filledItems} moreItems={moreItems} indicator="pill" />
+      </LinkProvider>
+    )
   },
 }

--- a/packages/core/src/shell/bottom-navbar.stories.tsx
+++ b/packages/core/src/shell/bottom-navbar.stories.tsx
@@ -38,8 +38,9 @@ const moreItems: BottomNavItem[] = [
   { title: 'Devsabha', href: '/devsabha', icon: <IconBook /> },
   { title: 'Adjustments', href: '/adjustments', icon: <IconAdjustmentsHorizontal /> },
   { title: 'Profile', href: '/profile', icon: <IconUserCircle /> },
-  { title: 'Admin', href: '/admin', icon: <IconShieldCheck /> },
-  { title: 'IconSettings', href: '/admin/system-config', icon: <IconSettings /> },
+  // Role-gated: only visible when user.role === 'Admin'
+  { title: 'Admin', href: '/admin', icon: <IconShieldCheck />, roles: ['Admin'] },
+  { title: 'System', href: '/admin/system-config', icon: <IconSettings />, roles: ['Admin'] },
 ]
 
 // ── Meta ─────────────────────────────────────────────────────
@@ -155,21 +156,61 @@ export const NoMoreItems: Story = {
 }
 
 export const AssociateRole: Story = {
+  name: 'Role-gated (Associate — admin items auto-hidden)',
   args: {
     currentPath: '/',
     user: associateUser,
     primaryItems,
-    moreItems: moreItems.filter((i) => i.href !== '/admin' && i.href !== '/admin/system-config'),
+    // No manual filtering — the Admin/System items declare roles: ['Admin'],
+    // so they hide automatically for a non-admin user.
+    moreItems,
   },
 }
 
 export const NoUser: Story = {
-  name: 'No User (Hidden)',
+  name: 'No user (role-gated items hidden)',
   args: {
     currentPath: '/',
     user: null,
     primaryItems,
     moreItems,
+  },
+}
+
+export const CanViewPredicate: Story = {
+  name: 'Custom visibility (canView)',
+  args: {
+    currentPath: '/',
+    user: associateUser,
+    primaryItems,
+    // Arbitrary per-item logic — here: hide Adjustments unless the name starts with 'A'.
+    moreItems: moreItems.map((i) =>
+      i.href === '/adjustments'
+        ? { ...i, canView: (u) => !!u && u.name.startsWith('A') }
+        : i,
+    ),
+  },
+}
+
+export const PillIndicator: Story = {
+  name: 'Material-3 pill indicator',
+  args: {
+    currentPath: '/attendance',
+    user: mockUser,
+    primaryItems,
+    moreItems,
+    indicator: 'pill',
+  },
+}
+
+export const LabelsOnSelected: Story = {
+  name: 'Labels on selected only',
+  args: {
+    currentPath: '/projects',
+    user: mockUser,
+    primaryItems,
+    moreItems,
+    labelVisibility: 'selected',
   },
 }
 

--- a/packages/core/src/shell/bottom-navbar.test.tsx
+++ b/packages/core/src/shell/bottom-navbar.test.tsx
@@ -124,6 +124,18 @@ describe('BottomNavbar', () => {
     expect(screen.queryByRole('button', { name: 'More navigation options' })).not.toBeInTheDocument()
   })
 
+  it('renders activeIcon on the active item, plain icon otherwise', () => {
+    const items: BottomNavItem[] = [
+      { title: 'Home', href: '/', exact: true, icon: <svg data-testid="home-idle" />, activeIcon: <svg data-testid="home-active" /> },
+      { title: 'Docs', href: '/docs', icon: <svg data-testid="docs-idle" />, activeIcon: <svg data-testid="docs-active" /> },
+    ]
+    render(<BottomNavbar currentPath="/" primaryItems={items} />)
+    expect(screen.getByTestId('home-active')).toBeInTheDocument()
+    expect(screen.queryByTestId('home-idle')).not.toBeInTheDocument()
+    expect(screen.getByTestId('docs-idle')).toBeInTheDocument()
+    expect(screen.queryByTestId('docs-active')).not.toBeInTheDocument()
+  })
+
   it('has no accessibility violations', async () => {
     const { container } = render(
       <BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={moreItems} user={admin} />,

--- a/packages/core/src/shell/bottom-navbar.test.tsx
+++ b/packages/core/src/shell/bottom-navbar.test.tsx
@@ -1,0 +1,133 @@
+import { IconBook, IconHome, IconSettings, IconShieldCheck } from '@tabler/icons-react'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { describeConformance } from '../test-utils/conformance'
+import { BottomNavbar, type BottomNavbarUser,type BottomNavItem } from './bottom-navbar'
+
+const primaryItems: BottomNavItem[] = [
+  { title: 'Home', href: '/', icon: <IconHome />, exact: true },
+  { title: 'Docs', href: '/docs', icon: <IconBook /> },
+]
+
+const moreItems: BottomNavItem[] = [
+  { title: 'Settings', href: '/settings', icon: <IconSettings /> },
+  { title: 'Admin', href: '/admin', icon: <IconShieldCheck />, roles: ['Admin'] },
+]
+
+const admin: BottomNavbarUser = { name: 'Aarav', role: 'Admin' }
+const associate: BottomNavbarUser = { name: 'Priya', role: 'Associate' }
+
+describeConformance('BottomNavbar', (props) => (
+  <BottomNavbar primaryItems={primaryItems} {...props} />
+))
+
+describe('BottomNavbar', () => {
+  it('renders primary items as links', () => {
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} />)
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument()
+  })
+
+  it('marks the active item with aria-current="page"', () => {
+    render(<BottomNavbar currentPath="/docs" primaryItems={primaryItems} />)
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('exact matching: "/" is only active on exact path', () => {
+    render(<BottomNavbar currentPath="/docs" primaryItems={primaryItems} />)
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current')
+  })
+
+  it('renders a notification badge and caps at 99+', () => {
+    render(
+      <BottomNavbar
+        currentPath="/"
+        primaryItems={[
+          { title: 'Home', href: '/', icon: <IconHome />, badge: 3 },
+          { title: 'Docs', href: '/docs', icon: <IconBook />, badge: 147 },
+        ]}
+      />,
+    )
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('99+')).toBeInTheDocument()
+  })
+
+  it('hides a zero/undefined badge', () => {
+    render(
+      <BottomNavbar
+        currentPath="/"
+        primaryItems={[{ title: 'Home', href: '/', icon: <IconHome />, badge: 0 }]}
+      />,
+    )
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  // ── Role gating ──────────────────────────────────────────────
+  it('role-gated item is shown to a matching role', async () => {
+    const user = userEvent.setup()
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={moreItems} user={admin} />)
+    await user.click(screen.getByRole('button', { name: 'More navigation options' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByRole('link', { name: 'Admin' })).toBeInTheDocument()
+  })
+
+  it('role-gated item is hidden from a non-matching role', async () => {
+    const user = userEvent.setup()
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={moreItems} user={associate} />)
+    await user.click(screen.getByRole('button', { name: 'More navigation options' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument()
+    expect(within(dialog).getByRole('link', { name: 'Settings' })).toBeInTheDocument()
+  })
+
+  it('role-gated item is hidden when there is no user', async () => {
+    const user = userEvent.setup()
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={moreItems} user={null} />)
+    await user.click(screen.getByRole('button', { name: 'More navigation options' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).queryByRole('link', { name: 'Admin' })).not.toBeInTheDocument()
+  })
+
+  it('canView predicate overrides roles', () => {
+    const canView = vi.fn(() => false)
+    render(
+      <BottomNavbar
+        currentPath="/"
+        primaryItems={[{ title: 'Secret', href: '/secret', icon: <IconShieldCheck />, canView }]}
+        user={admin}
+      />,
+    )
+    expect(screen.queryByRole('link', { name: 'Secret' })).not.toBeInTheDocument()
+    expect(canView).toHaveBeenCalledWith(admin)
+  })
+
+  // ── More sheet ───────────────────────────────────────────────
+  it('opens the More sheet and closes it after selecting an item', async () => {
+    const user = userEvent.setup()
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={[moreItems[0]]} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'More navigation options' }))
+    const dialog = await screen.findByRole('dialog')
+    const settings = within(dialog).getByRole('link', { name: 'Settings' })
+    await user.click(settings)
+    // selecting an item requests close
+    expect(await screen.findByRole('button', { name: 'More navigation options' })).toBeInTheDocument()
+  })
+
+  it('does not render a More button when there are no (visible) overflow items', () => {
+    render(<BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={[]} />)
+    expect(screen.queryByRole('button', { name: 'More navigation options' })).not.toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <BottomNavbar currentPath="/" primaryItems={primaryItems} moreItems={moreItems} user={admin} />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/shell/bottom-navbar.tsx
+++ b/packages/core/src/shell/bottom-navbar.tsx
@@ -54,8 +54,14 @@ export interface BottomNavItem {
   canView?: (user: BottomNavbarUser | null) => boolean
 }
 
-/** Active-item indicator: a top underline (default) or a Material-3 pill behind the icon. */
-export type BottomNavIndicator = 'underline' | 'pill'
+/**
+ * Active-item indicator, animated between items on selection:
+ * - `pill` (default) — Material-3 tonal pill behind the icon
+ * - `underline` — top accent bar (Material-2 tab style)
+ * - `tint` — subtle background tint on the whole active cell
+ * - `none` — no shape; rely on the filled `activeIcon` + accent color (iOS)
+ */
+export type BottomNavIndicator = 'pill' | 'underline' | 'tint' | 'none'
 /** Show labels always (default) or only for the selected item (narrow viewports). */
 export type BottomNavLabelVisibility = 'always' | 'selected'
 
@@ -68,7 +74,7 @@ export interface BottomNavbarProps extends React.HTMLAttributes<HTMLElement> {
   primaryItems?: BottomNavItem[]
   /** Additional items shown in the "More" overflow sheet */
   moreItems?: BottomNavItem[]
-  /** Active-indicator style. @default 'underline' */
+  /** Active-indicator style. @default 'pill' */
   indicator?: BottomNavIndicator
   /** Label visibility. @default 'always' */
   labelVisibility?: BottomNavLabelVisibility
@@ -113,32 +119,36 @@ function NavBadge({ count }: { count: number }) {
 // Active indicator (shared-element)
 // -----------------------------------------------------------------------
 
+/**
+ * The active-item indicator. A single shared-element (`layoutId`) that SLIDES
+ * to the selected item and fades in on first appearance. `none` renders
+ * nothing (the filled `activeIcon` + accent color carry the state).
+ */
 function ActiveIndicator({
   indicator,
+  layoutId,
   reduced,
 }: {
   indicator: BottomNavIndicator
+  layoutId: string
   reduced: boolean
 }) {
-  const transition = reduced ? { duration: 0 } : springs.snappy
-  if (indicator === 'pill') {
-    return (
-      <motion.span
-        layoutId="bottom-nav-indicator"
-        aria-hidden="true"
-        transition={transition}
-        className="absolute inset-0 rounded-pill bg-accent-3"
-      />
-    )
+  if (indicator === 'none') return null
+  const common = {
+    layoutId,
+    'aria-hidden': true as const,
+    transition: reduced ? { duration: 0 } : springs.snappy,
+    initial: reduced ? false : { opacity: 0 },
+    animate: { opacity: 1 },
   }
-  return (
-    <motion.span
-      layoutId="bottom-nav-indicator"
-      aria-hidden="true"
-      transition={transition}
-      className="absolute top-0 h-[3px] w-full rounded-b-control-inner bg-accent-9"
-    />
-  )
+  if (indicator === 'underline') {
+    return <motion.span {...common} className="absolute top-0 h-[3px] w-full rounded-b-control-inner bg-accent-9" />
+  }
+  if (indicator === 'tint') {
+    return <motion.span {...common} className="absolute inset-0 rounded-control bg-accent-3" />
+  }
+  // pill (default) — Material-3 tonal pill behind the icon
+  return <motion.span {...common} className="absolute inset-0 rounded-pill bg-accent-3" />
 }
 
 // -----------------------------------------------------------------------
@@ -146,18 +156,20 @@ function ActiveIndicator({
 // -----------------------------------------------------------------------
 
 const itemClass =
-  'flex h-16 w-full min-w-0 cursor-pointer flex-col items-center justify-center gap-ds-02 px-ds-01 pt-0 text-body-sm transition-colors duration-fast-02 ease-productive-standard'
+  'relative flex h-16 w-full min-w-0 cursor-pointer flex-col items-center justify-center gap-ds-02 px-ds-01 pt-0 text-body-sm transition-colors duration-fast-02 ease-productive-standard'
 
 function BottomNavLink({
   item,
   isActive,
   indicator,
+  indicatorId,
   showLabel,
   reduced,
 }: {
   item: BottomNavItem
   isActive: boolean
   indicator: BottomNavIndicator
+  indicatorId: string
   showLabel: boolean
   reduced: boolean
 }) {
@@ -174,12 +186,18 @@ function BottomNavLink({
         aria-current={isActive ? 'page' : undefined}
         className={cn(itemClass, isActive ? 'font-semibold text-accent-11' : 'text-surface-fg-subtle')}
       >
+        {/* tint covers the whole cell — sits behind the content */}
+        {isActive && indicator === 'tint' && (
+          <ActiveIndicator indicator="tint" layoutId={indicatorId} reduced={reduced} />
+        )}
         <div className="relative flex w-full min-w-0 flex-col items-center gap-ds-02">
           {isActive && indicator === 'underline' && (
-            <ActiveIndicator indicator="underline" reduced={reduced} />
+            <ActiveIndicator indicator="underline" layoutId={indicatorId} reduced={reduced} />
           )}
           <div className="relative px-ds-04 py-ds-01">
-            {isActive && indicator === 'pill' && <ActiveIndicator indicator="pill" reduced={reduced} />}
+            {isActive && indicator === 'pill' && (
+              <ActiveIndicator indicator="pill" layoutId={indicatorId} reduced={reduced} />
+            )}
             <span className="relative [&>svg]:h-ico-md [&>svg]:w-ico-md" aria-hidden="true">
               <IconProvider size="md">
                 {normalizeIcon(isActive && item.activeIcon ? item.activeIcon : item.icon)}
@@ -205,7 +223,7 @@ const BottomNavbar = React.forwardRef<HTMLElement, BottomNavbarProps>(
       user = null,
       primaryItems = [],
       moreItems = [],
-      indicator = 'underline',
+      indicator = 'pill',
       labelVisibility = 'always',
       className,
       ...props
@@ -215,6 +233,9 @@ const BottomNavbar = React.forwardRef<HTMLElement, BottomNavbarProps>(
     const Link = useLink()
     const reduced = useReducedMotion() ?? false
     const [showMore, setShowMore] = useState(false)
+    // Scope the shared-element layoutId per instance so two navbars don't animate into each other.
+    const instanceId = React.useId()
+    const indicatorId = `${instanceId}-nav-indicator`
 
     const isActive = (path: string, exact = false) => {
       if (exact || path === '/') return currentPath === path
@@ -245,6 +266,7 @@ const BottomNavbar = React.forwardRef<HTMLElement, BottomNavbarProps>(
             item={item}
             isActive={isActive(item.href, item.exact)}
             indicator={indicator}
+            indicatorId={indicatorId}
             showLabel={labelVisibility === 'always' || isActive(item.href, item.exact)}
             reduced={reduced}
           />
@@ -264,12 +286,17 @@ const BottomNavbar = React.forwardRef<HTMLElement, BottomNavbarProps>(
                   moreSelected ? 'font-semibold text-accent-11' : 'text-surface-fg-subtle',
                 )}
               >
+                {moreSelected && indicator === 'tint' && (
+                  <ActiveIndicator indicator="tint" layoutId={indicatorId} reduced={reduced} />
+                )}
                 <div className="relative flex w-full min-w-0 flex-col items-center gap-ds-02">
                   {moreSelected && indicator === 'underline' && (
-                    <ActiveIndicator indicator="underline" reduced={reduced} />
+                    <ActiveIndicator indicator="underline" layoutId={indicatorId} reduced={reduced} />
                   )}
-                  <div className="relative p-ds-03">
-                    {moreSelected && indicator === 'pill' && <ActiveIndicator indicator="pill" reduced={reduced} />}
+                  <div className="relative px-ds-04 py-ds-01">
+                    {moreSelected && indicator === 'pill' && (
+                      <ActiveIndicator indicator="pill" layoutId={indicatorId} reduced={reduced} />
+                    )}
                     <Icon icon={IconDots} />
                   </div>
                   {showMoreLabel && <span className="max-w-full truncate text-center">More</span>}

--- a/packages/core/src/shell/bottom-navbar.tsx
+++ b/packages/core/src/shell/bottom-navbar.tsx
@@ -3,25 +3,33 @@
 /**
  * BottomNavbar -- Mobile bottom navigation bar.
  *
- * Props-driven: accepts currentPath, user, navItems instead of
- * reading from Remix hooks or Zustand stores.
+ * Props-driven (currentPath / user / items) and router-agnostic via `useLink`.
+ * The "More" overflow uses the DS `Sheet` primitive, so it inherits focus trap,
+ * scroll lock, return-focus, `aria-modal`, and trigger↔panel ARIA wiring.
  */
-import { IconDots, IconX } from '@tabler/icons-react'
-import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { IconDots } from '@tabler/icons-react'
+import { motion, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
-import { useCallback,useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 
+import { Badge } from '../ui/badge'
 import { Icon } from '../ui/icon'
 import { IconProvider } from '../ui/icon-context'
 import type { IconInput } from '../ui/lib/icon-input'
 import { springs } from '../ui/lib/motion'
 import { normalizeIcon } from '../ui/lib/normalize-icon'
 import { cn } from '../ui/lib/utils'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '../ui/sheet'
 import { useLink } from './link-context'
 
 // -----------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------
+
+export interface BottomNavbarUser {
+  name: string
+  role?: string
+}
 
 export interface BottomNavItem {
   title: string
@@ -32,45 +40,102 @@ export interface BottomNavItem {
   exact?: boolean
   /** Notification badge count. 0 or undefined = hidden, 1–99 = shown, >99 = "99+" */
   badge?: number
+  /**
+   * Roles allowed to see this item, matched against `user.role`. Omit to show
+   * it to everyone. For arbitrary logic, use `canView` instead.
+   */
+  roles?: string[]
+  /**
+   * Visibility predicate — full control over whether this item renders.
+   * Receives the current `user` (or `null`). Takes precedence over `roles`.
+   */
+  canView?: (user: BottomNavbarUser | null) => boolean
 }
 
-export interface BottomNavbarUser {
-  name: string
-  role?: string
-}
+/** Active-item indicator: a top underline (default) or a Material-3 pill behind the icon. */
+export type BottomNavIndicator = 'underline' | 'pill'
+/** Show labels always (default) or only for the selected item (narrow viewports). */
+export type BottomNavLabelVisibility = 'always' | 'selected'
 
-export interface BottomNavbarProps
-  extends React.HTMLAttributes<HTMLElement> {
+export interface BottomNavbarProps extends React.HTMLAttributes<HTMLElement> {
   /** Currently active pathname */
   currentPath?: string
-  /** User information (used to determine admin status, presence) */
+  /** Current user. Drives per-item role gating via `item.roles` / `item.canView`. */
   user?: BottomNavbarUser | null
   /** Primary nav items shown directly in the bottom bar (max 4 recommended) */
   primaryItems?: BottomNavItem[]
-  /** Additional items shown in the "More" overflow menu */
+  /** Additional items shown in the "More" overflow sheet */
   moreItems?: BottomNavItem[]
+  /** Active-indicator style. @default 'underline' */
+  indicator?: BottomNavIndicator
+  /** Label visibility. @default 'always' */
+  labelVisibility?: BottomNavLabelVisibility
   /** Additional className for the nav element */
   className?: string
 }
 
 // -----------------------------------------------------------------------
-// NavBadge (internal)
+// Helpers
+// -----------------------------------------------------------------------
+
+/** Per-item role/visibility gate. `canView` wins; else `roles` matched against user.role; else visible. */
+function itemVisible(item: BottomNavItem, user: BottomNavbarUser | null): boolean {
+  if (item.canView) return item.canView(user)
+  if (item.roles && item.roles.length > 0) {
+    return !!user?.role && item.roles.includes(user.role)
+  }
+  return true
+}
+
+// -----------------------------------------------------------------------
+// NavBadge (composes Badge)
 // -----------------------------------------------------------------------
 
 function NavBadge({ count }: { count: number }) {
   if (!count || count <= 0) return null
   const display = count > 99 ? '99+' : String(count)
-  const isMultiDigit = count >= 10
   return (
-    <span
+    <Badge
+      color="error"
+      variant="solid"
+      size="xs"
       aria-label={`${count} notifications`}
-      className={cn(
-        'absolute -right-1 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-pill bg-error-9 text-[10px] font-semibold leading-none text-error-fg animate-in zoom-in-75',
-        isMultiDigit ? 'px-0.5' : '',
-      )}
+      className="pointer-events-none absolute -end-1 -top-1 justify-center px-ds-01 tabular-nums motion-safe:animate-in motion-safe:zoom-in-75"
     >
       {display}
-    </span>
+    </Badge>
+  )
+}
+
+// -----------------------------------------------------------------------
+// Active indicator (shared-element)
+// -----------------------------------------------------------------------
+
+function ActiveIndicator({
+  indicator,
+  reduced,
+}: {
+  indicator: BottomNavIndicator
+  reduced: boolean
+}) {
+  const transition = reduced ? { duration: 0 } : springs.snappy
+  if (indicator === 'pill') {
+    return (
+      <motion.span
+        layoutId="bottom-nav-indicator"
+        aria-hidden="true"
+        transition={transition}
+        className="absolute inset-0 rounded-pill bg-accent-3"
+      />
+    )
+  }
+  return (
+    <motion.span
+      layoutId="bottom-nav-indicator"
+      aria-hidden="true"
+      transition={transition}
+      className="absolute top-0 h-[3px] w-full rounded-b-control-inner bg-accent-9"
+    />
   )
 }
 
@@ -78,45 +143,47 @@ function NavBadge({ count }: { count: number }) {
 // BottomNavLink (internal)
 // -----------------------------------------------------------------------
 
+const itemClass =
+  'flex h-16 w-full min-w-0 cursor-pointer flex-col items-center justify-center gap-ds-02 px-ds-01 pt-0 text-body-sm transition-colors duration-fast-02 ease-productive-standard'
+
 function BottomNavLink({
   item,
   isActive,
-  onClick,
+  indicator,
+  showLabel,
+  reduced,
 }: {
   item: BottomNavItem
   isActive: boolean
-  onClick?: () => void
+  indicator: BottomNavIndicator
+  showLabel: boolean
+  reduced: boolean
 }) {
   const Link = useLink()
-  const prefersReducedMotion = useReducedMotion()
   return (
-    <motion.div whileTap={prefersReducedMotion ? undefined : { scale: 0.96 }} transition={prefersReducedMotion ? { duration: 0 } : springs.snappy} className="flex max-w-[70px] flex-1">
+    <motion.div
+      whileTap={reduced ? undefined : { scale: 0.96 }}
+      transition={reduced ? { duration: 0 } : springs.snappy}
+      className="flex min-w-0 flex-1 basis-0"
+    >
       <Link
         href={item.href}
-        onClick={onClick}
         aria-label={item.title}
         aria-current={isActive ? 'page' : undefined}
-        className={cn(
-          'flex h-16 w-full cursor-pointer flex-col items-center gap-ds-02 p-ds-02 pt-0 text-body-sm transition-colors duration-fast-02 ease-productive-standard',
-          isActive
-            ? 'font-semibold text-accent-11'
-            : 'text-surface-fg-subtle',
-        )}
+        className={cn(itemClass, isActive ? 'font-semibold text-accent-11' : 'text-surface-fg-subtle')}
       >
-        <div className="relative flex w-full flex-col items-center gap-ds-02">
-          {isActive && (
-            <motion.div
-              layoutId="bottom-nav-indicator"
-              className="absolute top-0 h-[3px] w-full rounded-b-control-inner bg-accent-9 p-0"
-              aria-hidden="true"
-              transition={prefersReducedMotion ? { duration: 0 } : springs.snappy}
-            />
+        <div className="relative flex w-full min-w-0 flex-col items-center gap-ds-02">
+          {isActive && indicator === 'underline' && (
+            <ActiveIndicator indicator="underline" reduced={reduced} />
           )}
           <div className="relative p-ds-03">
-            <span className="[&>svg]:h-ico-md [&>svg]:w-ico-md" aria-hidden="true"><IconProvider size="md">{normalizeIcon(item.icon)}</IconProvider></span>
+            {isActive && indicator === 'pill' && <ActiveIndicator indicator="pill" reduced={reduced} />}
+            <span className="relative [&>svg]:h-ico-md [&>svg]:w-ico-md" aria-hidden="true">
+              <IconProvider size="md">{normalizeIcon(item.icon)}</IconProvider>
+            </span>
             {item.badge != null && <NavBadge count={item.badge} />}
           </div>
-          <span className="text-center">{item.title}</span>
+          {showLabel && <span className="max-w-full truncate text-center">{item.title}</span>}
         </div>
       </Link>
     </motion.div>
@@ -131,157 +198,113 @@ const BottomNavbar = React.forwardRef<HTMLElement, BottomNavbarProps>(
   (
     {
       currentPath = '/',
-      user: _user,
+      user = null,
       primaryItems = [],
       moreItems = [],
+      indicator = 'underline',
+      labelVisibility = 'always',
       className,
       ...props
     },
     ref,
   ) => {
     const Link = useLink()
-    const prefersReducedMotion = useReducedMotion()
+    const reduced = useReducedMotion() ?? false
     const [showMore, setShowMore] = useState(false)
-    const overlayRef = useRef<HTMLDivElement>(null)
-
-    const closeMore = useCallback(() => setShowMore(false), [])
-
-    // Focus first focusable item when overlay opens
-    useEffect(() => {
-      if (showMore && overlayRef.current) {
-        const firstFocusable = overlayRef.current.querySelector<HTMLElement>('a, button')
-        firstFocusable?.focus()
-      }
-    }, [showMore])
 
     const isActive = (path: string, exact = false) => {
-      if (exact || path === '/') {
-        return currentPath === path
-      }
+      if (exact || path === '/') return currentPath === path
       return currentPath.startsWith(path)
     }
 
-    // Check if any "more" item is active
-    const isMoreActive = moreItems.some((item) =>
-      isActive(item.href, item.exact),
-    )
+    // Role/visibility gating
+    const visiblePrimary = primaryItems.filter((item) => itemVisible(item, user))
+    const visibleMore = moreItems.filter((item) => itemVisible(item, user))
+
+    const isMoreActive = visibleMore.some((item) => isActive(item.href, item.exact))
+    const moreSelected = showMore || isMoreActive
+    const showMoreLabel = labelVisibility === 'always' || moreSelected
 
     return (
-      <>
-        {/* More Menu Overlay */}
-        <AnimatePresence>
-        {showMore && (
-          // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- backdrop overlay, dismiss via mouse only; keyboard users close via Escape
-          <div
-            className="fixed inset-0 z-overlay md:hidden"
-            onClick={() => setShowMore(false)}
-          >
-          <div className="absolute inset-0 bg-overlay" />
-          { }
-          <motion.div
-            ref={overlayRef}
-            role="dialog"
-            aria-label="More navigation"
-            initial={{ y: '100%' }}
-            animate={{ y: 0 }}
-            exit={{ y: '100%' }}
-            transition={prefersReducedMotion ? { duration: 0 } : springs.smooth}
-            className="absolute bottom-[72px] left-0 right-0 rounded-t-bubble border-t border-surface-border-strong bg-surface-overlay p-ds-05 pb-ds-03"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => {
-              e.stopPropagation()
-              if (e.key === 'Escape') closeMore()
-            }}
-          >
-            <div className="mb-ds-04 flex items-center justify-between">
-              <span className="text-body-md font-semibold text-surface-fg">
-                More
-              </span>
-              <button
-                onClick={() => setShowMore(false)}
-                aria-label="Close more menu"
-                className="flex h-ds-sm w-ds-sm items-center justify-center rounded-pill hover:bg-surface-raised-hover"
-              >
-                <Icon icon={IconX} size="sm" className="text-surface-fg-muted" />
-              </button>
-            </div>
-            <div className="grid grid-cols-4 gap-ds-03">
-              {moreItems.map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setShowMore(false)}
-                  className={cn(
-                    'flex flex-col items-center gap-ds-02b rounded-overlay-lg p-ds-04 text-body-sm transition-colors ease-productive-standard',
-                    isActive(item.href, item.exact)
-                      ? 'bg-surface-raised-hover text-accent-11'
-                      : 'text-surface-fg-subtle hover:bg-surface-raised-hover',
-                  )}
-                >
-                  <span className="[&>svg]:h-ico-md [&>svg]:w-ico-md"><IconProvider size="md">{normalizeIcon(item.icon)}</IconProvider></span>
-                  <span className="text-center">
-                    {item.title}
-                  </span>
-                </Link>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      )}
-        </AnimatePresence>
-
-      {/* Bottom Navigation Bar */}
       <nav
         {...props}
         ref={ref}
         aria-label="Mobile navigation"
         className={cn(
-          'fixed bottom-0 left-0 right-0 z-sticky flex w-full flex-row items-start justify-between border-t border-surface-border-strong bg-surface-chrome px-ds-05 pb-safe pt-0 md:hidden',
+          'fixed bottom-0 start-0 end-0 z-sticky flex w-full flex-row items-stretch justify-between border-t border-surface-border-strong bg-surface-chrome px-ds-05 pb-safe pt-0 md:hidden',
           className,
         )}
       >
-        {primaryItems.map((item) => (
+        {visiblePrimary.map((item) => (
           <BottomNavLink
             key={item.href}
             item={item}
             isActive={isActive(item.href, item.exact)}
+            indicator={indicator}
+            showLabel={labelVisibility === 'always' || isActive(item.href, item.exact)}
+            reduced={reduced}
           />
         ))}
 
-        {/* More Button */}
-        {moreItems.length > 0 && (
-          <motion.button
-            type="button"
-            onClick={() => setShowMore(!showMore)}
-            aria-label="More navigation options"
-            aria-expanded={showMore}
-            whileTap={prefersReducedMotion ? undefined : { y: -2 }}
-            transition={prefersReducedMotion ? { duration: 0 } : springs.snappy}
-            className={cn(
-              'flex h-16 max-w-[70px] flex-1 cursor-pointer flex-col items-center gap-ds-02 p-ds-02 pt-0 text-body-sm',
-              showMore || isMoreActive
-                ? 'font-semibold text-accent-11'
-                : 'text-surface-fg-subtle',
-            )}
-          >
-            <div className="relative flex w-full flex-col items-center gap-ds-02">
-              {(showMore || isMoreActive) && (
-                <motion.div
-                  layoutId="bottom-nav-indicator"
-                  className="absolute top-0 h-[3px] w-full rounded-b-control-inner bg-accent-9 p-0"
-                  aria-hidden="true"
-                  transition={prefersReducedMotion ? { duration: 0 } : springs.snappy}
-                />
-              )}
-              <div className="p-ds-03">
-                <Icon icon={IconDots} />
+        {visibleMore.length > 0 && (
+          <Sheet open={showMore} onOpenChange={setShowMore}>
+            <SheetTrigger asChild>
+              <motion.button
+                type="button"
+                aria-label="More navigation options"
+                whileTap={reduced ? undefined : { scale: 0.96 }}
+                transition={reduced ? { duration: 0 } : springs.snappy}
+                className={cn(
+                  itemClass,
+                  'min-w-0 flex-1 basis-0',
+                  moreSelected ? 'font-semibold text-accent-11' : 'text-surface-fg-subtle',
+                )}
+              >
+                <div className="relative flex w-full min-w-0 flex-col items-center gap-ds-02">
+                  {moreSelected && indicator === 'underline' && (
+                    <ActiveIndicator indicator="underline" reduced={reduced} />
+                  )}
+                  <div className="relative p-ds-03">
+                    {moreSelected && indicator === 'pill' && <ActiveIndicator indicator="pill" reduced={reduced} />}
+                    <Icon icon={IconDots} />
+                  </div>
+                  {showMoreLabel && <span className="max-w-full truncate text-center">More</span>}
+                </div>
+              </motion.button>
+            </SheetTrigger>
+
+            <SheetContent side="bottom" className="rounded-t-bubble">
+              <SheetHeader>
+                <SheetTitle>More</SheetTitle>
+              </SheetHeader>
+              <div className="grid grid-cols-[repeat(auto-fit,minmax(72px,1fr))] gap-ds-03 pt-ds-04">
+                {visibleMore.map((item) => {
+                  const active = isActive(item.href, item.exact)
+                  return (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setShowMore(false)}
+                      aria-current={active ? 'page' : undefined}
+                      className={cn(
+                        'flex min-w-0 flex-col items-center gap-ds-02b rounded-overlay-lg p-ds-04 text-body-sm transition-colors ease-productive-standard',
+                        active
+                          ? 'bg-surface-raised-hover text-accent-11'
+                          : 'text-surface-fg-subtle hover:bg-surface-raised-hover',
+                      )}
+                    >
+                      <span className="[&>svg]:h-ico-md [&>svg]:w-ico-md" aria-hidden="true">
+                        <IconProvider size="md">{normalizeIcon(item.icon)}</IconProvider>
+                      </span>
+                      <span className="max-w-full truncate text-center">{item.title}</span>
+                    </Link>
+                  )
+                })}
               </div>
-              <span className="text-center">More</span>
-            </div>
-          </motion.button>
+            </SheetContent>
+          </Sheet>
         )}
       </nav>
-    </>
     )
   },
 )

--- a/packages/core/src/shell/bottom-navbar.tsx
+++ b/packages/core/src/shell/bottom-navbar.tsx
@@ -36,6 +36,8 @@ export interface BottomNavItem {
   href: string
   /** Icon for this nav item. Accepts any `IconInput`. */
   icon: IconInput
+  /** Icon shown when the item is active — e.g. a filled variant. Falls back to `icon`. */
+  activeIcon?: IconInput
   /** When true, the route matches only when the path is exactly equal */
   exact?: boolean
   /** Notification badge count. 0 or undefined = hidden, 1–99 = shown, >99 = "99+" */
@@ -176,10 +178,12 @@ function BottomNavLink({
           {isActive && indicator === 'underline' && (
             <ActiveIndicator indicator="underline" reduced={reduced} />
           )}
-          <div className="relative p-ds-03">
+          <div className="relative px-ds-04 py-ds-01">
             {isActive && indicator === 'pill' && <ActiveIndicator indicator="pill" reduced={reduced} />}
             <span className="relative [&>svg]:h-ico-md [&>svg]:w-ico-md" aria-hidden="true">
-              <IconProvider size="md">{normalizeIcon(item.icon)}</IconProvider>
+              <IconProvider size="md">
+                {normalizeIcon(isActive && item.activeIcon ? item.activeIcon : item.icon)}
+              </IconProvider>
             </span>
             {item.badge != null && <NavBadge count={item.badge} />}
           </div>


### PR DESCRIPTION
**Rebuild 1 of 4** from the finish-bar audit (#181). Bottom-navbar was 2/5 — a real a11y defect in primary mobile nav.

## Fixes the P0
The "More" overflow was a hand-rolled `role="dialog"` with **no focus trap, no scroll lock, no return-focus, no `aria-modal`**, plus a `jsx-a11y` suppression. Now it's the DS **`Sheet` (`side="bottom"`)** — all of that comes for free, plus `aria-haspopup`/`aria-controls` trigger wiring and a ≥-target built-in close.

## New capabilities
- **Composable role gating** — `BottomNavItem.roles?: string[]` (visible when `user.role` matches) + `canView?: (user) => boolean` (arbitrary logic, wins). The previously-**inert** `user` prop now drives it. Non-breaking.
- **`indicator`** — `'underline'` (default) or Material-3 `'pill'`.
- **`labelVisibility`** — `'always'` (default) or `'selected'`.

## Quality
Composes `Badge` (was re-rolled); label truncation + logical/RTL props; overflow grid adapts to count; badge animation reduced-motion gated; **restored 16 tests** (RTL + vitest-axe); stories + doc updated.

Verification: typecheck ✓ · 16 tests ✓ · lint ✓ · build ✓. Minor (additive, non-breaking).

Plan for all 4 rebuilds: `docs/plans/2026-07-24-finish-bar-rebuilds.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)