### PR TITLE
fix(schedule-view): use bg-surface-raised, not deprecated bg-surface-2

### DIFF
--- a/packages/core/src/composed/schedule-view.tsx
+++ b/packages/core/src/composed/schedule-view.tsx
@@ -258,7 +258,7 @@ function DayColumn({
         <div
           className={cn(
             'border-b border-surface-border-strong py-ds-02 text-center text-body-sm font-semibold',
-            todayInView ? 'bg-accent-2 text-accent-11' : 'bg-surface-2 text-surface-fg',
+            todayInView ? 'bg-accent-2 text-accent-11' : 'bg-surface-raised text-surface-fg',
           )}
         >
           {format(date, 'EEE d')}
@@ -454,7 +454,7 @@ const ScheduleView = React.forwardRef<HTMLDivElement, ScheduleViewProps>(
               ? `Schedule for ${format(date, 'EEEE, MMMM d, yyyy')}`
               : `Week schedule starting ${format(days[0], 'MMMM d, yyyy')}`
           }
-          className="flex overflow-hidden rounded-surface border border-surface-border-strong bg-surface-2"
+          className="flex overflow-hidden rounded-surface border border-surface-border-strong bg-surface-raised"
           style={{ height: typeof height === 'number' ? `${height}px` : height }}
         >
           <TimeColumn startHour={startHour} endHour={endHour} />


### PR DESCRIPTION
## What

#187's ScheduleView rebuild set the day-column header and the grid container to `bg-surface-2` — a **deprecated surface token**. The pre-publish-audit *Source Hygiene* gate (`No deprecated surface tokens in components`) rejects it.

This gate is **release-only, not in PR CI**, so #187 went green on its PR and only failed post-merge in the Integration workflow — turning `main` red at 0.53.0 before publish. Same class of trap as the radius-role gate on 0.52.0.

## Fix

`bg-surface-2` → `bg-surface-raised` at `schedule-view.tsx:261` (header) and `:457` (grid container). Matches the file's own `neutral` event fill (line 78) and hover state (line 280).

In-place fix into the already-staged, unpublished **0.53.0** — no changeset (mirrors the 0.52.0 #180 hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xec8boLySyygZpg1jXD69X