### PR TITLE
feat(site): hero easter eggs + golden slower opening

### DIFF
--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -47,7 +47,7 @@ html {
 }
 @media (prefers-reduced-motion: no-preference) {
   .hero-line-anim {
-    animation: hero-stroke var(--sdur, 2s) cubic-bezier(0.23, 1, 0.32, 1) var(--sdelay, 0ms) both;
+    animation: hero-stroke var(--sdur, 2s) cubic-bezier(0.618, 0, 0.382, 1) var(--sdelay, 0ms) both;
   }
 }
 
@@ -185,6 +185,26 @@ html {
 @media (prefers-reduced-motion: no-preference) {
   .hero-rise {
     opacity: 0;
-    animation: hero-rise 0.6s cubic-bezier(0.23, 1, 0.32, 1) var(--hero-delay, 0ms) both;
+    animation: hero-rise 0.6s cubic-bezier(0.618, 0, 0.382, 1) var(--hero-delay, 0ms) both;
+  }
+}
+
+/* Hero easter-egg chips (Learn More / link tile) — fade in late, WITH the other
+   specimens. Rests at 0.45 opacity (looks decorative/disabled). Hover uses
+   transform, not opacity, so the animation's held opacity doesn't fight it. */
+@keyframes egg-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.45;
+  }
+}
+.hero-egg {
+  opacity: 0.45;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .hero-egg {
+    animation: egg-in 0.5s cubic-bezier(0.618, 0, 0.382, 1) var(--egg-delay, 5.5s) both;
   }
 }

--- a/apps/site/components/brahma-backdrop.tsx
+++ b/apps/site/components/brahma-backdrop.tsx
@@ -33,7 +33,8 @@ const ORIGIN_ROW = 5
 // internally tangent at the origin (they "ripple" from one grid point).
 const RADII_CELLS = [3.4, 4.9, 6.6]
 
-const EASE_OUT = [0.23, 1, 0.32, 1] as const
+// Golden-ratio easing curve: control points at φ⁻¹ (0.618) and φ⁻² (0.382).
+const EASE_OUT = [0.618, 0, 0.382, 1] as const
 const HAIRLINE = 'var(--hero-line)'
 
 // Exact identity palette (fixed specimens). Accent-bound swatches use tokens.
@@ -73,37 +74,12 @@ const chips: Chip[] = [
       </Avatar>
     ),
   },
-  { id: 'sq-blue', col: 6, row: 2, node: swatch('size-8', C.blue) },
-  {
-    id: 'learn',
-    col: 7,
-    row: 6,
-    lg: true,
-    node: (
-      <span
-        className="inline-flex select-none items-center rounded-control px-ds-04 py-ds-03 text-ds-sm font-medium opacity-45"
-        style={{ background: C.lime, color: C.ink }}
-      >
-        Learn More
-      </span>
-    ),
-  },
-  { id: 'sq-lime', col: 6, row: 7, lg: true, node: swatch('size-8', C.lime) },
-  {
-    id: 'link',
-    col: 0,
-    row: 8,
-    lg: true,
-    node: (
-      <div
-        className="flex size-[4.5rem] items-center justify-center rounded-control shadow-raised"
-        style={{ background: C.ink, color: C.inkFg }}
-      >
-        <IconLink size={30} />
-      </div>
-    ),
-  },
-  { id: 'sq-black', col: 2, row: 9, lg: true, node: swatch('size-8', C.ink) },
+  // 'learn' (the faded easter-egg chip) is rendered separately below — it must
+  // live OUTSIDE the inert layer to stay clickable.
+  // 'link' (the ink tile) is also an easter egg — rendered below, outside inert.
+  { id: 'sq-blue', col: 8, row: 2, lg: true, node: swatch('size-8', C.blue) },
+  { id: 'sq-lime', col: 8, row: 7, lg: true, node: swatch('size-8', C.lime) },
+  { id: 'sq-black', col: 10, row: 8.7, lg: true, node: swatch('size-8', C.ink) },
   // Right-arm stack — a mini ramp of the ACTIVE accent (recolours with preset).
   { id: 'arm-1', col: 15, row: 5, lg: true, node: swatch('size-5', 'var(--color-accent-11)') },
   { id: 'arm-2', col: 15, row: 5.4, lg: true, node: swatch('size-5', 'var(--color-accent-9)') },
@@ -158,7 +134,7 @@ export function BrahmaBackdrop() {
     hidden: reduce ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.92 },
     shown: { opacity: 1, scale: 1 },
   }
-  const chipDelays = useMemo(() => chips.map(() => 2.9 + Math.random() * 1.2), [])
+  const chipDelays = useMemo(() => chips.map(() => 4.8 + Math.random() * 1.8), [])
 
   // A5 — replay the whole entrance when the theme is toggled on this page.
   // ThemeToggle dispatches 'ss-theme-change'; bumping this key remounts the
@@ -174,6 +150,7 @@ export function BrahmaBackdrop() {
   const py = (row: number) => `${row * CELL}px`
 
   return (
+    <>
     <div ref={rootRef} aria-hidden inert className="pointer-events-none absolute inset-0 overflow-hidden">
       {/* Invisible probe that mirrors the hero content container, so we can read
           its left edge and anchor the grid to it. */}
@@ -191,7 +168,7 @@ export function BrahmaBackdrop() {
               circle origin so the grid builds from the centre. */}
           {vLines.map((x, i) => {
             const dist = Math.abs(x - ox)
-            const delay = 0.3 + (dist / CELL) * 0.06
+            const delay = 0.5 + (dist / CELL) * 0.09
             return (
               <motion.line
                 key={`v-${i}`}
@@ -202,16 +179,16 @@ export function BrahmaBackdrop() {
                 stroke={HAIRLINE}
                 strokeWidth={1}
                 className={reduce ? undefined : 'hero-line-anim'}
-                style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay}s`, ['--sdur' as string]: '1.4s' } as React.CSSProperties)}
+                style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay}s`, ['--sdur' as string]: '2.0s' } as React.CSSProperties)}
                 initial={strokeInitial}
                 animate={{ pathLength: 1, opacity: 1 }}
-                transition={reduce ? { duration: 0 } : { pathLength: { duration: 0.7, delay, ease: EASE_OUT }, opacity: { duration: 0.2, delay } }}
+                transition={reduce ? { duration: 0 } : { pathLength: { duration: 1.1, delay, ease: EASE_OUT }, opacity: { duration: 0.2, delay } }}
               />
             )
           })}
           {hLines.map((y, i) => {
             const dist = Math.abs(y - oy)
-            const delay = 0.3 + (dist / CELL) * 0.06
+            const delay = 0.5 + (dist / CELL) * 0.09
             return (
               <motion.line
                 key={`h-${i}`}
@@ -222,10 +199,10 @@ export function BrahmaBackdrop() {
                 stroke={HAIRLINE}
                 strokeWidth={1}
                 className={reduce ? undefined : 'hero-line-anim'}
-                style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay}s`, ['--sdur' as string]: '1.4s' } as React.CSSProperties)}
+                style={reduce ? undefined : ({ ['--sdelay' as string]: `${delay}s`, ['--sdur' as string]: '2.0s' } as React.CSSProperties)}
                 initial={strokeInitial}
                 animate={{ pathLength: 1, opacity: 1 }}
-                transition={reduce ? { duration: 0 } : { pathLength: { duration: 0.7, delay, ease: EASE_OUT }, opacity: { duration: 0.2, delay } }}
+                transition={reduce ? { duration: 0 } : { pathLength: { duration: 1.1, delay, ease: EASE_OUT }, opacity: { duration: 0.2, delay } }}
               />
             )
           })}
@@ -245,8 +222,8 @@ export function BrahmaBackdrop() {
           ))}
           {RADII_CELLS.map((rc, i) => {
             const r = rc * CELL
-            const delay = 1.3 + i * 0.22
-            const dur = 2.1 + (i % 3) * 0.2
+            const delay = 2.2 + i * 0.34
+            const dur = 3.0 + (i % 3) * 0.3
             return (
               <g key={`c-${i}`}>
                 {/* opening right (center to the right of origin). The
@@ -301,8 +278,8 @@ export function BrahmaBackdrop() {
           reduce
             ? { duration: 0 }
             : {
-                duration: 1.05,
-                delay: 3.6,
+                duration: 1.3,
+                delay: 5.2,
                 times: [0, 0.09, 0.16, 0.28, 0.4, 0.52, 0.7, 1],
                 ease: EASE_OUT,
               }
@@ -334,5 +311,37 @@ export function BrahmaBackdrop() {
       )}
       </div>
     </div>
+
+    {/* Easter eggs — the faded "Learn More" chip and the ink link-tile look
+        decorative/disabled but rickroll on click. They live OUTSIDE the inert
+        decorative layer so they stay clickable. Mouse-only (tabIndex -1,
+        aria-hidden) so they never trap keyboard users. */}
+    {ready && (
+      <>
+        <a
+          href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+          target="_blank"
+          rel="noreferrer"
+          aria-hidden
+          tabIndex={-1}
+          className="hero-egg pointer-events-auto absolute z-20 hidden select-none rounded-control px-ds-04 py-ds-03 text-ds-sm font-medium transition-transform duration-fast-02 hover:scale-105 lg:block"
+          style={{ left: px(9.2), top: py(5.4), background: C.lime, color: C.ink, ['--egg-delay' as string]: '5.4s' }}
+        >
+          Learn More
+        </a>
+        <a
+          href="https://www.youtube.com/watch?v=iik25wqIuFo"
+          target="_blank"
+          rel="noreferrer"
+          aria-hidden
+          tabIndex={-1}
+          className="hero-egg pointer-events-auto absolute z-20 hidden size-[4.5rem] items-center justify-center rounded-control shadow-raised transition-transform duration-fast-02 hover:scale-105 lg:flex"
+          style={{ left: px(9), top: py(8), background: C.ink, color: C.inkFg, ['--egg-delay' as string]: '5.8s' }}
+        >
+          <IconLink size={30} />
+        </a>
+      </>
+    )}
+    </>
   )
 }

--- a/apps/site/components/hero.tsx
+++ b/apps/site/components/hero.tsx
@@ -14,15 +14,15 @@ export function Hero() {
           right. pt clears the floating pill (~70–80px). */}
       <div className="relative z-10 mx-auto flex w-full max-w-[96rem] flex-col px-page-x pt-ds-11 pb-ds-10 md:pt-ds-13 md:pb-ds-12">
         <div className="flex flex-col items-center gap-ds-06 text-center md:gap-ds-07 lg:max-w-[40rem] lg:items-start lg:text-left">
-          <h1 className="font-display text-[length:var(--typo-heading-2xl-size)] font-[number:var(--typo-heading-2xl-weight)] leading-[var(--typo-heading-2xl-leading)] tracking-[var(--typo-heading-2xl-tracking)] text-surface-fg text-balance hero-rise" style={{ ['--hero-delay' as string]: '4450ms' } as React.CSSProperties}>
+          <h1 className="font-display text-[length:var(--typo-heading-2xl-size)] font-[number:var(--typo-heading-2xl-weight)] leading-[var(--typo-heading-2xl-leading)] tracking-[var(--typo-heading-2xl-tracking)] text-surface-fg text-balance hero-rise" style={{ ['--hero-delay' as string]: '6800ms' } as React.CSSProperties}>
             A design system that takes{' '}
             <span className="text-accent-11">your brand&apos;s shape.</span>
           </h1>
-          <Text variant="body-lg" className="max-w-2xl text-pretty text-surface-fg hero-rise" style={{ ['--hero-delay' as string]: '4600ms' } as React.CSSProperties}>
+          <Text variant="body-lg" className="max-w-2xl text-pretty text-surface-fg hero-rise" style={{ ['--hero-delay' as string]: '6950ms' } as React.CSSProperties}>
             Pick one colour and your whole interface matches it. Buttons, cards, forms, light and
             dark. Install with one prompt and start building.
           </Text>
-          <div className="mt-ds-03 flex w-full max-w-sm flex-col gap-ds-03 sm:w-auto sm:max-w-none sm:flex-row hero-rise" style={{ ['--hero-delay' as string]: '4750ms' } as React.CSSProperties}>
+          <div className="mt-ds-03 flex w-full max-w-sm flex-col gap-ds-03 sm:w-auto sm:max-w-none sm:flex-row hero-rise" style={{ ['--hero-delay' as string]: '7100ms' } as React.CSSProperties}>
             <CopyInstallButton />
             <TrackedLink
               href="/theming"
@@ -41,8 +41,8 @@ export function Hero() {
             </TrackedLink>
           </div>
           {/* Trust chips — layman signals that matter for a DS; no slop. */}
-          <ul className="mt-ds-08 flex w-full flex-wrap items-center justify-center gap-x-ds-03 gap-y-ds-02 text-ds-base text-surface-fg-muted lg:justify-start hero-rise" style={{ ['--hero-delay' as string]: '4880ms' } as React.CSSProperties}>
-            {['120+ components', 'WCAG-AA accessible', 'MIT · open source', 'React 19 + Tailwind 4'].map(
+          <ul className="mt-ds-08 flex w-full flex-wrap items-center justify-center gap-x-ds-03 gap-y-ds-02 text-ds-base text-surface-fg-muted lg:justify-start hero-rise" style={{ ['--hero-delay' as string]: '7250ms' } as React.CSSProperties}>
+            {['120+ components', 'WCAG-AA accessible', 'MIT · open source'].map(
               (chip, i) => (
                 <li key={chip} className="inline-flex items-center gap-ds-03 whitespace-nowrap">
                   {i > 0 && (


### PR DESCRIPTION
Clickable rickroll easter eggs (Learn More + link tile, z-20 above content, mouse-only), fade in with the other layers, golden-ratio slower opening, overlap fix, removed React 19 chip. next build green.