### PR TITLE
feat(site): integrate #193 — dark theming preview + docs code contrast

### DIFF
--- a/apps/.impeccable/hook.cache.json
+++ b/apps/.impeccable/hook.cache.json
@@ -1,0 +1,1 @@
+{"version":1,"sessions":{"43d0070d-75ce-4a63-9eaf-c32b67fa7a78":{"updatedAt":1784882509003,"files":{"C:\\Users\\mudit\\Documents\\GitHub\\shilp-sutra\\.claude\\worktrees\\site-visual-refresh\\apps\\site\\components\\site-header.tsx":{"editCount":3,"findings":[]}}}}}

--- a/apps/site/components/markdown-code-block.tsx
+++ b/apps/site/components/markdown-code-block.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import { track } from '@/lib/analytics'
+
+/**
+ * Code block for the docs markdown renderer. Unlike the shared `CodeBlock`
+ * (which sits inside surface-2 cards and uses a sunken `surface-overlay` body),
+ * docs code sits directly on the `surface-base` page — so it uses
+ * `surface-raised` to read as a distinct, elevated block in BOTH themes
+ * (whiter than the page in light, lighter than the page in dark). Adds a
+ * hover-revealed copy button, matching the copy affordance elsewhere on site.
+ */
+export function MarkdownCodeBlock({ code, language }: { code: string; language?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      track('code_copied', { context: 'docs', language: language ?? 'text' })
+      setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // ignore — older browsers without clipboard permission
+    }
+  }
+
+  return (
+    <div className="group relative my-ds-04 overflow-hidden rounded-control border border-surface-border bg-surface-raised">
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        className="absolute right-ds-02 top-ds-02 z-10 inline-flex h-7 w-7 items-center justify-center rounded-control-inner border border-surface-border-subtle bg-surface-raised-hover text-surface-fg-muted opacity-70 transition-opacity duration-fast-01 hover:text-surface-fg hover:opacity-100 focus-visible:opacity-100 group-hover:opacity-100"
+      >
+        {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+      </button>
+      <pre className="overflow-x-auto px-ds-04 py-ds-04 text-ds-sm font-mono leading-relaxed text-surface-fg whitespace-pre">
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}

--- a/apps/site/components/markdown-code-block.tsx
+++ b/apps/site/components/markdown-code-block.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useState } from 'react'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import { track } from '@/lib/analytics'
+
+/**
+ * Code block for the docs markdown renderer. Unlike the shared `CodeBlock`
+ * (which sits inside surface-2 cards and uses a sunken `surface-overlay` body),
+ * docs code sits directly on the `surface-base` page — so it uses
+ * `surface-raised` to read as a distinct, elevated block in BOTH themes
+ * (whiter than the page in light, lighter than the page in dark). Adds a
+ * hover-revealed copy button, matching the copy affordance elsewhere on site.
+ */
+export function MarkdownCodeBlock({ code, language }: { code: string; language?: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopied(true)
+      track('code_copied', { context: 'docs', language: language ?? 'text' })
+      setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // ignore — older browsers without clipboard permission
+    }
+  }
+
+  return (
+    <div className="group relative my-ds-04 overflow-hidden rounded-control border border-surface-border bg-surface-raised">
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? 'Copied' : 'Copy code'}
+        className="absolute right-ds-02 top-ds-02 z-10 inline-flex h-7 w-7 items-center justify-center rounded-control-inner border border-surface-border-subtle bg-surface-2 text-surface-fg-muted opacity-70 transition-opacity duration-fast-01 hover:text-surface-fg hover:opacity-100 focus-visible:opacity-100 group-hover:opacity-100"
+      >
+        {copied ? <IconCheck size={14} /> : <IconCopy size={14} />}
+      </button>
+      <pre className="overflow-x-auto px-ds-04 py-ds-04 text-ds-sm font-mono leading-relaxed text-surface-fg whitespace-pre">
+        <code>{code}</code>
+      </pre>
+    </div>
+  )
+}

--- a/apps/site/components/markdown.tsx
+++ b/apps/site/components/markdown.tsx
@@ -1,6 +1,17 @@
+import { isValidElement, type ReactNode } from 'react'
 import Link from 'next/link'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { MarkdownCodeBlock } from '@/components/markdown-code-block'
+
+/** Recursively collect the raw text of a code node's children into a string. */
+function nodeToText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(nodeToText).join('')
+  if (isValidElement(node)) return nodeToText((node.props as { children?: ReactNode }).children)
+  return ''
+}
 
 const components: Components = {
   h1: (props) => (
@@ -65,12 +76,10 @@ const components: Components = {
     )
   },
   code: ({ children, className, ...rest }) => {
-    const isBlock = typeof className === 'string' && className.startsWith('language-')
-    if (isBlock) {
+    const match = typeof className === 'string' ? className.match(/language-(\w+)/) : null
+    if (match) {
       return (
-        <code className="block font-mono text-ds-sm leading-relaxed text-surface-fg whitespace-pre" {...rest}>
-          {children}
-        </code>
+        <MarkdownCodeBlock code={nodeToText(children).replace(/\n$/, '')} language={match[1]} />
       )
     }
     return (
@@ -82,11 +91,9 @@ const components: Components = {
       </code>
     )
   },
-  pre: ({ children }) => (
-    <pre className="my-ds-04 px-ds-04 py-ds-04 rounded-control border border-surface-border bg-surface-overlay overflow-x-auto">
-      {children}
-    </pre>
-  ),
+  // Fenced blocks render as a self-contained MarkdownCodeBlock (its own <div><pre>),
+  // so the wrapping <pre> just passes children through — avoids invalid <pre><div>.
+  pre: ({ children }) => <>{children}</>,
   table: (props) => (
     <div className="my-ds-05 overflow-x-auto rounded-control border border-surface-border">
       <table className="w-full text-ds-sm" {...props} />

--- a/apps/site/components/markdown.tsx
+++ b/apps/site/components/markdown.tsx
@@ -1,6 +1,17 @@
+import { Children, isValidElement, type ReactNode } from 'react'
 import Link from 'next/link'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { MarkdownCodeBlock } from '@/components/markdown-code-block'
+
+/** Recursively collect the raw text of a code node's children into a string. */
+function nodeToText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(nodeToText).join('')
+  if (isValidElement(node)) return nodeToText((node.props as { children?: ReactNode }).children)
+  return ''
+}
 
 const components: Components = {
   h1: (props) => (
@@ -65,12 +76,10 @@ const components: Components = {
     )
   },
   code: ({ children, className, ...rest }) => {
-    const isBlock = typeof className === 'string' && className.startsWith('language-')
-    if (isBlock) {
+    const match = typeof className === 'string' ? className.match(/language-(\w+)/) : null
+    if (match) {
       return (
-        <code className="block font-mono text-ds-sm leading-relaxed text-surface-fg whitespace-pre" {...rest}>
-          {children}
-        </code>
+        <MarkdownCodeBlock code={nodeToText(children).replace(/\n$/, '')} language={match[1]} />
       )
     }
     return (
@@ -82,11 +91,9 @@ const components: Components = {
       </code>
     )
   },
-  pre: ({ children }) => (
-    <pre className="my-ds-04 px-ds-04 py-ds-04 rounded-control border border-surface-border bg-surface-overlay overflow-x-auto">
-      {children}
-    </pre>
-  ),
+  // Fenced blocks render as a self-contained MarkdownCodeBlock (its own <div><pre>),
+  // so the wrapping <pre> just passes children through — avoids invalid <pre><div>.
+  pre: ({ children }) => <>{children}</>,
   table: (props) => (
     <div className="my-ds-05 overflow-x-auto rounded-control border border-surface-border">
       <table className="w-full text-ds-sm" {...props} />

--- a/apps/site/components/markdown.tsx
+++ b/apps/site/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, type ReactNode } from 'react'
+import { isValidElement, type ReactNode } from 'react'
 import Link from 'next/link'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'

--- a/apps/site/components/themer/ThemingHub.tsx
+++ b/apps/site/components/themer/ThemingHub.tsx
@@ -19,6 +19,7 @@ import { InstallTabs } from '../install-tabs'
 import {
   type ArchetypeName,
   ARCHETYPE_TITLES,
+  darkSurface,
   mergeArchetype,
   suggestArchetypeByHue,
 } from '@/lib/archetype-presets'
@@ -76,6 +77,28 @@ function capitalize(s: string): string {
 }
 
 /**
+ * Track the site's `.dark` class on <html> so the live preview picks the
+ * matching surface + accent ramp. The ThemeToggle flips this class at runtime,
+ * so we observe it rather than reading once. Lazy-init reads the class directly
+ * (this component only renders client-side — it sits behind the page's
+ * useSearchParams Suspense boundary), avoiding a light-card flash in dark mode.
+ */
+function useIsDark(): boolean {
+  const [isDark, setIsDark] = React.useState(
+    () => typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+  )
+  React.useEffect(() => {
+    const el = document.documentElement
+    const update = () => setIsDark(el.classList.contains('dark'))
+    update()
+    const observer = new MutationObserver(update)
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
+}
+
+/**
  * Crude hex → OKLCH-hue approximation. Good enough to pick a hue band
  * (which is all we need to suggest an archetype).
  */
@@ -130,24 +153,32 @@ export function ThemingHub() {
   const hue = state.hue ?? 340
   const chroma = state.chroma ?? 0.19
 
+  const isDark = useIsDark()
   const ramp = React.useMemo(() => generateRamp(hue, chroma), [hue, chroma])
   const role = React.useMemo(() => mergeArchetype(archetype), [archetype])
+  // In dark mode the archetype presets' light-only surfaces (near-white bg,
+  // light border, soft shadow) would render a white card — swap for derived
+  // dark counterparts so the preview matches the page theme.
+  const surface = React.useMemo(() => (isDark ? { ...role, ...darkSurface(role) } : role), [role, isDark])
   const archetypeAccent = ARCHETYPE_ACCENT[archetype]
   const archetypeAccentColor = `oklch(0.5 ${archetypeAccent.chroma} ${archetypeAccent.hue})`
 
   const liveSampleStyle = React.useMemo(() => {
     const style: Record<string, string> = {}
-    ramp.light.forEach((s) => {
+    // Inject the ramp for the CURRENT theme — the light ramp on a dark surface
+    // washes accent-tinted elements (Beta badge, brand notice) out to near-white.
+    const activeRamp = isDark ? ramp.dark : ramp.light
+    activeRamp.forEach((s) => {
       style[`--color-accent-${s.step}`] = s.value
     })
-    style['--color-accent-fg'] = deriveAccentFg(ramp.light[8].value)
+    style['--color-accent-fg'] = deriveAccentFg(activeRamp[8].value)
     if (state.customRadius != null) {
       style['--radius-control'] = `${state.customRadius}px`
       style['--radius-surface'] = `${Math.round(state.customRadius * 1.6)}px`
       style['--radius-control-inner'] = `${Math.max(state.customRadius - 2, 0)}px`
     }
     return style as React.CSSProperties
-  }, [ramp, state.customRadius])
+  }, [ramp, state.customRadius, isDark])
   const css = React.useMemo(() => generateThemerCss(state), [state])
 
   const applyHex = (value: string) => {
@@ -385,10 +416,10 @@ export function ThemingHub() {
             <div
               className="flex flex-col gap-ds-04"
               style={{
-                background: role.bg,
-                border: `${role.bw}px solid ${role.bc}`,
+                background: surface.bg,
+                border: `${role.bw}px solid ${surface.bc}`,
                 borderRadius: `${role.rs}px`,
-                boxShadow: role.shad,
+                boxShadow: surface.shad,
                 padding: `${role.cp}px`,
               }}
             >
@@ -425,7 +456,7 @@ export function ThemingHub() {
                   className="text-surface-fg placeholder:text-surface-fg-subtle bg-surface-overlay"
                   style={{
                     borderRadius: `${role.rc}px`,
-                    border: `${role.bw}px solid ${role.bc}`,
+                    border: `${role.bw}px solid ${surface.bc}`,
                     paddingInline: `${role.px}px`,
                     paddingBlock: `${role.py}px`,
                   }}

--- a/apps/site/components/themer/ThemingHub.tsx
+++ b/apps/site/components/themer/ThemingHub.tsx
@@ -18,6 +18,7 @@ import { InstallTabs } from '../install-tabs'
 import {
   type ArchetypeName,
   ARCHETYPE_TITLES,
+  darkSurface,
   mergeArchetype,
   suggestArchetypeByHue,
 } from '@/lib/archetype-presets'
@@ -75,6 +76,28 @@ function capitalize(s: string): string {
 }
 
 /**
+ * Track the site's `.dark` class on <html> so the live preview picks the
+ * matching surface + accent ramp. The ThemeToggle flips this class at runtime,
+ * so we observe it rather than reading once. Lazy-init reads the class directly
+ * (this component only renders client-side — it sits behind the page's
+ * useSearchParams Suspense boundary), avoiding a light-card flash in dark mode.
+ */
+function useIsDark(): boolean {
+  const [isDark, setIsDark] = React.useState(
+    () => typeof document !== 'undefined' && document.documentElement.classList.contains('dark'),
+  )
+  React.useEffect(() => {
+    const el = document.documentElement
+    const update = () => setIsDark(el.classList.contains('dark'))
+    update()
+    const observer = new MutationObserver(update)
+    observer.observe(el, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+  return isDark
+}
+
+/**
  * Crude hex → OKLCH-hue approximation. Good enough to pick a hue band
  * (which is all we need to suggest an archetype).
  */
@@ -129,24 +152,32 @@ export function ThemingHub() {
   const hue = state.hue ?? 340
   const chroma = state.chroma ?? 0.19
 
+  const isDark = useIsDark()
   const ramp = React.useMemo(() => generateRamp(hue, chroma), [hue, chroma])
   const role = React.useMemo(() => mergeArchetype(archetype), [archetype])
+  // In dark mode the archetype presets' light-only surfaces (near-white bg,
+  // light border, soft shadow) would render a white card — swap for derived
+  // dark counterparts so the preview matches the page theme.
+  const surface = React.useMemo(() => (isDark ? { ...role, ...darkSurface(role) } : role), [role, isDark])
   const archetypeAccent = ARCHETYPE_ACCENT[archetype]
   const archetypeAccentColor = `oklch(0.5 ${archetypeAccent.chroma} ${archetypeAccent.hue})`
 
   const liveSampleStyle = React.useMemo(() => {
     const style: Record<string, string> = {}
-    ramp.light.forEach((s) => {
+    // Inject the ramp for the CURRENT theme — the light ramp on a dark surface
+    // washes accent-tinted elements (Beta badge, brand notice) out to near-white.
+    const activeRamp = isDark ? ramp.dark : ramp.light
+    activeRamp.forEach((s) => {
       style[`--color-accent-${s.step}`] = s.value
     })
-    style['--color-accent-fg'] = deriveAccentFg(ramp.light[8].value)
+    style['--color-accent-fg'] = deriveAccentFg(activeRamp[8].value)
     if (state.customRadius != null) {
       style['--radius-control'] = `${state.customRadius}px`
       style['--radius-surface'] = `${Math.round(state.customRadius * 1.6)}px`
       style['--radius-control-inner'] = `${Math.max(state.customRadius - 2, 0)}px`
     }
     return style as React.CSSProperties
-  }, [ramp, state.customRadius])
+  }, [ramp, state.customRadius, isDark])
   const css = React.useMemo(() => generateThemerCss(state), [state])
 
   const applyHex = (value: string) => {
@@ -383,10 +414,10 @@ export function ThemingHub() {
             <div
               className="flex flex-col gap-ds-04"
               style={{
-                background: role.bg,
-                border: `${role.bw}px solid ${role.bc}`,
+                background: surface.bg,
+                border: `${role.bw}px solid ${surface.bc}`,
                 borderRadius: `${role.rs}px`,
-                boxShadow: role.shad,
+                boxShadow: surface.shad,
                 padding: `${role.cp}px`,
               }}
             >
@@ -422,7 +453,7 @@ export function ThemingHub() {
                   className="text-surface-fg placeholder:text-surface-fg-subtle bg-surface-overlay"
                   style={{
                     borderRadius: `${role.rc}px`,
-                    border: `${role.bw}px solid ${role.bc}`,
+                    border: `${role.bw}px solid ${surface.bc}`,
                     paddingInline: `${role.px}px`,
                     paddingBlock: `${role.py}px`,
                   }}

--- a/apps/site/lib/archetype-presets.ts
+++ b/apps/site/lib/archetype-presets.ts
@@ -134,6 +134,41 @@ export function mergeArchetype(
   }
 }
 
+/** Parse the leading `oklch(L C H …)` triple from a colour string. */
+function parseOklch(s: string): { l: number; c: number; h: number } | null {
+  const m = s.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)/i)
+  if (!m) return null
+  return { l: Number(m[1]), c: Number(m[2]), h: Number(m[3]) }
+}
+
+/**
+ * Dark-mode counterparts for an archetype's surface values (bg/border/shadow).
+ *
+ * The `ARCHETYPES` presets above are light-mode only — near-white backgrounds
+ * with light hairline borders and soft black shadows. Rendering those verbatim
+ * on a dark page produces a white card (the /theming preview bug fixed here).
+ *
+ * We derive dark surfaces by flipping OKLCH lightness while preserving the
+ * archetype's hue/chroma tint (so Devalok's card still reads warm, Linear's
+ * still reads neutral), and swap the shadow: flat archetypes keep a subtle
+ * light inset edge, elevated ones get a darker drop shadow that actually reads
+ * against a dark background. Light-mode values are untouched.
+ */
+export function darkSurface(
+  v: ArchetypeRoleValues,
+): Pick<ArchetypeRoleValues, 'bg' | 'bc' | 'shad'> {
+  const bg = parseOklch(v.bg)
+  const bc = parseOklch(v.bc)
+  const isFlat = v.shad.includes('inset')
+  return {
+    bg: bg ? `oklch(0.185 ${Math.min(bg.c + 0.004, 0.03)} ${bg.h})` : 'oklch(0.185 0.005 280)',
+    bc: bc ? `oklch(0.32 ${Math.min(bc.c, 0.03)} ${bc.h})` : 'oklch(0.32 0.006 280)',
+    shad: isFlat
+      ? `inset 0 0 0 ${v.bw}px oklch(1 0 0 / 0.05)`
+      : '0 8px 24px oklch(0 0 0 / 0.45), 0 1px 2px oklch(0 0 0 / 0.3)',
+  }
+}
+
 /** Archetype defaults — used to suppress "override" labelling when consumer didn't change anything. */
 export const ARCHETYPE_DEFAULTS: Record<ArchetypeName, {
   density: DensityName


### PR DESCRIPTION
Integrates rudraksharma016's #193 onto current main (auto-merged cleanly): dark-mode theming live-preview (useIsDark + darkSurface + active dark ramp), MarkdownCodeBlock with surface-raised + hover copy, fixed markdown code/pre nesting. Fixed the one deprecated bg-surface-2 token. Supersedes #193. next build green.