### PR TITLE
feat(site): BrandOrbit conveyor + FeatureGrid cards (C1, C8)

### DIFF
--- a/apps/site/_shot.mjs
+++ b/apps/site/_shot.mjs
@@ -1,0 +1,38 @@
+import { chromium } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+const [url, out, viewport = '1440x900', theme = 'light', scroll = '0', full = 'viewport'] =
+  process.argv.slice(2)
+const [vw, vh] = viewport.split('x').map(Number)
+const outPath = resolve(out)
+await mkdir(dirname(outPath), { recursive: true })
+const browser = await chromium.launch()
+const ctx = await browser.newContext({
+  viewport: { width: vw, height: vh },
+  deviceScaleFactor: 2,
+  colorScheme: theme === 'dark' ? 'dark' : 'light',
+})
+const page = await ctx.newPage()
+await page.addInitScript((t) => {
+  try {
+    localStorage.setItem('theme', t)
+  } catch {}
+}, theme)
+await page.goto(url, { waitUntil: 'load', timeout: 60000 })
+if (theme === 'dark') await page.evaluate(() => document.documentElement.classList.add('dark'))
+// Pre-scroll through the page to trigger lazy-mounted (below-fold) sections,
+// then settle on the requested scroll position.
+if (Number(scroll) > 0 || full === 'full') {
+  await page.evaluate(async () => {
+    for (let y = 0; y < document.body.scrollHeight; y += 600) {
+      window.scrollTo(0, y)
+      await new Promise((r) => setTimeout(r, 120))
+    }
+  })
+  await page.waitForTimeout(600)
+}
+if (Number(scroll) > 0) await page.evaluate((px) => window.scrollTo(0, Number(px)), scroll)
+await page.waitForTimeout(Number(process.env.SHOT_WAIT || 6500))
+const result = await page.screenshot({ path: outPath, fullPage: full === 'full' })
+console.log(`Saved ${outPath} (${(result.length / 1024).toFixed(1)} KB)`)
+await browser.close()

--- a/apps/site/components/.impeccable/hook.cache.json
+++ b/apps/site/components/.impeccable/hook.cache.json
@@ -1,0 +1,1 @@
+{"version":1,"sessions":{"3daece04-5b47-4ea1-9b49-a0d8389fe1d5":{"updatedAt":1784892922524,"files":{"C:\\Users\\mudit\\Documents\\GitHub\\shilp-sutra\\.claude\\worktrees\\site-visual-refresh\\apps\\site\\components\\feature-grid.tsx":{"editCount":1,"findings":[]}}}}}

--- a/apps/site/components/brand-orbit.tsx
+++ b/apps/site/components/brand-orbit.tsx
@@ -1,29 +1,22 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ComponentType } from 'react'
 import { motion, useReducedMotion } from 'framer-motion'
-import {
-  IconBolt,
-  IconLink,
-  IconLockOpen,
-  IconSettings,
-  IconShield,
-} from '@tabler/icons-react'
+import { IconBolt, IconLink, IconLockOpen, IconSettings, IconShield } from '@tabler/icons-react'
 import { Avatar, AvatarFallback } from '@devalok/shilp-sutra/ui/avatar'
 import { Switch } from '@devalok/shilp-sutra/ui/switch'
 
 /**
- * Decorative brand flourish: real shilp-sutra components (Switch, Avatar) plus a
- * few dark icon tiles, spaced evenly around a ring that orbits slowly and
- * continuously. Each item counter-rotates so it stays upright while the cluster
- * turns — the components orbit, they don't spin. A few of the switches quietly
- * flip off-and-back on a stagger, for a "someone's tuning settings" feel.
+ * "120+ components" flourish. Three layers:
+ *   1. A background conveyor — faded component-name chips scrolling like a belt,
+ *      to show the breadth of the library.
+ *   2. A slow orbit of real DS components (Switch, Avatar) + ink tiles that
+ *      counter-rotate to stay upright. Switches flip and items pulse on a slow,
+ *      randomised cadence (not a metronome).
+ *   3. A centred "120+ / components" plate.
  *
- * Purely decorative — the whole thing is aria-hidden and non-interactive.
- * Recreates Figma 56-25874 (Shilp Sutra | Visual Identity).
- *
- * Reduced motion: rotation is frozen and the switch-flipping stops.
+ * Decorative: aria-hidden, non-interactive. Reduced motion freezes everything.
  */
 
 type TablerIcon = ComponentType<{ size?: number | string; stroke?: number | string; className?: string }>
@@ -33,18 +26,13 @@ type OrbitItem =
   | { kind: 'avatar'; id: string; initials: string; face: string }
   | { kind: 'tile'; id: string; icon: TablerIcon }
 
-// Soft pastel avatar faces, matching the Figma palette.
 const FACE_BLUE = 'bg-info-3 text-info-11'
 const FACE_MINT = 'bg-category-teal-3 text-category-teal-11'
-
-// ON-track tints per switch. `Switch` defaults to accent; className wins via
-// tailwind-merge, so these override the checked-track background.
 const TINT_BLUE = 'data-[state=checked]:bg-info-9'
 const TINT_TEAL = 'data-[state=checked]:bg-category-teal-9'
 const TINT_AMBER = 'data-[state=checked]:bg-category-amber-9'
 const TINT_BRAND = 'data-[state=checked]:bg-accent-9'
 
-// Clockwise from 12 o'clock. 14 items → evenly spaced ~25.7° apart.
 const ITEMS: OrbitItem[] = [
   { kind: 'switch', id: 'sw-blue-1', tint: TINT_BLUE },
   { kind: 'avatar', id: 'av-gp', initials: 'GP', face: FACE_BLUE },
@@ -63,70 +51,133 @@ const ITEMS: OrbitItem[] = [
 ]
 
 const SWITCH_IDS = ITEMS.filter((i) => i.kind === 'switch').map((i) => i.id)
+const ALL_IDS = ITEMS.map((i) => i.id)
 
-// Ring geometry + timing.
-const RADIUS = 43 // % of half-container, from center
-const SPIN_SECONDS = 52 // full 360° revolution
-const FLIP_EVERY = 2600 // ms between staggered switch flips
-const FLIP_HOLD = 1300 // ms a flipped switch stays off before flipping back
+// Ring geometry + timing (slow + calm).
+const RADIUS = 43
+const SPIN_SECONDS = 66
+const spin = { duration: SPIN_SECONDS, ease: 'linear' as const, repeat: Infinity }
 
-const spin = {
-  duration: SPIN_SECONDS,
-  ease: 'linear' as const,
-  repeat: Infinity,
-}
+// Background conveyor — a spread of real component names, three rows.
+const COMPONENT_ROWS = [
+  ['Button', 'Card', 'Input', 'Select', 'Combobox', 'Dialog', 'Sheet', 'Drawer', 'Tabs', 'Accordion', 'Table', 'DataTable', 'Toast', 'Tooltip', 'Popover'],
+  ['Badge', 'Avatar', 'Switch', 'Slider', 'Checkbox', 'Radio', 'Progress', 'Skeleton', 'Breadcrumb', 'Pagination', 'Stepper', 'Calendar', 'Command', 'Menu', 'Alert'],
+  ['Chip', 'Rating', 'Timeline', 'Color Input', 'File Upload', 'Empty State', 'Code Block', 'Kbd', 'Separator', 'Hover Card', 'Tree View', 'Segmented', 'Stat Card', 'Textarea', 'Toggle'],
+]
 
 export function BrandOrbit() {
   const reduce = useReducedMotion()
-  // flipped[id] === true → that switch is momentarily OFF. Default: all ON.
   const [flipped, setFlipped] = useState<Record<string, boolean>>({})
+  const [pulsed, setPulsed] = useState<Record<string, boolean>>({})
 
+  // Slow, randomised switch flips.
   useEffect(() => {
     if (reduce) return
     const timeouts: ReturnType<typeof setTimeout>[] = []
-    const interval = setInterval(() => {
+    const tick = () => {
       const id = SWITCH_IDS[Math.floor(Math.random() * SWITCH_IDS.length)]
-      setFlipped((prev) => ({ ...prev, [id]: true }))
-      const restore = setTimeout(() => {
-        setFlipped((prev) => ({ ...prev, [id]: false }))
-      }, FLIP_HOLD)
-      timeouts.push(restore)
-    }, FLIP_EVERY)
+      setFlipped((p) => ({ ...p, [id]: true }))
+      timeouts.push(setTimeout(() => setFlipped((p) => ({ ...p, [id]: false })), 900 + Math.random() * 1600))
+      timeouts.push(setTimeout(tick, 3200 + Math.random() * 3600))
+    }
+    const start = setTimeout(tick, 1500)
     return () => {
-      clearInterval(interval)
+      clearTimeout(start)
+      timeouts.forEach(clearTimeout)
+    }
+  }, [reduce])
+
+  // Occasional pulse on any item (avatars/tiles animate too, not just switches).
+  useEffect(() => {
+    if (reduce) return
+    const timeouts: ReturnType<typeof setTimeout>[] = []
+    const tick = () => {
+      const id = ALL_IDS[Math.floor(Math.random() * ALL_IDS.length)]
+      setPulsed((p) => ({ ...p, [id]: true }))
+      timeouts.push(setTimeout(() => setPulsed((p) => ({ ...p, [id]: false })), 520))
+      timeouts.push(setTimeout(tick, 2600 + Math.random() * 3200))
+    }
+    const start = setTimeout(tick, 2600)
+    return () => {
+      clearTimeout(start)
       timeouts.forEach(clearTimeout)
     }
   }, [reduce])
 
   return (
-    <div
-      aria-hidden
-      className="pointer-events-none relative mx-auto aspect-square w-full max-w-[540px] select-none"
-    >
+    <div aria-hidden className="pointer-events-none relative isolate select-none py-ds-06">
+      {/* Layer 1 — conveyor */}
+      <div className="absolute inset-0 flex flex-col justify-center gap-ds-05 [mask-image:linear-gradient(to_right,transparent,black_14%,black_86%,transparent)]">
+        {COMPONENT_ROWS.map((row, i) => (
+          <ConveyorRow key={i} items={row} duration={54 + i * 12} reverse={i % 2 === 1} reduce={!!reduce} />
+        ))}
+      </div>
+
+      {/* Layer 2 + 3 — orbit + centre plate */}
+      <div className="relative mx-auto aspect-square w-full max-w-[520px]">
+        <motion.div className="absolute inset-0" animate={reduce ? undefined : { rotate: 360 }} transition={reduce ? undefined : spin}>
+          {ITEMS.map((item, i) => {
+            const angle = (i / ITEMS.length) * Math.PI * 2 - Math.PI / 2
+            const left = 50 + RADIUS * Math.cos(angle)
+            const top = 50 + RADIUS * Math.sin(angle)
+            return (
+              <motion.div
+                key={item.id}
+                className="absolute"
+                style={{ left: `${left}%`, top: `${top}%`, x: '-50%', y: '-50%' }}
+                animate={reduce ? undefined : { rotate: -360 }}
+                transition={reduce ? undefined : spin}
+              >
+                <motion.div
+                  animate={{ scale: pulsed[item.id] ? 1.14 : 1 }}
+                  transition={{ duration: 0.42, ease: [0.23, 1, 0.32, 1] }}
+                >
+                  {renderItem(item, !flipped[item.id])}
+                </motion.div>
+              </motion.div>
+            )
+          })}
+        </motion.div>
+
+        {/* Centre plate */}
+        <div className="absolute left-1/2 top-1/2 flex h-[9.5rem] w-[9.5rem] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center rounded-full border border-surface-border-subtle bg-surface-base/85 text-center shadow-raised backdrop-blur-sm">
+          <span className="font-display text-[length:var(--typo-heading-xl-size)] font-[number:var(--typo-heading-xl-weight)] leading-none text-surface-fg">
+            120+
+          </span>
+          <span className="mt-ds-01 text-ds-sm text-surface-fg-muted">components</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ConveyorRow({
+  items,
+  duration,
+  reverse,
+  reduce,
+}: {
+  items: string[]
+  duration: number
+  reverse: boolean
+  reduce: boolean
+}) {
+  const doubled = useMemo(() => [...items, ...items], [items])
+  return (
+    <div className="flex w-max opacity-[0.55]">
       <motion.div
-        className="absolute inset-0"
-        animate={reduce ? undefined : { rotate: 360 }}
-        transition={reduce ? undefined : spin}
+        className="flex gap-ds-03 pr-ds-03"
+        animate={reduce ? undefined : { x: reverse ? ['-50%', '0%'] : ['0%', '-50%'] }}
+        transition={reduce ? undefined : { duration, ease: 'linear', repeat: Infinity }}
       >
-        {ITEMS.map((item, i) => {
-          const angle = (i / ITEMS.length) * Math.PI * 2 - Math.PI / 2
-          const left = 50 + RADIUS * Math.cos(angle)
-          const top = 50 + RADIUS * Math.sin(angle)
-          return (
-            <motion.div
-              key={item.id}
-              className="absolute"
-              // x/y centre the item on its orbit point; framer owns the
-              // transform, so rotate composes with the -50% offset rather than
-              // clobbering a Tailwind translate class.
-              style={{ left: `${left}%`, top: `${top}%`, x: '-50%', y: '-50%' }}
-              animate={reduce ? undefined : { rotate: -360 }}
-              transition={reduce ? undefined : spin}
-            >
-              {renderItem(item, !flipped[item.id])}
-            </motion.div>
-          )
-        })}
+        {doubled.map((name, i) => (
+          <span
+            key={`${name}-${i}`}
+            className="whitespace-nowrap rounded-pill border border-surface-border-subtle bg-surface-raised px-ds-04 py-ds-02 text-ds-xs text-surface-fg-subtle"
+          >
+            {name}
+          </span>
+        ))}
       </motion.div>
     </div>
   )
@@ -134,15 +185,7 @@ export function BrandOrbit() {
 
 function renderItem(item: OrbitItem, checked: boolean) {
   if (item.kind === 'switch') {
-    return (
-      <Switch
-        size="lg"
-        checked={checked}
-        onCheckedChange={() => {}}
-        tabIndex={-1}
-        className={item.tint}
-      />
-    )
+    return <Switch size="lg" checked={checked} onCheckedChange={() => {}} tabIndex={-1} className={item.tint} />
   }
   if (item.kind === 'avatar') {
     return (
@@ -152,10 +195,8 @@ function renderItem(item: OrbitItem, checked: boolean) {
     )
   }
   const Glyph = item.icon
-  // Ink chip — DS tokens, theme-aware. `surface-fg` is near-black in light /
-  // near-white in dark; `surface-1` is its inverse, so the glyph always reads.
   return (
-    <div className="flex h-14 w-14 items-center justify-center rounded-surface bg-surface-fg text-surface-1 shadow-overlay ring-1 ring-surface-1/10">
+    <div className="flex h-14 w-14 items-center justify-center rounded-surface bg-surface-fg text-surface-base shadow-overlay ring-1 ring-surface-base/10">
       <Glyph size={24} stroke={2} />
     </div>
   )

--- a/apps/site/components/feature-grid.tsx
+++ b/apps/site/components/feature-grid.tsx
@@ -1,75 +1,65 @@
 import { IconLayoutGrid, IconPalette, IconShield, IconUsers } from '@tabler/icons-react'
 import { Text } from '@devalok/shilp-sutra/ui/text'
-import { CARD_RESTING } from '@/lib/card-recipe'
 
 /**
- * Three pillars + one builder promise. Per docs/copy/shilp-sutra-copy-context.md §3 + §14.
- *
- * Pillars (§3) — the three the doc names, and only these three:
- *   1. Be yourself      — customisability is the headline
- *   2. Thought through  — craft shown, not claimed
- *   3. Real-scale       — full pages, not toys
- *
- * Promise (§4) — "For builders, by builders" is the audience line, NOT a
- * pillar. It renders as a distinct card below the pillar row so the
- * "Three pillars. One promise." heading counts true.
- *
- * Agent angle lives in <AgentCallout /> below this section, not here.
+ * "Built to ship real products" — three pillars as cards + one promise card.
+ * Per docs/copy/shilp-sutra-copy-context.md §3/§4. Short, layman copy.
  */
 const pillars = [
   {
     icon: IconPalette,
     title: 'Your brand, everywhere',
-    body: "Set one colour and every button, badge, card, and form recolours across light and dark. CSS variables carry it, so there's no config file and no list of hex codes to keep in sync.",
+    body: 'Set one colour. Every button, card, and form recolours across light and dark. No config, no hex list.',
   },
   {
     icon: IconShield,
     title: 'The tedious parts, handled',
-    body: "Keyboard navigation, screen-reader labels, focus traps, roving tabindex, dismissable popovers, visible focus rings. The accessibility work lives inside every component, so you don't rewire it on each screen.",
+    body: 'Keyboard nav, screen-reader labels, focus rings. The accessibility work lives inside every component.',
   },
   {
     icon: IconLayoutGrid,
     title: 'Real production components',
-    body: 'Dashboards, settings, pricing, sign-up, data tables, toasts. The full set a shipping product needs, ready to drop in.',
+    body: 'Dashboards, settings, pricing, tables, toasts. The full set a shipping product needs, ready to drop in.',
   },
 ] as const
-
-const promise = {
-  icon: IconUsers,
-  title: 'We build on it too',
-  body: "shilp-sutra runs Devalok's own products: Karm, Devalok Hiring, BharatTools, and Gurukul. One library, one team maintaining it, shaped by shipping real software.",
-} as const
 
 export function FeatureGrid() {
   return (
     <section className="mx-auto max-w-6xl px-page-x py-ds-12">
       <div className="flex flex-col gap-ds-08">
-        <div className="flex flex-col items-center gap-ds-03 max-w-3xl mx-auto text-center">
-          <Text variant="heading-xl" className="text-surface-fg">
-            Built to ship real products.
-          </Text>
-        </div>
+        <Text variant="heading-xl" className="max-w-3xl text-surface-fg">
+          Built to ship real products.
+        </Text>
 
-        {/* The three pillars — one clean row on desktop. */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-x-ds-08 gap-y-ds-07">
+        <div className="grid grid-cols-1 gap-ds-05 md:grid-cols-3">
           {pillars.map((f) => (
-            <div key={f.title} className="flex flex-col gap-ds-02">
-              <div className="flex items-center gap-ds-02">
-                <f.icon size={18} className="text-accent-11 shrink-0" />
-                <h3 className="text-ds-md text-surface-fg font-semibold">{f.title}</h3>
+            <div
+              key={f.title}
+              className="flex flex-col gap-ds-04 rounded-surface border border-surface-border-subtle bg-surface-raised p-ds-06"
+            >
+              <span className="flex size-10 items-center justify-center rounded-control bg-accent-3 text-accent-11">
+                <f.icon size={20} />
+              </span>
+              <div className="flex flex-col gap-ds-02">
+                <h3 className="text-ds-md font-semibold text-surface-fg">{f.title}</h3>
+                <p className="text-ds-sm text-surface-fg-muted">{f.body}</p>
               </div>
-              <p className="text-ds-sm text-surface-fg-subtle">{f.body}</p>
             </div>
           ))}
         </div>
 
-        {/* The one promise — set apart from the pillars as its own card. */}
-        <div className={`${CARD_RESTING} flex flex-col gap-ds-03 sm:flex-row sm:items-center sm:gap-ds-06`}>
-          <div className="flex items-center gap-ds-02 sm:w-64 sm:shrink-0">
-            <promise.icon size={18} className="text-accent-11 shrink-0" />
-            <h3 className="text-ds-md text-surface-fg font-semibold">{promise.title}</h3>
+        {/* The one promise — a distinct accent-tinted card. */}
+        <div className="flex flex-col gap-ds-04 rounded-surface border border-accent-6 bg-accent-2 p-ds-06 sm:flex-row sm:items-center sm:gap-ds-06">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-control bg-accent-9 text-accent-fg">
+            <IconUsers size={20} />
+          </span>
+          <div className="flex flex-col gap-ds-01">
+            <h3 className="text-ds-md font-semibold text-surface-fg">We build on it too</h3>
+            <p className="text-ds-sm text-surface-fg-muted">
+              shilp-sutra runs Karm, our own studio tool. One library, one team, shaped by shipping
+              real software.
+            </p>
           </div>
-          <p className="text-ds-sm text-surface-fg-subtle sm:flex-1">{promise.body}</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
C1: BrandOrbit gets a background component conveyor + '120+ components' centre + slower/varied animation. C8: FeatureGrid 'Built to ship real products' as icon-tile cards, trimmed copy, Karm-only promise. next build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)