### PR TITLE
docs: refresh OSS governance for public-repo accuracy

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding options for Shilp Sutra — the Devalok Design System.
+# Shows a "Sponsor" button on the GitHub repo.
+custom: ["https://razorpay.me/@devalok"]

--- a/.github/ISSUE_TEMPLATE/ai-agent-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ai-agent-feedback.yml
@@ -22,7 +22,7 @@ body:
     id: package-version
     attributes:
       label: shilp-sutra version
-      placeholder: "0.38.0"
+      placeholder: "0.52.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: Package version
       description: Output of `pnpm view @devalok/shilp-sutra version` OR the version pinned in your lockfile.
-      placeholder: "0.38.0"
+      placeholder: "0.52.0"
     validations:
       required: true
 
@@ -37,7 +37,7 @@ body:
     id: framework-version
     attributes:
       label: Framework version
-      placeholder: "Next 15.2.0 / Vite 5.4.0 / Astro 5.0.0"
+      placeholder: "Next 15.x / Vite 8.x / Astro 5.x"
     validations:
       required: true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ If a change touches public-API surface, it's a real semver event. Err toward the
 
 ## Beta SLA
 
-> Active for the `0.40.0` public beta window. See [docs/plans/2026-05-24-beta-release-plan.md](./docs/plans/2026-05-24-beta-release-plan.md) for the full beta plan.
+> Active for the pre-1.0 public beta. See [docs/plans/2026-05-24-beta-release-plan.md](./docs/plans/2026-05-24-beta-release-plan.md) for the full beta plan.
 
 The beta SLA scopes maintainer commitment honestly — bot ack is automated, human commitment is to **triage**, not fix.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 # Contributors
 
-shilp-sutra is built by the team at [Devalok Design & Strategy Studios](https://devalok.com).
+shilp-sutra is built by the team at [Devalok Design & Strategy Studios](https://devalok.in).
 
 ## Core Team
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,15 @@
 
 ## Supported Versions
 
-We patch security issues on the latest minor release line only. Older minors do not receive backported fixes; upgrade to a supported version.
+While Shilp Sutra is pre-1.0, we patch security issues on the **latest published minor release line only**. Older minors do not receive backported fixes; upgrade to a supported version. Because we release frequently, we describe support by position rather than pinning version numbers (which go stale) — check the [npm version badge](https://www.npmjs.com/package/@devalok/shilp-sutra) for the current line.
 
-| Version  | Status                  |
-|----------|-------------------------|
-| `0.38.x` | ✅ Active               |
-| `0.37.x` | ✅ Critical fixes only  |
-| `< 0.37` | ❌ Unsupported          |
+| Release line                        | Status                                        |
+|-------------------------------------|-----------------------------------------------|
+| Latest published minor (`0.x`)      | ✅ Active — security patches land here         |
+| Immediately previous minor          | ⚠️ Critical fixes only, best-effort           |
+| Anything older                      | ❌ Unsupported — upgrade to the latest minor   |
+
+Once we reach `1.0.0`, this policy will be revised to cover the latest major line and the previous major for a defined window.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Open-source readiness audit of the (already-public) repo. Scaffolding was strong — LICENSE, CoC, CONTRIBUTING, SECURITY, CODEOWNERS, issue/PR templates, provenance, no secrets in tree or full git history. This closes the last accuracy/polish gaps.

## Changes

- **SECURITY.md** — stale pinned supported-versions table (`0.38.x` / `0.37.x`, while latest is `0.52.0`) → version-independent policy (latest minor / previous minor / older). Won't rot between releases. Added pre-1.0 note + post-1.0 revision clause.
- **CONTRIBUTORS.md** — studio link `devalok.com` → `devalok.in` (matches contact email + published package homepage).
- **CONTRIBUTING.md** — Beta SLA de-pinned from `0.40.0` window → "pre-1.0 public beta".
- **ISSUE_TEMPLATE/bug-report.yml, ai-agent-feedback.yml** — version placeholder `0.38.0` → `0.52.0`; framework placeholder → current stack (Next 15.x / Vite 8.x / Astro 5.x).
- **.github/FUNDING.yml** (new) — Sponsor button → razorpay.me/@devalok.

## Scope

Docs/meta only. No source, no published-package, no release trigger. Base is 1 commit behind origin only for unrelated site-preview files (#202) — zero overlap with this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)