### PR TITLE
fix(site): mobile topbar break + responsiveness

### DIFF
--- a/apps/site/app/globals.css
+++ b/apps/site/app/globals.css
@@ -15,6 +15,9 @@ body {
 /* Floating pill bar overlaps top of viewport — anchor jumps must clear it. */
 html {
   scroll-padding-top: 5.5rem;
+  /* Safety net: never let a stray-wide element create horizontal scroll (it
+     breaks the fixed, viewport-width topbar). `clip` still allows vertical. */
+  overflow-x: clip;
 }
 
 /* Hero backdrop hairline — the source #EAEAEA in light; a faint white in dark so
@@ -186,6 +189,13 @@ html {
   .hero-rise {
     opacity: 0;
     animation: hero-rise 0.6s cubic-bezier(0.618, 0, 0.382, 1) var(--hero-delay, 0ms) both;
+  }
+  /* Mobile/tablet has no elaborate backdrop composition (specimens are lg-only),
+     so the copy appears quickly instead of waiting out the desktop timeline. */
+  @media (max-width: 1023px) {
+    .hero-rise {
+      animation-delay: 140ms;
+    }
   }
 }
 

--- a/apps/site/components/brand-orbit.tsx
+++ b/apps/site/components/brand-orbit.tsx
@@ -105,9 +105,10 @@ export function BrandOrbit() {
   }, [reduce])
 
   return (
-    <div aria-hidden className="pointer-events-none relative isolate select-none py-ds-06">
-      {/* Layer 1 — conveyor */}
-      <div className="absolute inset-0 flex flex-col justify-center gap-ds-05 [mask-image:linear-gradient(to_right,transparent,black_14%,black_86%,transparent)]">
+    <div aria-hidden className="pointer-events-none relative isolate select-none overflow-hidden py-ds-06">
+      {/* Layer 1 — conveyor. overflow-hidden on BOTH this root and the row
+          container so the w-max belts never widen the page (mobile h-scroll). */}
+      <div className="absolute inset-0 flex flex-col justify-center gap-ds-05 overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_14%,black_86%,transparent)]">
         {COMPONENT_ROWS.map((row, i) => (
           <ConveyorRow key={i} items={row} duration={54 + i * 12} reverse={i % 2 === 1} reduce={!!reduce} />
         ))}


### PR DESCRIPTION
Fix mobile horizontal overflow (BrandOrbit conveyor was 2328px wide → broke the fixed topbar); add overflow-x clip safety net; fast mobile hero timing. Verified 0 overflow across 7 pages × 3 widths. next build green.