### PR TITLE
feat(schedule-view): grid a11y + overlapping columns + live now-line

### DIFF
--- a/.changeset/schedule-view-rebuild.md
+++ b/.changeset/schedule-view-rebuild.md
@@ -1,0 +1,16 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+**ScheduleView rebuild (finish-bar).** Fixes the P0 a11y flood, the overlapping-event illegibility, the stale now-line, and the surface/border regression.
+
+- **No more phantom tab stops.** Slots are focusable/keyboard-navigable only when `onSlotClick` is set; otherwise they're inert grid lines. A read-only week view previously exposed ~140 sequential tab stops. Interactive slots now use **roving tabindex + Arrow/Home/End** navigation (RTL-aware) — one tab stop into the widget.
+- **Overlapping events** partition into side-by-side columns (greedy interval colouring) instead of stacking on top of each other.
+- **Live now-line** — ticks every minute and scrolls into view on mount (was frozen at mount time).
+- **Surface fix** — shell uses the `surface-2` card tier + `rounded-surface` + a real border (was `surface-raised` + the dead `border-card-strong` class).
+- **RTL** — logical properties throughout; now-dot centered via transform.
+- **New props:** `selectedEventId` (rings the active event), `renderEvent` (custom event body), `header` (toolbar slot), `emptyState`, `height`.
+
+Non-breaking: `view`/`date`/`events`/`onEventClick`/`onSlotClick` unchanged; new props additive.
+
+Scope note: full ARIA grid-matrix semantics (`role="grid"` with row/column indices) were intentionally not adopted — the component stays a labelled `region` with keyboard-navigable slots, which is honest and lint-clean rather than a partial/broken grid.

--- a/packages/core/docs/components/composed/schedule-view.md
+++ b/packages/core/docs/components/composed/schedule-view.md
@@ -10,14 +10,19 @@
     events: ScheduleEvent[] (REQUIRED) — { id, title, start: Date, end: Date, color? }
     onEventClick?: (event: ScheduleEvent) => void
     onSlotClick?: (start: Date, end: Date) => void
-    startHour: number (default: 8)
-    endHour: number (default: 18, exclusive)
-    slotDuration: number (minutes, default: 30)
+    startHour?: number (default: 8)
+    endHour?: number (default: 18, exclusive)
+    slotDuration?: number (minutes, default: 30)
+    selectedEventId?: string (rings the active event)
+    renderEvent?: (event) => ReactNode (custom event body)
+    header?: ReactNode (toolbar slot above the grid)
+    emptyState?: ReactNode (shown when events is empty)
+    height?: number | string (grid body height, default 480)
 
 Event colors: "accent" | "success" | "warning" | "error" | "info" | "neutral"
 
 ## Defaults
-    startHour=8, endHour=18, slotDuration=30
+    startHour=8, endHour=18, slotDuration=30, height=480
 
 ## Example
 ```jsx
@@ -32,7 +37,12 @@ Event colors: "accent" | "success" | "warning" | "error" | "info" | "neutral"
 ## Composability
 - **Day / Week calendar view** for time-block display (meetings, shifts, availability). Not a full calendar app — no month view, no drag-to-create.
 - **Event data is consumer-owned:** You pass `events` as an array; ScheduleView doesn't fetch, doesn't cache, doesn't expand recurring events. All scheduling logic lives in your app.
-- **Event click + slot click** — `onEventClick` for existing events; `onSlotClick` for creating new events (fires with start/end of the empty slot).
+- **Event click + slot click** — `onEventClick` for existing events; `onSlotClick` for creating new events (fires with start/end of the empty slot). **Slots are only interactive (focusable + keyboard-navigable) when `onSlotClick` is set** — otherwise they render as inert grid lines, so a read-only schedule adds no keyboard/AT tab stops.
+- **Keyboard (interactive slots):** roving tabindex — Arrow keys move between slots (up/down within a day, left/right across days, RTL-aware), Home/End jump within the day; only one slot is in the tab order at a time.
+- **Overlapping events** are partitioned into side-by-side columns automatically so double-booked times stay legible.
+- **Live now-line** ticks every minute and scrolls into view on mount.
+- **`renderEvent`** customizes the event block body; **`header`** adds a toolbar; **`selectedEventId`** rings the active event; **`emptyState`** shows when there are no events.
+- **Composes the DS card shell tokens** (`surface-2` + `rounded-surface` + border) and is RTL-safe (logical properties throughout).
 - **Color vocabulary matches the DS** — `accent/success/warning/error/info/neutral`. Map your event types to these at the data layer.
 - **endHour is exclusive:** `endHour=18` means the last visible slot starts at 17:30 (with 30min slots). Match your UX expectation: 9-5 typically means `startHour=9, endHour=18`.
 - **Pairs with date-picker/composed** — use DatePicker or DateRangePicker to choose which date to show; pass that as ScheduleView's `date`.
@@ -43,6 +53,11 @@ Event colors: "accent" | "success" | "warning" | "error" | "info" | "neutral"
 - Events that span outside `startHour`/`endHour` may be clipped
 
 ## Changes
+### v0.53.0
+- **Changed** Read-only schedules no longer flood the tab order — slots are interactive only when `onSlotClick` is set; otherwise inert grid lines. Interactive slots use roving tabindex + Arrow/Home/End keyboard navigation (RTL-aware).
+- **Changed** Overlapping events now lay out in side-by-side columns instead of stacking illegibly. The now-line ticks live (per-minute) and scrolls into view; shell uses the `surface-2` card tier (fixed the prior `surface-raised` + dead-`border-card-strong` regression); layout uses logical (RTL-safe) properties; magic-number sizes tokenized.
+- **Added** `selectedEventId`, `renderEvent`, `header`, `emptyState`, and `height` props.
+
 ### v0.49.0
 - **BREAKING** `ScheduleEvent.color` value `"primary"` renamed `"accent"` (DS colour vocabulary). It was the default, so untyped events are unaffected.
 - **Added** keyboard focus rings on slot cells + event blocks; current-time indicator uses the shared `<Dot>`.

--- a/packages/core/src/composed/schedule-view.test.tsx
+++ b/packages/core/src/composed/schedule-view.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
 
 import { describeConformance } from '../test-utils/conformance'
 import { type ScheduleEvent,ScheduleView } from './schedule-view'
@@ -29,7 +31,7 @@ const sampleEvents: ScheduleEvent[] = [
 ]
 
 describe('ScheduleView', () => {
-  it('renders day view with aria label', () => {
+  it('renders day view as a labelled region', () => {
     render(
       <ScheduleView view="day" date={baseDate} events={[]} />,
     )
@@ -38,7 +40,7 @@ describe('ScheduleView', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders week view with aria label', () => {
+  it('renders week view as a labelled region', () => {
     render(
       <ScheduleView view="week" date={baseDate} events={[]} />,
     )
@@ -91,5 +93,75 @@ describe('ScheduleView', () => {
     render(<ScheduleView view="week" date={baseDate} events={[]} />)
     expect(screen.getByText(/Mon/)).toBeInTheDocument()
     expect(screen.getByText(/Tue/)).toBeInTheDocument()
+  })
+
+  it('slots are non-interactive (no tab stops) when onSlotClick is absent', () => {
+    render(<ScheduleView view="day" date={baseDate} events={[]} startHour={8} endHour={10} />)
+    // No slot buttons — only event buttons would be role=button, and there are none here.
+    expect(screen.queryAllByRole('button')).toHaveLength(0)
+  })
+
+  it('slots become interactive buttons when onSlotClick is provided', async () => {
+    const onSlotClick = vi.fn()
+    render(
+      <ScheduleView view="day" date={baseDate} events={[]} startHour={8} endHour={10} slotDuration={30} onSlotClick={onSlotClick} />,
+    )
+    const slots = screen.getAllByRole('button')
+    expect(slots.length).toBeGreaterThan(0)
+    await userEvent.click(slots[0])
+    expect(onSlotClick).toHaveBeenCalled()
+  })
+
+  it('roving tabindex: only one slot is tabbable, arrows move focus', async () => {
+    const user = userEvent.setup()
+    render(
+      <ScheduleView view="day" date={baseDate} events={[]} startHour={8} endHour={10} slotDuration={30} onSlotClick={vi.fn()} />,
+    )
+    const slots = screen.getAllByRole('button')
+    const tabbable = slots.filter((s) => s.getAttribute('tabindex') === '0')
+    expect(tabbable).toHaveLength(1)
+    tabbable[0].focus()
+    await user.keyboard('{ArrowDown}')
+    expect(document.activeElement).toBe(slots[1])
+  })
+
+  it('overlapping events both render side by side', () => {
+    const overlapping: ScheduleEvent[] = [
+      { id: 'a', title: 'A', start: new Date('2026-03-17T09:00:00Z'), end: new Date('2026-03-17T10:00:00Z') },
+      { id: 'b', title: 'B', start: new Date('2026-03-17T09:30:00Z'), end: new Date('2026-03-17T10:30:00Z') },
+    ]
+    render(<ScheduleView view="day" date={baseDate} events={overlapping} />)
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+  })
+
+  it('marks the selected event', () => {
+    render(<ScheduleView view="day" date={baseDate} events={sampleEvents} selectedEventId="1" />)
+    const selected = screen.getByText('Team Standup').closest('button')!
+    expect(selected).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('renders a custom empty state', () => {
+    render(<ScheduleView view="day" date={baseDate} events={[]} emptyState="Nothing today" />)
+    expect(screen.getByText('Nothing today')).toBeInTheDocument()
+  })
+
+  it('renderEvent customizes the event body', () => {
+    render(
+      <ScheduleView
+        view="day"
+        date={baseDate}
+        events={sampleEvents}
+        renderEvent={(e) => <span data-testid="ev">{e.id}</span>}
+      />,
+    )
+    expect(screen.getAllByTestId('ev')[0]).toHaveTextContent('1')
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <ScheduleView view="week" date={baseDate} events={sampleEvents} onSlotClick={vi.fn()} />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/packages/core/src/composed/schedule-view.tsx
+++ b/packages/core/src/composed/schedule-view.tsx
@@ -29,7 +29,9 @@ export interface ScheduleEvent {
 
 /**
  * A day/week calendar schedule grid. Renders time-slotted events with
- * proportional height, color coding, click handlers, and a current-time indicator.
+ * proportional height, color coding, overlapping-event columns, a live
+ * current-time indicator, and keyboard-navigable slots (when `onSlotClick` is
+ * set). Presentational — drive `events`/`date`/`view` from the parent.
  */
 export interface ScheduleViewProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Display mode: single-day column or full-week (7 columns). */
@@ -40,7 +42,10 @@ export interface ScheduleViewProps extends React.HTMLAttributes<HTMLDivElement> 
   events: ScheduleEvent[]
   /** Called when an event block is clicked. */
   onEventClick?: (event: ScheduleEvent) => void
-  /** Called when an empty time slot is clicked, with the slot's start and end times. */
+  /**
+   * Called when an empty time slot is clicked. When omitted, slots render as
+   * non-interactive grid lines (no keyboard/AT tab stops).
+   */
   onSlotClick?: (start: Date, end: Date) => void
   /** First visible hour (default 8). */
   startHour?: number
@@ -48,16 +53,23 @@ export interface ScheduleViewProps extends React.HTMLAttributes<HTMLDivElement> 
   endHour?: number
   /** Slot duration in minutes (default 30). */
   slotDuration?: number
+  /** Currently-selected event id — rendered with a ring. */
+  selectedEventId?: string
+  /** Custom event content renderer. Receives the event; return the block body. */
+  renderEvent?: (event: ScheduleEvent) => React.ReactNode
+  /** Optional toolbar/header rendered above the grid. */
+  header?: React.ReactNode
+  /** Content shown when there are no events in view. */
+  emptyState?: React.ReactNode
+  /** Grid body height (CSS length or px number). @default 480 */
+  height?: number | string
 }
 
 /* ------------------------------------------------------------------ */
 /*  Color map                                                          */
 /* ------------------------------------------------------------------ */
 
-const eventColorMap: Record<
-  NonNullable<ScheduleEvent['color']>,
-  string
-> = {
+const eventColorMap: Record<NonNullable<ScheduleEvent['color']>, string> = {
   accent: 'bg-accent-2 text-accent-11',
   success: 'bg-success-3 text-success-11',
   warning: 'bg-warning-3 text-warning-11',
@@ -66,12 +78,7 @@ const eventColorMap: Record<
   neutral: 'bg-surface-raised text-surface-fg-muted',
 }
 
-// Solid category dot — the color-blind-safe, shape-based signal that replaces the
-// former left accent rail (the AI tell). Tint above carries the ambient color.
-const eventDotMap: Record<
-  NonNullable<ScheduleEvent['color']>,
-  string
-> = {
+const eventDotMap: Record<NonNullable<ScheduleEvent['color']>, string> = {
   accent: 'bg-accent-9',
   success: 'bg-success-9',
   warning: 'bg-warning-9',
@@ -91,50 +98,81 @@ function formatHourLabel(hour: number): string {
   return `${hour - 12} PM`
 }
 
-function getEventStyle(
-  event: ScheduleEvent,
+interface PositionedEvent {
+  event: ScheduleEvent
+  top: number
+  height: number
+  col: number
+  cols: number
+}
+
+/**
+ * Position a day's events, partitioning concurrent events into side-by-side
+ * columns so overlaps stay legible (greedy interval colouring per overlap
+ * cluster).
+ */
+function layoutDayEvents(
+  events: ScheduleEvent[],
   startHour: number,
   endHour: number,
-) {
+): PositionedEvent[] {
   const totalMinutes = (endHour - startHour) * 60
-  const eventStartMinutes =
-    (getHours(event.start) - startHour) * 60 + getMinutes(event.start)
-  const durationMinutes = differenceInMinutes(event.end, event.start)
+  const sorted = [...events].sort((a, b) => a.start.getTime() - b.start.getTime())
 
-  const top = (eventStartMinutes / totalMinutes) * 100
-  const height = (durationMinutes / totalMinutes) * 100
+  const result: PositionedEvent[] = []
+  let cluster: PositionedEvent[] = []
+  let clusterEnd = -Infinity
 
-  return {
-    top: `${top}%`,
-    height: `${height}%`,
+  const flush = () => {
+    const cols = cluster.reduce((m, e) => Math.max(m, e.col + 1), 0)
+    for (const e of cluster) e.cols = cols
+    result.push(...cluster)
+    cluster = []
+    clusterEnd = -Infinity
   }
+
+  for (const event of sorted) {
+    const startM = (getHours(event.start) - startHour) * 60 + getMinutes(event.start)
+    const durationM = Math.max(differenceInMinutes(event.end, event.start), 1)
+    const startMs = event.start.getTime()
+
+    // New cluster when this event starts after everything so far has ended.
+    if (startMs >= clusterEnd && cluster.length > 0) flush()
+
+    // First free column within the cluster.
+    const taken = new Set(cluster.filter((c) => c.event.end.getTime() > startMs).map((c) => c.col))
+    let col = 0
+    while (taken.has(col)) col++
+
+    cluster.push({
+      event,
+      top: (startM / totalMinutes) * 100,
+      height: (durationM / totalMinutes) * 100,
+      col,
+      cols: 1,
+    })
+    clusterEnd = Math.max(clusterEnd, event.end.getTime())
+  }
+  if (cluster.length > 0) flush()
+
+  return result
 }
 
 /* ------------------------------------------------------------------ */
-/*  Sub-components                                                     */
+/*  Time column                                                        */
 /* ------------------------------------------------------------------ */
 
-interface TimeColumnProps {
-  startHour: number
-  endHour: number
-}
-
-function TimeColumn({ startHour, endHour }: TimeColumnProps) {
+function TimeColumn({ startHour, endHour }: { startHour: number; endHour: number }) {
   const hours: number[] = []
-  for (let h = startHour; h < endHour; h++) {
-    hours.push(h)
-  }
+  for (let h = startHour; h < endHour; h++) hours.push(h)
   const slotHeight = 100 / (endHour - startHour)
 
   return (
-    <div
-      className="relative shrink-0 w-[60px] border-r border-surface-border-strong"
-      aria-hidden="true"
-    >
+    <div className="relative w-ds-11 shrink-0 border-e border-surface-border-strong" aria-hidden="true">
       {hours.map((hour) => (
         <div
           key={hour}
-          className="text-caption text-surface-fg-muted pr-ds-02 text-right"
+          className="pe-ds-02 text-end text-caption text-surface-fg-muted"
           style={{ height: `${slotHeight}%` }}
         >
           {formatHourLabel(hour)}
@@ -144,128 +182,178 @@ function TimeColumn({ startHour, endHour }: TimeColumnProps) {
   )
 }
 
+/* ------------------------------------------------------------------ */
+/*  Day column                                                         */
+/* ------------------------------------------------------------------ */
+
 interface DayColumnProps {
+  dayIndex: number
   date: Date
   events: ScheduleEvent[]
   startHour: number
   endHour: number
   slotDuration: number
+  now: Date
+  active: { day: number; slot: number }
+  interactive: boolean
+  onSlotKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement>) => void
+  selectedEventId?: string
+  renderEvent?: (event: ScheduleEvent) => React.ReactNode
   onEventClick?: (event: ScheduleEvent) => void
   onSlotClick?: (start: Date, end: Date) => void
   showHeader?: boolean
+  nowLineRef?: React.Ref<HTMLDivElement>
 }
 
 function DayColumn({
+  dayIndex,
   date,
   events,
   startHour,
   endHour,
   slotDuration,
+  now,
+  active,
+  interactive,
+  onSlotKeyDown,
+  selectedEventId,
+  renderEvent,
   onEventClick,
   onSlotClick,
   showHeader,
+  nowLineRef,
 }: DayColumnProps) {
-  const dayEvents = events.filter((e) => isSameDay(e.start, date))
+  const dayEvents = React.useMemo(
+    () => layoutDayEvents(events.filter((e) => isSameDay(e.start, date)), startHour, endHour),
+    [events, date, startHour, endHour],
+  )
   const totalMinutes = (endHour - startHour) * 60
   const slotCount = totalMinutes / slotDuration
 
-  const slots: { start: Date; end: Date }[] = []
-  for (let i = 0; i < slotCount; i++) {
-    const slotStart = new Date(date)
-    slotStart.setHours(startHour, i * slotDuration, 0, 0)
-    const slotEnd = new Date(slotStart)
-    slotEnd.setMinutes(slotEnd.getMinutes() + slotDuration)
-    slots.push({ start: slotStart, end: slotEnd })
-  }
+  const slots = React.useMemo(() => {
+    const out: { start: Date; end: Date }[] = []
+    for (let i = 0; i < slotCount; i++) {
+      const slotStart = new Date(date)
+      slotStart.setHours(startHour, i * slotDuration, 0, 0)
+      const slotEnd = new Date(slotStart)
+      slotEnd.setMinutes(slotEnd.getMinutes() + slotDuration)
+      out.push({ start: slotStart, end: slotEnd })
+    }
+    return out
+  }, [date, startHour, slotDuration, slotCount])
 
   const todayInView = isToday(date)
-
-  // Current time indicator position
   let nowIndicatorTop: number | null = null
   if (todayInView) {
-    const now = new Date()
     const nowHour = getHours(now)
-    const nowMin = getMinutes(now)
     if (nowHour >= startHour && nowHour < endHour) {
-      const nowMinutes = (nowHour - startHour) * 60 + nowMin
+      const nowMinutes = (nowHour - startHour) * 60 + getMinutes(now)
       nowIndicatorTop = (nowMinutes / totalMinutes) * 100
     }
   }
 
   return (
-    <div className="flex flex-1 flex-col min-w-ds-11">
+    <div className="flex min-w-ds-11 flex-1 flex-col">
       {showHeader && (
         <div
           className={cn(
-            'text-center text-body-sm font-semibold py-ds-02 border-b border-surface-border-strong',
-            todayInView
-              ? 'text-accent-11 bg-accent-2'
-              : 'text-surface-fg bg-surface-raised',
+            'border-b border-surface-border-strong py-ds-02 text-center text-body-sm font-semibold',
+            todayInView ? 'bg-accent-2 text-accent-11' : 'bg-surface-2 text-surface-fg',
           )}
         >
           {format(date, 'EEE d')}
         </div>
       )}
       <div className="relative flex-1">
-        {/* Slot grid lines */}
-        {slots.map((slot, i) => (
-          <button
-            key={i}
-            type="button"
-            className={cn(
-              'block w-full border-b border-surface-border hover:bg-surface-raised-hover transition-colors ease-productive-standard',
-              'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-9',
-              i % 2 === 0 ? 'border-surface-border-strong' : 'border-surface-border-subtle',
-            )}
-            style={{ height: `${100 / slotCount}%` }}
-            onClick={() => onSlotClick?.(slot.start, slot.end)}
-            aria-label={`${format(slot.start, 'h:mm a')} to ${format(slot.end, 'h:mm a')}`}
-          />
-        ))}
+        {/* Slot lines — interactive buttons only when onSlotClick is set,
+            otherwise inert grid lines (no tab stops, hidden from AT). */}
+        {slots.map((slot, i) =>
+          interactive ? (
+            <button
+              key={i}
+              type="button"
+              data-day={dayIndex}
+              data-slot={i}
+              tabIndex={dayIndex === active.day && i === active.slot ? 0 : -1}
+              className={cn(
+                'block w-full min-h-ds-06 border-b transition-colors ease-productive-standard duration-fast-02',
+                'hover:bg-surface-raised-hover',
+                'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent-9',
+                i % 2 === 0 ? 'border-surface-border-strong' : 'border-surface-border-subtle',
+              )}
+              style={{ height: `${100 / slotCount}%` }}
+              onClick={() => onSlotClick?.(slot.start, slot.end)}
+              onKeyDown={onSlotKeyDown}
+              aria-label={`${format(slot.start, 'EEE h:mm a')} to ${format(slot.end, 'h:mm a')}`}
+            />
+          ) : (
+            <div
+              key={i}
+              aria-hidden="true"
+              className={cn(
+                'w-full border-b',
+                i % 2 === 0 ? 'border-surface-border-strong' : 'border-surface-border-subtle',
+              )}
+              style={{ height: `${100 / slotCount}%` }}
+            />
+          ),
+        )}
 
-        {/* Events */}
-        {dayEvents.map((event) => {
-          const style = getEventStyle(event, startHour, endHour)
+        {/* Events — column-partitioned so overlaps sit side by side */}
+        {dayEvents.map(({ event, top, height, col, cols }) => {
           const eventColor = event.color ?? 'accent'
-          const colorClass = eventColorMap[eventColor]
-          const dotClass = eventDotMap[eventColor]
+          const colWidth = 100 / cols
+          const selected = event.id === selectedEventId
           return (
             <button
               key={event.id}
               type="button"
+              aria-pressed={selected || undefined}
               className={cn(
-                'absolute left-ds-01 right-ds-01 rounded-control-inner px-ds-02 py-ds-01',
-                'text-left text-body-xs font-medium overflow-hidden cursor-pointer',
-                'hover:shadow-raised transition-[box-shadow] duration-fast-02 ease-productive-standard',
+                'absolute overflow-hidden rounded-control-inner px-ds-02 py-ds-01',
+                'cursor-pointer text-start text-body-xs font-medium',
+                'transition-[box-shadow] ease-productive-standard duration-fast-02 hover:shadow-raised',
                 'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9',
-                colorClass,
+                'motion-safe:active:scale-[0.98]',
+                selected && 'ring-2 ring-accent-9',
+                eventColorMap[eventColor],
               )}
-              style={style}
+              style={{
+                top: `${top}%`,
+                height: `${height}%`,
+                insetInlineStart: `calc(${col * colWidth}% + 2px)`,
+                width: `calc(${colWidth}% - 4px)`,
+              }}
               onClick={(e) => {
                 e.stopPropagation()
                 onEventClick?.(event)
               }}
               aria-label={`${event.title}, ${format(event.start, 'h:mm a')} to ${format(event.end, 'h:mm a')}`}
             >
-              <span className="flex items-start gap-ds-02">
-                <span
-                  className={cn('mt-[3px] h-ds-03 w-ds-03 shrink-0 rounded-pill', dotClass)}
-                  aria-hidden="true"
-                />
-                <span className="line-clamp-2">{event.title}</span>
-              </span>
+              {renderEvent ? (
+                renderEvent(event)
+              ) : (
+                <span className="flex items-start gap-ds-02">
+                  <span
+                    className={cn('mt-0.5 h-ds-03 w-ds-03 shrink-0 rounded-pill', eventDotMap[eventColor])}
+                    aria-hidden="true"
+                  />
+                  <span className="line-clamp-2">{event.title}</span>
+                </span>
+              )}
             </button>
           )
         })}
 
-        {/* Current time indicator */}
+        {/* Live current-time indicator */}
         {nowIndicatorTop != null && (
           <div
-            className="absolute left-0 right-0 h-ds-01 bg-error-9 z-10 pointer-events-none"
+            ref={nowLineRef}
+            className="pointer-events-none absolute inset-x-0 z-raised h-ds-01 bg-error-9"
             style={{ top: `${nowIndicatorTop}%` }}
             aria-hidden="true"
           >
-            <Dot color="error" size="lg" pulse className="absolute -left-[5px] -top-[4px]" />
+            <Dot color="error" size="lg" pulse className="absolute -translate-x-1/2 -translate-y-1/2" />
           </div>
         )}
       </div>
@@ -288,48 +376,116 @@ const ScheduleView = React.forwardRef<HTMLDivElement, ScheduleViewProps>(
       startHour = 8,
       endHour = 18,
       slotDuration = 30,
+      selectedEventId,
+      renderEvent,
+      header,
+      emptyState,
+      height = 480,
       className,
       ...props
     },
     ref,
   ) => {
-    const days: Date[] = React.useMemo(() => {
+    const days = React.useMemo<Date[]>(() => {
       if (view === 'day') return [date]
-      const weekStart = startOfWeek(date, { weekStartsOn: 1 }) // Monday
+      const weekStart = startOfWeek(date, { weekStartsOn: 1 })
       return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i))
     }, [view, date])
 
+    const interactive = !!onSlotClick
+    const slotCount = ((endHour - startHour) * 60) / slotDuration
+
+    // Live now-line: re-render each minute so the indicator actually ticks.
+    const [now, setNow] = React.useState(() => new Date())
+    React.useEffect(() => {
+      const id = setInterval(() => setNow(new Date()), 60_000)
+      return () => clearInterval(id)
+    }, [])
+
+    // Roving-tabindex slot navigation (only meaningful when interactive).
+    const gridRef = React.useRef<HTMLDivElement>(null)
+    const nowLineRef = React.useRef<HTMLDivElement>(null)
+    const [active, setActive] = React.useState<{ day: number; slot: number }>({ day: 0, slot: 0 })
+
+    // Scroll the now-line into view on mount.
+    React.useEffect(() => {
+      nowLineRef.current?.scrollIntoView({ block: 'center' })
+    }, [])
+
+    const handleSlotKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (!interactive) return
+      const target = e.target as HTMLElement
+      const dayAttr = target.getAttribute('data-day')
+      const slotAttr = target.getAttribute('data-slot')
+      if (dayAttr == null || slotAttr == null) return
+      const day = Number(dayAttr)
+      const slot = Number(slotAttr)
+      const rtl = getComputedStyle(gridRef.current ?? target).direction === 'rtl'
+      let nextDay = day
+      let nextSlot = slot
+      switch (e.key) {
+        case 'ArrowDown': nextSlot = Math.min(slot + 1, slotCount - 1); break
+        case 'ArrowUp': nextSlot = Math.max(slot - 1, 0); break
+        case 'ArrowRight': nextDay = rtl ? Math.max(day - 1, 0) : Math.min(day + 1, days.length - 1); break
+        case 'ArrowLeft': nextDay = rtl ? Math.min(day + 1, days.length - 1) : Math.max(day - 1, 0); break
+        case 'Home': nextSlot = 0; break
+        case 'End': nextSlot = slotCount - 1; break
+        default: return
+      }
+      e.preventDefault()
+      setActive({ day: nextDay, slot: nextSlot })
+      // Focus the target cell now — focus() works regardless of the tabIndex
+      // the re-render is about to move onto it.
+      gridRef.current
+        ?.querySelector<HTMLButtonElement>(`[data-day="${nextDay}"][data-slot="${nextSlot}"]`)
+        ?.focus()
+    }
+
+    const isEmpty = events.length === 0
+
     return (
-      <div
-        ref={ref}
-        role="region"
-        aria-label={
-          view === 'day'
-            ? `Schedule for ${format(date, 'EEEE, MMMM d, yyyy')}`
-            : `Week schedule starting ${format(days[0], 'MMMM d, yyyy')}`
-        }
-        className={cn(
-          'flex rounded-control border border-card-strong bg-surface-raised overflow-hidden',
-          'h-[480px]',
-          className,
-        )}
-        {...props}
-      >
-        <TimeColumn startHour={startHour} endHour={endHour} />
-        <div className="flex flex-1 divide-x divide-surface-border overflow-x-auto">
-          {days.map((day) => (
-            <DayColumn
-              key={day.toISOString()}
-              date={day}
-              events={events}
-              startHour={startHour}
-              endHour={endHour}
-              slotDuration={slotDuration}
-              onEventClick={onEventClick}
-              onSlotClick={onSlotClick}
-              showHeader={view === 'week'}
-            />
-          ))}
+      <div ref={ref} className={cn('flex flex-col', className)} {...props}>
+        {header}
+        <div
+          ref={gridRef}
+          role="region"
+          aria-label={
+            view === 'day'
+              ? `Schedule for ${format(date, 'EEEE, MMMM d, yyyy')}`
+              : `Week schedule starting ${format(days[0], 'MMMM d, yyyy')}`
+          }
+          className="flex overflow-hidden rounded-surface border border-surface-border-strong bg-surface-2"
+          style={{ height: typeof height === 'number' ? `${height}px` : height }}
+        >
+          <TimeColumn startHour={startHour} endHour={endHour} />
+          <div className="relative flex flex-1 divide-x divide-surface-border overflow-x-auto overflow-y-auto">
+            {days.map((day, i) => (
+              <DayColumn
+                key={day.toISOString()}
+                dayIndex={i}
+                date={day}
+                events={events}
+                startHour={startHour}
+                endHour={endHour}
+                slotDuration={slotDuration}
+                now={now}
+                active={active}
+                interactive={interactive}
+                onSlotKeyDown={handleSlotKeyDown}
+                selectedEventId={selectedEventId}
+                renderEvent={renderEvent}
+                onEventClick={onEventClick}
+                onSlotClick={onSlotClick}
+                showHeader={view === 'week'}
+                nowLineRef={i === 0 || isSameDay(day, now) ? nowLineRef : undefined}
+              />
+            ))}
+            {isEmpty && (
+              <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-ds-05 text-center text-body-sm text-surface-fg-muted">
+                {emptyState ?? 'No events scheduled.'}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
**Rebuild 4 of 4** from the finish-bar audit (#181). ScheduleView was 3/5 — a P0 a11y flood + illegible overlaps + a frozen now-line + a surface regression.

## Fixes
- **No more phantom tab stops (P0).** Slots are focusable + keyboard-navigable (**roving tabindex + Arrow/Home/End**, RTL-aware) only when `onSlotClick` is set; otherwise inert grid lines. A read-only week view previously exposed ~140 sequential tab stops.
- **Overlapping events** partition into side-by-side columns (greedy interval colouring) instead of stacking on top of each other.
- **Live now-line** — ticks every minute + scrolls into view on mount (was frozen at mount time).
- **Surface** — shell now uses the `surface-2` card tier + `rounded-surface` + a real border (was `surface-raised` + the dead `border-card-strong` class). RTL logical properties throughout; magic-number sizes tokenized.

## New props
`selectedEventId` (rings the active event), `renderEvent`, `header` (toolbar slot), `emptyState`, `height`.

Non-breaking (existing props unchanged; new props additive). typecheck ✓ · 19 tests ✓ · lint ✓ · build ✓.

**Scope note:** full ARIA grid-matrix semantics were intentionally *not* adopted — it stays a labelled `region` with keyboard-navigable slots (honest + lint-clean) rather than a partial/broken grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)