### PR TITLE
perf(site): full-height lander + lazy-load below-fold

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,12 @@
+node_modules
+**/node_modules
+.git
+.next
+**/.next
+dist
+**/dist
+.turbo
+**/.turbo
+.claude
+**/screenshots
+*.log

--- a/apps/site/app/page.tsx
+++ b/apps/site/app/page.tsx
@@ -1,23 +1,16 @@
-import { AgentCallout } from '@/components/agent-callout'
-import { BrandOrbit } from '@/components/brand-orbit'
-import { BuiltWith } from '@/components/built-with'
-import { ButtonShowcase } from '@/components/button-showcase'
-import { ComponentShowcase } from '@/components/component-showcase'
-import { DevalokBlock } from '@/components/devalok-block'
-import { FeatureGrid } from '@/components/feature-grid'
+import { BelowFold } from '@/components/below-fold'
 import { Hero } from '@/components/hero'
 import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
-import { StackSupport } from '@/components/stack-support'
-import { UnifiedCanvas } from '@/components/unified-canvas'
 
 /**
- * Landing flow. Built-with strip + Devalok block added per
- * docs/copy/shilp-sutra-copy-context.md §6 + §7 + §5. Wedge row + stack strip
- * added right under the hero per §2 — answer "why this, not shadcn?" and
- * "does this fit my stack?" before the reader scrolls.
+ * Landing flow. Only the lander (header + full-height hero) paints on load; the
+ * rest is deferred via <BelowFold> (lazy chunks, mounted on scroll/idle) for a
+ * faster first paint. Section order + rationale per
+ * docs/copy/shilp-sutra-copy-context.md §2/§5/§6/§7:
  *
- *   1. Hero              — what we are
+ *   1. Hero              — what we are (full viewport height)
+ *   — below the fold (lazy) —
  *   2. StackSupport      — framework strip; kills the "my stack?" doubt (§6)
  *   3. UnifiedCanvas     — six industries in one tabbed canvas, all live
  *   4. ButtonShowcase    — one component, ten worlds (close-up craft)
@@ -33,19 +26,7 @@ export default function HomePage() {
       <SiteHeader />
       <main id="main" className="flex-1">
         <Hero />
-        {/* TODO(placement): temporary home for the animated brand orbit
-            (Figma 56-25874) — decorative, will be repositioned. */}
-        <section className="px-page-x py-ds-08">
-          <BrandOrbit />
-        </section>
-        <StackSupport />
-        <UnifiedCanvas />
-        <ButtonShowcase />
-        <BuiltWith />
-        <ComponentShowcase />
-        <FeatureGrid />
-        <AgentCallout />
-        <DevalokBlock />
+        <BelowFold />
       </main>
       <SiteFooter />
     </>

--- a/apps/site/components/below-fold.tsx
+++ b/apps/site/components/below-fold.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+/**
+ * BelowFold — defers everything under the hero so only the lander paints on
+ * load. Each section is a separate lazy chunk (ssr:false); they mount when the
+ * sentinel nears the viewport (scroll) OR on idle as a fallback, so users who
+ * never scroll — and crawlers that run JS — still get the full page.
+ *
+ * Tradeoff: below-fold content is client-rendered (not in the SSR HTML), so it
+ * isn't in the raw-HTML crawl. The hero + all page metadata remain server-
+ * rendered. This is a deliberate performance choice for the marketing lander.
+ */
+
+import dynamic from 'next/dynamic'
+import { useEffect, useRef, useState } from 'react'
+
+const BrandOrbit = dynamic(() => import('./brand-orbit').then((m) => m.BrandOrbit))
+const StackSupport = dynamic(() => import('./stack-support').then((m) => m.StackSupport))
+const UnifiedCanvas = dynamic(() => import('./unified-canvas').then((m) => m.UnifiedCanvas))
+const ButtonShowcase = dynamic(() => import('./button-showcase').then((m) => m.ButtonShowcase))
+const BuiltWith = dynamic(() => import('./built-with').then((m) => m.BuiltWith))
+const ComponentShowcase = dynamic(() =>
+  import('./component-showcase').then((m) => m.ComponentShowcase),
+)
+const FeatureGrid = dynamic(() => import('./feature-grid').then((m) => m.FeatureGrid))
+const AgentCallout = dynamic(() => import('./agent-callout').then((m) => m.AgentCallout))
+const DevalokBlock = dynamic(() => import('./devalok-block').then((m) => m.DevalokBlock))
+
+export function BelowFold() {
+  const [show, setShow] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (show) return
+    let done = false
+    const reveal = () => {
+      if (done) return
+      done = true
+      setShow(true)
+    }
+
+    const el = ref.current
+    const io = el
+      ? new IntersectionObserver(
+          (entries) => {
+            if (entries.some((e) => e.isIntersecting)) reveal()
+          },
+          { rootMargin: '600px 0px' },
+        )
+      : null
+    if (io && el) io.observe(el)
+
+    // Fallback: mount on idle so non-scrollers + JS crawlers get the content.
+    const w = window as Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
+    }
+    const idleId = w.requestIdleCallback
+      ? w.requestIdleCallback(reveal, { timeout: 3500 })
+      : window.setTimeout(reveal, 2500)
+
+    return () => {
+      io?.disconnect()
+      if (typeof idleId === 'number') window.clearTimeout(idleId)
+    }
+  }, [show])
+
+  return (
+    <div ref={ref}>
+      {show && (
+        <>
+          {/* TODO(placement): temporary home for the animated brand orbit. */}
+          <section className="px-page-x py-ds-08">
+            <BrandOrbit />
+          </section>
+          <StackSupport />
+          <UnifiedCanvas />
+          <ButtonShowcase />
+          <BuiltWith />
+          <ComponentShowcase />
+          <FeatureGrid />
+          <AgentCallout />
+          <DevalokBlock />
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/site/components/brahma-backdrop.tsx
+++ b/apps/site/components/brahma-backdrop.tsx
@@ -24,12 +24,15 @@
  */
 
 import { useMemo } from 'react'
+import dynamic from 'next/dynamic'
 import { motion, useReducedMotion, type Variants } from 'framer-motion'
 import { IconLink } from '@tabler/icons-react'
 import { Avatar, AvatarFallback } from '@devalok/shilp-sutra/ui/avatar'
 import { Switch } from '@devalok/shilp-sutra/ui/switch'
 
-import { BrahmaArt } from './brahma-art'
+// Code-split the 700KB+ deity vector out of the initial bundle — it flickers in
+// last (3.6s), so loading its chunk after first paint costs nothing visible.
+const BrahmaArt = dynamic(() => import('./brahma-art').then((m) => m.BrahmaArt), { ssr: false })
 
 // ── Source-frame geometry (px in the 1920×1080 Figma frame) ──────────────────
 const FRAME_W = 1920

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -7,7 +7,7 @@ import { TrackedLink } from './tracked-link'
 
 export function Hero() {
   return (
-    <section className="relative isolate overflow-hidden min-h-[720px] lg:min-h-[900px]">
+    <section className="relative isolate flex min-h-svh flex-col justify-center overflow-hidden">
       <BrahmaBackdrop />
       {/* Content sits in a left column; the Brahma identity composition owns the
           right. pt clears the floating pill (~70–80px). */}


### PR DESCRIPTION
Follow-up to #189.

- **Full-height hero** (`min-h-svh`, content vertically centred).
- **Only the lander paints on load** — header + hero are SSR'd; everything below is deferred via `<BelowFold>` (each section a separate lazy chunk, mounted on scroll-near or idle).
- **Code-split the ~700KB Brahma vector** out of the initial bundle (`next/dynamic`, ssr:false) — it flickers in last, so its chunk load is invisible.
- Adds `.railwayignore`.
- Default light mode already in place (theme-init opts into dark only on explicit toggle).

Homepage First Load JS: 301 kB (Brahma + below-fold now separate chunks). Verified: tsc clean, `next build` green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)