### PR TITLE
feat(priority-indicator): recompose on Badge, static severity, real a11y

### DIFF
--- a/.changeset/priority-indicator-rebuild.md
+++ b/.changeset/priority-indicator-rebuild.md
@@ -1,0 +1,14 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+**PriorityIndicator rebuild (finish-bar).** Recomposed on the `Badge` primitive instead of a bespoke re-rolled chip, fixing two P0s (unguarded infinite motion + no compact accessible name) and the radius/motion drift from `Badge`.
+
+- **Severity by weight, not motion.** URGENT is now a solid `Badge` (static, high-contrast) so the top tier reads at a glance. The perpetual scale-pulse is **removed** (it was unguarded infinite motion — WCAG 2.2.2 Pause/Stop/Hide). No animation at all now.
+- **Real compact a11y.** Icon-only chips carry `role="img"` + `aria-label` (was a mouse-only `title` on a `<div>`).
+- **New `iconOnly`** replaces the dead `display` CVA axis (both its branches emitted empty strings). `display` is kept as a **deprecated alias** (`'compact'` → icon-only).
+- **New `children`** overrides the label for i18n / custom copy.
+- Unknown `priority` values now fall back to MEDIUM instead of throwing.
+- Doc corrected (LOW = slate, not success; not server-safe).
+
+Note: because it now composes `Badge`, the rendered element (and forwarded `ref`) is a `span` rather than a `div`, and the chip uses `Badge`'s pill radius. Behavioral API (`priority`) is unchanged.

--- a/packages/core/docs/components/composed/priority-indicator.md
+++ b/packages/core/docs/components/composed/priority-indicator.md
@@ -1,37 +1,48 @@
 # PriorityIndicator
 
 - Import: @devalok/shilp-sutra/composed/priority-indicator
-- Server-safe: Yes
+- Server-safe: No
 - Category: composed
 
 ## Props
     priority: Priority
-    display: "compact" | "full" (default: "full")
+    iconOnly?: boolean (icon-only chip, no visible text)
+    display?: "compact" | "full" (@deprecated — use iconOnly)
+    children?: ReactNode (override the label, e.g. i18n)
 
 Priority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT' | 'low' | 'medium' | 'high' | 'urgent'
 
 ## Defaults
-    display="full"
+    iconOnly: false
 
 ## Example
 ```jsx
 <PriorityIndicator priority="HIGH" />
-<PriorityIndicator priority="low" display="compact" />
+<PriorityIndicator priority="low" iconOnly />
+<PriorityIndicator priority="URGENT">Critical</PriorityIndicator>
 ```
 
 ## Composability
-- **Server-safe priority label** — icon + color + text for task / issue priority.
+- **Composes `Badge`** — radius, color semantics, a11y labelling, and reduced-motion handling all come from one place (no bespoke re-roll).
 - **Composes inside list rows, DataTable cells, Card headers, task panels** — anywhere a priority flag fits.
-- **display="compact"** shows only the icon (with priority text as title attribute for tooltip). Use in tight cells; use `display="full"` (default) in free space.
-- **Case-insensitive priority** — accepts both UPPERCASE (LOW/MEDIUM/HIGH/URGENT) and lowercase. Designed to match both backend conventions without manual coercion.
-- Color semantics: LOW=success, MEDIUM=warning, HIGH=error, URGENT=error with bolder icon.
+- **`iconOnly`** shows only the icon with a real accessible name (`role="img"` + `aria-label`), for tight cells. Omit it (default) for icon + label.
+- **Severity by weight, not motion** — URGENT renders as a solid fill so the top tier reads at a glance; the others are soft. No animation (removes the prior perpetual pulse).
+- **Case-insensitive priority** — accepts both UPPERCASE and lowercase; unknown values fall back to MEDIUM instead of throwing.
+- **`children`** overrides the label for i18n / custom copy.
+- Color semantics: LOW = slate (neutral), MEDIUM = warning, HIGH = error (soft), URGENT = error (solid).
 
 ## Gotchas
-- Case-insensitive — "low" and "LOW" both work
-- Server-safe: can be imported directly in Next.js Server Components
-- `compact` display shows only the icon; `full` shows icon + text label
+- Case-insensitive — "low" and "LOW" both work; unknown values fall back to MEDIUM
+- `iconOnly` shows only the icon (accessible-named); default shows icon + text label
+- `display` is deprecated — use `iconOnly`
 
 ## Changes
+### v0.53.0
+- **Changed** Recomposed on the `Badge` primitive (was a bespoke re-rolled chip): inherits pill radius, color semantics, accessible labelling.
+- **Changed** URGENT is now a solid static fill; the perpetual scale-pulse is removed (was unguarded infinite motion, WCAG 2.2.2). Severity reads without animation.
+- **Added** `iconOnly` (replaces deprecated `display`) and `children` (label override for i18n).
+- **Fixed** Icon-only chip now has a real accessible name (`role="img"` + `aria-label`), not a mouse-only `title`. Unknown priority no longer throws.
+
 ### v0.2.0
 - **Added** Identified as server-safe component
 

--- a/packages/core/src/composed/priority-indicator.stories.tsx
+++ b/packages/core/src/composed/priority-indicator.stories.tsx
@@ -10,9 +10,13 @@ const meta: Meta<typeof PriorityIndicator> = {
       control: 'select',
       options: ['LOW', 'MEDIUM', 'HIGH', 'URGENT'],
     },
+    iconOnly: {
+      control: 'boolean',
+    },
     display: {
       control: 'select',
       options: ['full', 'compact'],
+      description: 'Deprecated — use `iconOnly`.',
     },
   },
 }
@@ -105,11 +109,31 @@ export const SideBySideComparison: Story = {
       {(['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const).map((priority) => (
         <div key={priority} style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
           <div style={{ width: 120 }}>
-            <PriorityIndicator priority={priority} display="full" />
+            <PriorityIndicator priority={priority} />
           </div>
-          <PriorityIndicator priority={priority} display="compact" />
+          <PriorityIndicator priority={priority} iconOnly />
         </div>
       ))}
     </div>
   ),
+}
+
+export const IconOnly: Story = {
+  name: 'Icon only (accessible)',
+  render: () => (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <PriorityIndicator priority="LOW" iconOnly />
+      <PriorityIndicator priority="MEDIUM" iconOnly />
+      <PriorityIndicator priority="HIGH" iconOnly />
+      <PriorityIndicator priority="URGENT" iconOnly />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Icon-only chips carry a real accessible name (`role="img"` + `aria-label`), not a mouse-only `title`. URGENT is a solid fill so the top tier reads at a glance — severity is conveyed by weight, never motion.',
+      },
+    },
+  },
 }

--- a/packages/core/src/composed/priority-indicator.test.tsx
+++ b/packages/core/src/composed/priority-indicator.test.tsx
@@ -38,17 +38,31 @@ describe('PriorityIndicator', () => {
     expect(screen.getByText('Low')).toBeInTheDocument()
   })
 
-  it('renders compact display with title attribute', () => {
-    const { container } = render(<PriorityIndicator priority="HIGH" display="compact" />)
-    const el = container.querySelector('[title="High"]')
-    expect(el).toBeInTheDocument()
-    // Should not render a text label in compact mode
+  it('iconOnly: no visible text but a real accessible name', () => {
+    render(<PriorityIndicator priority="HIGH" iconOnly />)
+    // Accessible name via aria-label + role="img" (not a mouse-only title on a div)
+    expect(screen.getByRole('img', { name: 'High' })).toBeInTheDocument()
     expect(screen.queryByText('High')).not.toBeInTheDocument()
+  })
+
+  it('deprecated display="compact" still maps to icon-only', () => {
+    render(<PriorityIndicator priority="HIGH" display="compact" />)
+    expect(screen.getByRole('img', { name: 'High' })).toBeInTheDocument()
+  })
+
+  it('children override the label (i18n)', () => {
+    render(<PriorityIndicator priority="HIGH">Alta</PriorityIndicator>)
+    expect(screen.getByText('Alta')).toBeInTheDocument()
+    expect(screen.queryByText('High')).not.toBeInTheDocument()
+  })
+
+  it('unknown priority falls back without throwing', () => {
+    // @ts-expect-error deliberately invalid priority
+    expect(() => render(<PriorityIndicator priority="BOGUS" />)).not.toThrow()
   })
 
   it('renders an SVG icon', () => {
     const { container } = render(<PriorityIndicator priority="LOW" />)
     expect(container.querySelector('svg')).toBeInTheDocument()
   })
-
 })

--- a/packages/core/src/composed/priority-indicator.tsx
+++ b/packages/core/src/composed/priority-indicator.tsx
@@ -1,142 +1,91 @@
-'use client'
-
-import type { Icon as TablerIcon } from '@tabler/icons-react'
 import {
   IconAlertTriangle,
   IconArrowDown,
   IconArrowUp,
   IconMinus,
 } from '@tabler/icons-react'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { motion } from 'framer-motion'
 import * as React from 'react'
 
-import { Icon, type IconProps } from '../ui/icon'
-import { cn } from '../ui/lib/utils'
+import { Badge, type BadgeColor, type BadgeProps } from '../ui/badge'
+import type { IconInput } from '../ui/lib/icon-input'
 
-export type Priority = 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT' | 'low' | 'medium' | 'high' | 'urgent'
+export type Priority =
+  | 'LOW'
+  | 'MEDIUM'
+  | 'HIGH'
+  | 'URGENT'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'urgent'
 
+/**
+ * Severity is conveyed by **icon + color + weight**, never motion. URGENT uses
+ * a solid fill so the top tier reads at a glance without any animation
+ * (matches Linear/Jira; also removes the prior WCAG 2.2.2 infinite-pulse issue).
+ */
 const priorityConfig: Record<
-  Uppercase<Priority>,
-  { icon: TablerIcon; color: string; bgColor: string; label: string }
+  'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT',
+  { icon: IconInput; color: BadgeColor; variant: NonNullable<BadgeProps['variant']>; label: string }
 > = {
-  LOW: {
-    icon: IconArrowDown,
-    color: 'text-category-slate-11',
-    bgColor: 'bg-category-slate-3',
-    label: 'Low',
-  },
-  MEDIUM: {
-    icon: IconMinus,
-    color: 'text-warning-11',
-    bgColor: 'bg-warning-3',
-    label: 'Medium',
-  },
-  HIGH: {
-    icon: IconArrowUp,
-    color: 'text-error-11',
-    bgColor: 'bg-error-3',
-    label: 'High',
-  },
-  URGENT: {
-    icon: IconAlertTriangle,
-    color: 'text-error-11',
-    bgColor: 'bg-error-3',
-    label: 'Urgent',
-  },
+  LOW: { icon: IconArrowDown, color: 'slate', variant: 'soft', label: 'Low' },
+  MEDIUM: { icon: IconMinus, color: 'warning', variant: 'soft', label: 'Medium' },
+  HIGH: { icon: IconArrowUp, color: 'error', variant: 'soft', label: 'High' },
+  URGENT: { icon: IconAlertTriangle, color: 'error', variant: 'solid', label: 'Urgent' },
 }
 
-const priorityVariants = cva(
-  'inline-flex items-center gap-ds-02b font-body',
-  {
-    variants: {
-      display: {
-        compact: '',
-        full: '',
-      },
-    },
-    defaultVariants: {
-      display: 'full',
-    },
-  },
-)
-
-export interface PriorityIndicatorProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
-    VariantProps<typeof priorityVariants> {
+export interface PriorityIndicatorProps extends React.HTMLAttributes<HTMLElement> {
   priority: Priority
+  /** Render an icon-only chip (no visible text). Set an accessible name is handled automatically. */
+  iconOnly?: boolean
+  /**
+   * @deprecated Use `iconOnly`. `'compact'` → icon-only, `'full'` → labeled.
+   * Accepted for back-compat; maps to `iconOnly`.
+   */
+  display?: 'compact' | 'full'
+  /** Override the label text (i18n / custom copy). Defaults to the priority name. */
+  children?: React.ReactNode
 }
 
-const PriorityIndicator = React.forwardRef<HTMLDivElement, PriorityIndicatorProps>(
-  ({ priority, display, className, ...props }, ref) => {
-    const normalizedPriority = priority.toUpperCase() as 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'
-    const config = priorityConfig[normalizedPriority]
-    const PriorityIcon = config.icon as IconProps['icon']
+/**
+ * Presentational priority chip — composes `Badge` so radius, color semantics,
+ * a11y labeling, and reduced-motion handling come from one place.
+ */
+const PriorityIndicator = React.forwardRef<HTMLElement, PriorityIndicatorProps>(
+  ({ priority, iconOnly, display, children, ...props }, ref) => {
+    const key = priority.toUpperCase() as 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT'
+    // Defensive fallback: an unexpected priority string renders as MEDIUM
+    // rather than throwing on `config.icon`.
+    const config = priorityConfig[key] ?? priorityConfig.MEDIUM
+    const compact = iconOnly ?? display === 'compact'
+    const label = children ?? config.label
 
-    const isUrgent = normalizedPriority === 'URGENT'
-
-    if (display === 'compact') {
-      const iconWrapper = (
-        <div
+    if (compact) {
+      return (
+        <Badge
           ref={ref}
-          className={cn(
-            'inline-flex items-center justify-center rounded-control p-ds-02',
-            config.bgColor,
-            className,
-          )}
-          title={config.label}
           {...props}
-        >
-          <Icon icon={PriorityIcon} size="sm" className={config.color} />
-        </div>
+          variant={config.variant}
+          color={config.color}
+          size="sm"
+          startIcon={config.icon}
+          role="img"
+          aria-label={typeof label === 'string' ? label : config.label}
+        />
       )
-
-      if (isUrgent) {
-        return (
-          <motion.div
-            animate={{ scale: [1, 1.1, 1] }}
-            transition={{ repeat: Infinity, duration: 2, ease: 'easeInOut' }}
-            className="inline-flex"
-          >
-            {iconWrapper}
-          </motion.div>
-        )
-      }
-
-      return iconWrapper
     }
 
     return (
-      <div
+      <Badge
         ref={ref}
-        className={cn(priorityVariants({ display }), className)}
         {...props}
+        variant={config.variant}
+        color={config.color}
+        size="sm"
+        startIcon={config.icon}
       >
-        {isUrgent ? (
-          <motion.div
-            animate={{ scale: [1, 1.1, 1] }}
-            transition={{ repeat: Infinity, duration: 2, ease: 'easeInOut' }}
-            className={cn(
-              'inline-flex items-center justify-center rounded-control p-ds-01',
-              config.bgColor,
-            )}
-          >
-            <Icon icon={PriorityIcon} size="sm" className={config.color} />
-          </motion.div>
-        ) : (
-          <div
-            className={cn(
-              'inline-flex items-center justify-center rounded-control p-ds-01',
-              config.bgColor,
-            )}
-          >
-            <Icon icon={PriorityIcon} size="sm" className={config.color} />
-          </div>
-        )}
-        <span className="text-body-sm text-surface-fg-muted">
-          {config.label}
-        </span>
-      </div>
+        {label}
+      </Badge>
     )
   },
 )


### PR DESCRIPTION
**Rebuild 2 of 4** from the finish-bar audit (#181). PriorityIndicator was 2/5 — two P0s (unguarded infinite motion + no compact accessible name) + composition drift.

## Fixes
- **Recomposed on `Badge`** (was a bespoke re-rolled chip ×3). Inherits pill radius, color semantics, a11y labelling, reduced-motion handling.
- **Severity by weight, not motion.** URGENT is a solid Badge (static, high-contrast); the perpetual scale-pulse is **gone** (was unguarded infinite motion — WCAG 2.2.2). Zero animation now.
- **Real compact a11y** — icon-only chips carry `role="img"` + `aria-label` (was a mouse-only `title` on a `<div>`).

## API
- **`iconOnly`** (new) replaces the dead `display` CVA axis (both branches emitted `''`). `display` kept as a **deprecated alias**.
- **`children`** (new) overrides the label (i18n). Unknown `priority` falls back to MEDIUM instead of throwing.

Doc corrected (LOW = slate, not success; not server-safe). Tests: 14 (incl. compact a11y name + fallback).

Note: composing Badge means the root element/ref is now a `span` (was `div`); chip uses Badge's pill radius. `priority` API unchanged.

Verification: typecheck ✓ · 14 tests ✓ · lint ✓. Minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)