### PR TITLE
feat(site): stroke restore + theming cleanup + docs AI-band

### DIFF
--- a/apps/site/app/docs/page.tsx
+++ b/apps/site/app/docs/page.tsx
@@ -105,11 +105,37 @@ export default function DocsIndexPage() {
         <div className="mx-auto max-w-6xl px-page-x pt-[5.5rem] sm:pt-[5rem] pb-ds-09">
           <div className="flex flex-col gap-ds-09">
             <PageHeader
-              eyebrow="Docs"
               title="Pick your stack. Ship in five minutes."
-              subtitle="Six framework recipes, plus theming, server components, and troubleshoot."
-              description="Every recipe is the same as the one shipped inside the npm tarball at node_modules/@devalok/shilp-sutra/docs/recipes/. Single source of truth, no drift."
+              subtitle="Framework recipes, theming, server components, and troubleshooting. The same recipes ship inside the npm package."
             />
+
+            {/* For AI editors — first-class path. The MCP serves version-exact
+                docs so agents stop guessing. */}
+            <section className="flex flex-col gap-ds-04 rounded-surface border border-accent-6 bg-accent-2 p-ds-06">
+              <div className="flex items-center gap-ds-02">
+                <IconCode size={16} className="text-accent-11" />
+                <Text variant="label-sm" className="font-semibold uppercase tracking-wide text-accent-11">
+                  For AI editors
+                </Text>
+              </div>
+              <Text variant="heading-sm" className="text-surface-fg">
+                Point your editor at the docs MCP.
+              </Text>
+              <Text variant="body-sm" className="max-w-2xl text-surface-fg-muted">
+                Cursor, Claude, Copilot, and Aider can read every component, prop, token, and setup
+                step straight from the source. Add the server once and stop pasting docs into chat.
+              </Text>
+              <code className="w-fit rounded-control bg-surface-base px-ds-03 py-ds-02 font-mono text-ds-sm text-surface-fg">
+                https://shilp-sutra.devalok.in/mcp
+              </code>
+              <Link
+                href="/agents"
+                className="inline-flex w-fit items-center gap-ds-01 text-ds-sm text-accent-11 hover:text-accent-12"
+              >
+                Full editor setup
+                <IconArrowRight size={14} />
+              </Link>
+            </section>
 
             <section className="flex flex-col gap-ds-05">
               <header className="flex flex-col gap-ds-02 max-w-3xl">
@@ -137,25 +163,6 @@ export default function DocsIndexPage() {
               <DocsSection eyebrow="Troubleshoot" title="When things break." items={TROUBLESHOOT} />
             </div>
 
-            <section className="rounded-control border border-surface-border-subtle bg-surface-raised p-ds-06 flex flex-col gap-ds-03">
-              <div className="flex items-center gap-ds-02">
-                <IconCode size={16} className="text-surface-fg-subtle" />
-                <Text variant="label-sm" className="text-surface-fg-subtle">
-                  Working with an AI editor?
-                </Text>
-              </div>
-              <Text variant="body-sm" className="text-surface-fg-muted max-w-3xl">
-                Install the Agent Skill once. Cursor, Claude Code, Codex, Aider then know every
-                component, every setup step, every gotcha. No more pasting docs into chat.
-              </Text>
-              <Link
-                href="/agents"
-                className="text-ds-sm text-accent-11 hover:text-accent-12 inline-flex items-center gap-ds-01 w-fit"
-              >
-                Set up your editor
-                <IconArrowRight size={14} />
-              </Link>
-            </section>
           </div>
         </div>
       </main>

--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -51,6 +51,30 @@ html {
   }
 }
 
+/* Grid-layer colour: draws in the dark trace, then settles to the hairline.
+   Drives --hero-grid, used by the repeating-linear-gradient grid. Registered so
+   the keyframe can animate it (unregistered custom props don't animate). */
+@property --hero-grid {
+  syntax: '<color>';
+  inherits: false;
+  initial-value: #eaeaea;
+}
+:root {
+  --hero-grid: #eaeaea;
+}
+.dark {
+  --hero-grid: color-mix(in oklch, white 9%, transparent);
+}
+@keyframes hero-grid-settle {
+  0%,
+  60% {
+    --hero-grid: var(--hero-line-trace);
+  }
+  100% {
+    --hero-grid: var(--hero-line);
+  }
+}
+
 /*
  * Colour hierarchy — Figma "Branding" palette (node 103:1155):
  *   Primary   -> --color-accent-*    Teal.  Brand-preset default (brand-presets.ts) —

--- a/apps/site/app/theming/page.tsx
+++ b/apps/site/app/theming/page.tsx
@@ -21,9 +21,8 @@ export default function ThemingPage() {
         <div className="mx-auto max-w-6xl px-page-x pt-[5.5rem] sm:pt-[5rem] pb-ds-09">
           <div className="flex flex-col gap-ds-09">
             <PageHeader
-              eyebrow="Theming"
-              title="One color in. Everything out."
-              subtitle="Every component recolors — buttons, badges, alerts, focus rings, light and dark. Move the sliders, pick a preset, or paste your hex. Export the CSS and your whole app follows."
+              title="One colour in. Everything out."
+              subtitle="Pick a colour and every component follows, in light and dark. Copy the CSS and your whole app matches."
             />
 
             <Suspense fallback={null}>
@@ -72,11 +71,8 @@ export default function ThemingPage() {
                 CSS variables. No JS theme provider.
               </Text>
               <Text variant="body-sm" className="text-surface-fg-muted leading-relaxed">
-                Whichever door you pick above, you walk out with the same thing: a CSS block of
-                role tokens + an OKLCH accent ramp. Paste into your global stylesheet. Every
-                shilp-sutra component follows. Switch themes by toggling a class, or write{' '}
-                <code className="font-mono text-ds-sm text-surface-fg">data-archetype=&quot;apple&quot;</code>{' '}
-                on the body and reload.
+                You walk out with one CSS block: role tokens plus an OKLCH accent ramp. Paste it
+                into your global stylesheet and every shilp-sutra component follows.
               </Text>
               <div className="flex flex-wrap gap-ds-03 text-ds-sm mt-ds-02">
                 <Link href="/docs/customize-brand" className="text-accent-11 underline underline-offset-2 hover:text-accent-12">

--- a/apps/site/components/brahma-backdrop.tsx
+++ b/apps/site/components/brahma-backdrop.tsx
@@ -175,8 +175,10 @@ export function BrahmaBackdrop() {
           animate={{ opacity: 1 }}
           transition={{ duration: reduce ? 0 : 1.2, delay: reduce ? 0 : 0.3 }}
           style={{
-            backgroundImage: `repeating-linear-gradient(to right, ${HAIRLINE} 0 1px, transparent 1px ${CELL}px), repeating-linear-gradient(to bottom, ${HAIRLINE} 0 1px, transparent 1px ${CELL}px)`,
+            backgroundImage: `repeating-linear-gradient(to right, var(--hero-grid) 0 1px, transparent 1px ${CELL}px), repeating-linear-gradient(to bottom, var(--hero-grid) 0 1px, transparent 1px ${CELL}px)`,
             backgroundPosition: `${gx0}px 0`,
+            // Grid lines draw in dark, then settle to the faint hairline.
+            animation: reduce ? undefined : 'hero-grid-settle 2.6s cubic-bezier(0.23,1,0.32,1) 0.3s both',
           }}
         />
       )}
@@ -204,13 +206,17 @@ export function BrahmaBackdrop() {
             const dur = 2.1 + (i % 3) * 0.2
             return (
               <g key={`c-${i}`}>
-                {/* opening right (center to the right of origin) */}
+                {/* opening right (center to the right of origin). The
+                    hero-line-anim class draws the stroke in DARK, then settles
+                    to the faint hairline (--sdelay/--sdur sync to pathLength). */}
                 <motion.circle
                   cx={ox + r}
                   cy={oy}
                   r={r}
                   stroke={HAIRLINE}
                   strokeWidth={1.25}
+                  className={reduce ? undefined : 'hero-line-anim'}
+                  style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay}s`, ['--sdur' as string]: `${dur + 0.9}s` } as React.CSSProperties)}
                   initial={strokeInitial}
                   animate={{ pathLength: 1, opacity: 1 }}
                   transition={
@@ -226,6 +232,8 @@ export function BrahmaBackdrop() {
                   r={r}
                   stroke={HAIRLINE}
                   strokeWidth={1.25}
+                  className={reduce ? undefined : 'hero-line-anim'}
+                  style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay + 0.1}s`, ['--sdur' as string]: `${dur + 0.9}s` } as React.CSSProperties)}
                   initial={strokeInitial}
                   animate={{ pathLength: 1, opacity: 1 }}
                   transition={

--- a/apps/site/components/themer/BrandImportPanel.tsx
+++ b/apps/site/components/themer/BrandImportPanel.tsx
@@ -62,7 +62,7 @@ export function BrandImportPanel() {
               value={hex}
               onChange={(e) => setHex(e.target.value)}
               onBlur={handleHexBlur}
-              className="flex-1 rounded-control border border-surface-border-subtle bg-surface-2 px-ds-03 py-ds-02 text-ds-md font-mono text-surface-fg focus:outline-hidden focus:ring-2 focus:ring-accent-9"
+              className="flex-1 rounded-control border border-surface-border-subtle bg-surface-raised px-ds-03 py-ds-02 text-ds-md font-mono text-surface-fg focus:outline-hidden focus:ring-2 focus:ring-accent-9"
               placeholder="#d946a6"
             />
             <input
@@ -128,7 +128,7 @@ export function BrandImportPanel() {
           ))}
         </div>
 
-        <div className="rounded-surface border border-surface-border-subtle bg-surface-2 p-ds-04 flex flex-col gap-ds-02">
+        <div className="rounded-surface border border-surface-border-subtle bg-surface-raised p-ds-04 flex flex-col gap-ds-02">
           <span className="text-ds-xs text-surface-fg-subtle">
             Suggested archetype
           </span>

--- a/apps/site/components/themer/ResultActions.tsx
+++ b/apps/site/components/themer/ResultActions.tsx
@@ -36,14 +36,14 @@ export function ResultActions({ css }: ResultActionsProps) {
         <button
           type="button"
           onClick={() => copy(css, setCssState)}
-          className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-strong bg-surface-2 px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg hover:bg-surface-3"
+          className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-strong bg-surface-raised px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg hover:bg-surface-raised-hover"
         >
           {cssState === 'copied' ? 'Copied' : 'Copy CSS'}
         </button>
         <button
           type="button"
           onClick={() => copy(window.location.href, setShareState)}
-          className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-subtle bg-surface-2 px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg-muted hover:text-surface-fg hover:bg-surface-3"
+          className="inline-flex items-center gap-ds-02 rounded-control border border-surface-border-subtle bg-surface-raised px-ds-04 py-ds-02 text-ds-sm font-medium text-surface-fg-muted hover:text-surface-fg hover:bg-surface-raised-hover"
         >
           {shareState === 'copied' ? 'Share URL copied' : 'Copy share URL'}
         </button>

--- a/apps/site/components/themer/ThemingHub.tsx
+++ b/apps/site/components/themer/ThemingHub.tsx
@@ -9,7 +9,6 @@ import {
   IconChevronRight,
   IconCopy,
   IconFingerprint,
-  IconMail,
 } from '@tabler/icons-react'
 import { Badge } from '@devalok/shilp-sutra/ui/badge'
 import { Button } from '@devalok/shilp-sutra/ui/button'
@@ -181,7 +180,7 @@ export function ThemingHub() {
   return (
     <div className="flex flex-col gap-ds-09">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-ds-08 items-start">
-        <section className="flex flex-col gap-ds-05 rounded-surface border border-surface-border-subtle bg-surface-2 p-ds-06 lg:sticky lg:top-24">
+        <section className="flex flex-col gap-ds-05 rounded-surface border border-surface-border-subtle bg-surface-raised p-ds-06 lg:sticky lg:top-24">
             <div role="tablist" aria-label="Theming mode" className="flex items-center gap-ds-05 border-b border-surface-border-subtle">
               {(
                 [
@@ -264,9 +263,8 @@ export function ThemingHub() {
                   </div>
                 </div>
                 <p className="text-ds-xs text-surface-fg-subtle -mt-ds-02">
-                  Brand color blurs into hue below and suggests a matching archetype. Corner
-                  radius overrides whatever the archetype would otherwise pick — leave blank to
-                  use it.
+                  Your colour sets the hue and picks a matching archetype. Leave radius blank
+                  to use the archetype default.
                 </p>
 
                 <SliderField
@@ -330,7 +328,7 @@ export function ThemingHub() {
                 </button>
               </div>
             ) : (
-              <div className="flex flex-col gap-ds-02 rounded-control border border-surface-border-subtle bg-surface-1 p-ds-02">
+              <div className="flex flex-col gap-ds-02 rounded-control border border-surface-border-subtle bg-surface-sunken p-ds-02">
                 {ARCHETYPE_ORDER.map((name) => {
                   const isActive = archetype === name
                   const accent = ARCHETYPE_ACCENT[name]
@@ -342,13 +340,13 @@ export function ThemingHub() {
                       className={[
                         'flex items-center gap-ds-07 px-ds-06 py-ds-05 rounded-control border text-left transition-colors duration-fast-01',
                         isActive
-                          ? 'border-surface-border bg-surface-2 shadow-raised'
-                          : 'border-surface-border-subtle bg-transparent hover:bg-surface-2/60',
+                          ? 'border-surface-border bg-surface-raised shadow-raised'
+                          : 'border-surface-border-subtle bg-transparent hover:bg-surface-raised/60',
                       ].join(' ')}
                     >
                       <span
                         aria-hidden
-                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-control bg-surface-2 border border-surface-border-subtle text-surface-fg"
+                        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-control bg-surface-raised border border-surface-border-subtle text-surface-fg"
                       >
                         <IconFingerprint size={16} />
                       </span>
@@ -368,7 +366,7 @@ export function ThemingHub() {
             )}
         </section>
 
-        <section className="flex flex-col gap-ds-04 rounded-surface border border-surface-border-subtle bg-surface-2 p-ds-06">
+        <section className="flex flex-col gap-ds-04 rounded-surface border border-surface-border-subtle bg-surface-raised p-ds-06">
             <div className="flex items-center justify-between">
               <Text variant="label-sm" className="text-surface-fg-subtle">
                 Live preview
@@ -403,8 +401,7 @@ export function ThemingHub() {
                 className="text-surface-fg-muted"
                 style={{ fontSize: `${role.bodySize}px`, lineHeight: role.leading }}
               >
-                A card with role tokens applied. Shape, density, and shadow come from the
-                archetype preset.
+                Shape, spacing, and shadow all come from the archetype.
               </p>
               <div className="flex flex-wrap items-center gap-ds-03">
                 <button
@@ -467,8 +464,8 @@ export function ThemingHub() {
                   Brand-tinted notice
                 </Text>
                 <Text variant="body-sm" className="text-surface-fg mt-ds-01">
-                  Surface, border, and text all read against the active hue. The DS does the
-                  heavy lifting; you only pick the colour.
+                  Surface, border, and text all follow your colour. You pick it, the system
+                  does the rest.
                 </Text>
               </div>
             </div>
@@ -499,18 +496,18 @@ export function ThemingHub() {
                     <code>{css}</code>
                   </pre>
                   <Text variant="body-sm" className="text-surface-fg-subtle">
-                    Paste this into your consumer CSS after the{' '}
+                    Paste this after your{' '}
                     <code className="font-mono text-surface-fg">
                       @import &quot;@devalok/shilp-sutra/css&quot;
                     </code>{' '}
-                    line. Your whole app picks up the new ramp instantly. See the{' '}
+                    line and every component follows. Need radius, fonts, or spacing? See the{' '}
                     <a
                       href="/docs/customize-brand"
                       className="underline underline-offset-2 hover:text-surface-fg"
                     >
                       customize-brand recipe
-                    </a>{' '}
-                    for deeper customizations (radius, fonts, spacing).
+                    </a>
+                    .
                   </Text>
                   <InstallTabs />
                 </>
@@ -518,56 +515,6 @@ export function ThemingHub() {
             </div>
         </section>
       </div>
-
-      <section className="flex flex-col gap-ds-06">
-        <div className="flex flex-col items-center gap-ds-02 text-center max-w-2xl mx-auto">
-          <Text variant="heading-md" className="text-surface-fg">
-            Four ways in. Same CSS out
-          </Text>
-          <Text variant="body-sm" className="text-surface-fg-muted">
-            Four entry doors: pick an archetype, paste your brand color, take a wizard, or just
-            see a result page. Each drops you at install + CSS to paste, no editing required.
-          </Text>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-05">
-          <div className="flex flex-col gap-ds-04 rounded-control border border-surface-border-subtle bg-surface-2 p-ds-05">
-            <div className="flex h-32 items-center justify-center rounded-control bg-surface-1 px-ds-06">
-              <div className="w-full h-1 rounded-pill bg-surface-border-subtle relative">
-                <div
-                  className="absolute inset-y-0 left-0 rounded-pill bg-accent-9"
-                  style={{ width: '35%' }}
-                />
-              </div>
-            </div>
-            <div className="flex flex-col gap-ds-02">
-              <Text variant="label-sm" className="text-surface-fg inline-flex items-center gap-ds-02">
-                <IconMail size={14} /> Walk me through it
-              </Text>
-              <Text variant="body-sm" className="text-surface-fg-muted">
-                Answer five questions about your product and we pick the tokens, surfaces, and
-                radius that fit.
-              </Text>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-ds-04 rounded-control border border-surface-border-subtle bg-surface-2 p-ds-05">
-            <div className="flex h-32 items-center justify-center gap-ds-03 rounded-control bg-surface-1">
-              <span className="text-ds-lg font-semibold text-success-11">4.5:1</span>
-              <Badge color="accent" variant="soft">PASS AA</Badge>
-            </div>
-            <div className="flex flex-col gap-ds-02">
-              <Text variant="label-sm" className="text-surface-fg inline-flex items-center gap-ds-02">
-                <IconMail size={14} /> Show me a result page
-              </Text>
-              <Text variant="body-sm" className="text-surface-fg-muted">
-                See a fully themed component set before you commit to anything — copy the CSS if
-                it feels right.
-              </Text>
-            </div>
-          </div>
-        </div>
-      </section>
     </div>
   )
 }

--- a/apps/site/components/themer/WizardFlow.tsx
+++ b/apps/site/components/themer/WizardFlow.tsx
@@ -108,7 +108,7 @@ export function WizardFlow() {
           <span>
             {step + 1} / {total}
           </span>
-          <div className="h-[2px] flex-1 bg-surface-3 rounded-pill overflow-hidden">
+          <div className="h-[2px] flex-1 bg-surface-raised-hover rounded-pill overflow-hidden">
             <div
               className="h-full bg-accent-9 transition-all duration-moderate-01"
               style={{ width: `${((step + (isDone ? 1 : 0)) / total) * 100}%` }}
@@ -130,7 +130,7 @@ export function WizardFlow() {
                   'group flex flex-col gap-ds-01 rounded-control border p-ds-04 text-left transition-colors duration-fast-01',
                   isSelected
                     ? 'border-accent-9 bg-accent-2'
-                    : 'border-surface-border-subtle bg-surface-2 hover:border-surface-border-strong hover:bg-surface-3',
+                    : 'border-surface-border-subtle bg-surface-raised hover:border-surface-border-strong hover:bg-surface-raised-hover',
                 ].join(' ')}
               >
                 <span className="text-ds-md font-medium text-surface-fg">{c.label}</span>


### PR DESCRIPTION
Tail of the homepage R2 pass: restore hero dark→light line draw; theming page trim + ThemingHub surface-token fixes + cut broken 'four ways' section; docs leads with the For-AI-editors MCP band. tsc + next build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)