### PR TITLE
feat(site): 39 more component previews (69 total) + index badges

### DIFF
--- a/apps/site/app/components/page.tsx
+++ b/apps/site/app/components/page.tsx
@@ -7,6 +7,7 @@ import { SiteFooter } from '@/components/site-footer'
 import { SiteHeader } from '@/components/site-header'
 import { FUNCTION_CATEGORIES } from '@/lib/component-categories'
 import { getRegistry, groupByFunction } from '@/lib/component-registry'
+import { getPreviewSlugs } from '@/lib/preview-registry'
 import { SHILP_SUTRA_MINOR } from '@/lib/version'
 
 export const metadata: Metadata = {
@@ -54,7 +55,7 @@ export default async function ComponentsPage() {
                     {items.length} components · browse by category or search by name.
                   </h2>
                 </header>
-                <ComponentGrid items={items} />
+                <ComponentGrid items={items} previewSlugs={getPreviewSlugs()} />
               </div>
             </div>
           </div>

--- a/apps/site/components/aurora-playground.tsx
+++ b/apps/site/components/aurora-playground.tsx
@@ -132,7 +132,7 @@ export function AuroraPlayground() {
                 type="button"
                 onClick={() => applyPreset(id)}
                 className={
-                  'group text-left rounded-control border bg-surface-2 overflow-hidden transition-colors focus-visible:focus-ring ' +
+                  'group text-left rounded-control border bg-surface-raised overflow-hidden transition-colors focus-visible:focus-ring ' +
                   (isActive
                     ? 'border-accent-9 ring-1 ring-accent-9/30'
                     : 'border-surface-border hover:border-surface-border-strong')
@@ -229,7 +229,7 @@ export function AuroraPlayground() {
             </div>
           </div>
 
-          <details className="rounded-control border border-surface-border bg-surface-2 px-ds-04 py-ds-03 text-ds-sm">
+          <details className="rounded-control border border-surface-border bg-surface-raised px-ds-04 py-ds-03 text-ds-sm">
             <summary className="cursor-pointer text-surface-fg-muted">Show the JSX</summary>
             <pre className="mt-ds-03 overflow-x-auto rounded-control-inner bg-surface-base p-ds-04 text-ds-xs font-mono text-surface-fg leading-relaxed">
               <code>{codeSnippet}</code>
@@ -305,7 +305,7 @@ export function AuroraPlayground() {
             />
           </ControlRow>
 
-          <div className="flex items-center justify-between rounded-control border border-surface-border bg-surface-2 px-ds-04 py-ds-03">
+          <div className="flex items-center justify-between rounded-control border border-surface-border bg-surface-raised px-ds-04 py-ds-03">
             <Text variant="body-sm" className="text-surface-fg">
               Breathing
             </Text>

--- a/apps/site/components/component-grid.tsx
+++ b/apps/site/components/component-grid.tsx
@@ -15,8 +15,15 @@ const LAYER_LABELS: Record<Layer, string> = {
 }
 
 
-export function ComponentGrid({ items }: { items: ComponentMeta[] }) {
+export function ComponentGrid({
+  items,
+  previewSlugs = [],
+}: {
+  items: ComponentMeta[]
+  previewSlugs?: string[]
+}) {
   const [query, setQuery] = useState('')
+  const previewSet = useMemo(() => new Set(previewSlugs), [previewSlugs])
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -92,6 +99,11 @@ export function ComponentGrid({ items }: { items: ComponentMeta[] }) {
                         <span className="inline-flex items-center px-ds-02 py-[1px] rounded-control-inner bg-surface-overlay text-ds-xs text-surface-fg-subtle font-mono">
                           {LAYER_LABELS[item.layer]}
                         </span>
+                        {previewSet.has(item.slug) && (
+                          <span className="inline-flex items-center px-ds-02 py-[1px] rounded-control-inner bg-accent-3 text-accent-11 text-ds-xs font-mono">
+                            live preview
+                          </span>
+                        )}
                         {item.serverSafe && (
                           <span className="inline-flex items-center px-ds-02 py-[1px] rounded-control-inner bg-success-3 text-success-11 text-ds-xs font-mono">
                             rsc-safe

--- a/apps/site/content/components/alert-dialog.preview.tsx
+++ b/apps/site/content/components/alert-dialog.preview.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@devalok/shilp-sutra/ui/alert-dialog'
+
+export function AlertDialogHero() {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="soft" color="error">Delete account</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. It will permanently delete your account and remove your
+            data from our servers.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Yes, delete account</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export function AlertDialogVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="confirm before leaving">
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="outline">Discard changes</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+              <AlertDialogDescription>
+                You have edits that have not been saved yet. Leaving now will lose them.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Keep editing</AlertDialogCancel>
+              <AlertDialogAction>Discard</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/autocomplete.preview.tsx
+++ b/apps/site/content/components/autocomplete.preview.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import * as React from 'react'
+import { Autocomplete, type AutocompleteOption } from '@devalok/shilp-sutra/ui/autocomplete'
+
+const CITIES: AutocompleteOption[] = [
+  { value: 'mumbai', label: 'Mumbai' },
+  { value: 'delhi', label: 'Delhi' },
+  { value: 'bengaluru', label: 'Bengaluru' },
+  { value: 'chennai', label: 'Chennai' },
+  { value: 'kolkata', label: 'Kolkata' },
+  { value: 'hyderabad', label: 'Hyderabad' },
+]
+
+export function AutocompleteHero() {
+  const [city, setCity] = React.useState<AutocompleteOption | null>(null)
+
+  return (
+    <div className="w-full max-w-xs">
+      <Autocomplete
+        options={CITIES}
+        value={city}
+        onValueChange={setCity}
+        placeholder="Search cities…"
+      />
+    </div>
+  )
+}
+
+export function AutocompleteVariants() {
+  const [picked, setPicked] = React.useState<AutocompleteOption | null>(null)
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="custom emptyText">
+        <Autocomplete
+          options={CITIES}
+          onValueChange={setPicked}
+          emptyText="No matching cities"
+          placeholder="Type to filter…"
+        />
+      </Block>
+
+      <Block title="disabled">
+        <Autocomplete
+          options={CITIES}
+          value={{ value: 'delhi', label: 'Delhi' }}
+          disabled
+          placeholder="Search cities…"
+        />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/avatar-group.preview.tsx
+++ b/apps/site/content/components/avatar-group.preview.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { AvatarGroup } from '@devalok/shilp-sutra/composed/avatar-group'
+
+const TEAM = [
+  { name: 'Aisha Kapoor' },
+  { name: 'Ben Carter' },
+  { name: 'Chen Wei' },
+  { name: 'Diego Alvarez' },
+  { name: 'Elena Rossi' },
+  { name: 'Farid Hassan' },
+]
+
+export function AvatarGroupHero() {
+  return <AvatarGroup users={TEAM} max={4} />
+}
+
+export function AvatarGroupVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="size">
+        <AvatarGroup users={TEAM} max={3} size="sm" />
+        <AvatarGroup users={TEAM} max={3} size="md" />
+        <AvatarGroup users={TEAM} max={3} size="lg" />
+      </Block>
+
+      <Block title="max (overflow +N)">
+        <AvatarGroup users={TEAM} max={2} />
+        <AvatarGroup users={TEAM} max={4} />
+      </Block>
+
+      <Block title="showTooltip={false}">
+        <AvatarGroup users={TEAM} max={4} showTooltip={false} />
+      </Block>
+
+      <Block title="expandDirection=left">
+        <AvatarGroup users={TEAM} max={4} expandDirection="left" />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-05">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/badge-group.preview.tsx
+++ b/apps/site/content/components/badge-group.preview.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+import { BadgeGroup } from '@devalok/shilp-sutra/ui/badge-group'
+
+export function BadgeGroupHero() {
+  return (
+    <BadgeGroup max={3}>
+      <Badge variant="soft">Design</Badge>
+      <Badge variant="soft">Research</Badge>
+      <Badge variant="soft">Frontend</Badge>
+      <Badge variant="soft">Backend</Badge>
+      <Badge variant="soft">DevOps</Badge>
+    </BadgeGroup>
+  )
+}
+
+export function BadgeGroupVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="no max (all shown)">
+        <BadgeGroup>
+          <Badge color="accent">React</Badge>
+          <Badge color="success">TypeScript</Badge>
+          <Badge color="warning">Tailwind</Badge>
+        </BadgeGroup>
+      </Block>
+
+      <Block title="max=2 (overflow +N)">
+        <BadgeGroup max={2}>
+          <Badge variant="soft">Alpha</Badge>
+          <Badge variant="soft">Beta</Badge>
+          <Badge variant="soft">Gamma</Badge>
+          <Badge variant="soft">Delta</Badge>
+        </BadgeGroup>
+      </Block>
+
+      <Block title="gap">
+        <BadgeGroup gap="tight">
+          <Badge variant="soft">Tight</Badge>
+          <Badge variant="soft">Tight</Badge>
+        </BadgeGroup>
+        <BadgeGroup gap="loose">
+          <Badge variant="soft">Loose</Badge>
+          <Badge variant="soft">Loose</Badge>
+        </BadgeGroup>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-05">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/banner.preview.tsx
+++ b/apps/site/content/components/banner.preview.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Banner } from '@devalok/shilp-sutra/ui/banner'
+
+export function BannerHero() {
+  return (
+    <div className="w-full overflow-hidden rounded-control border border-surface-border-subtle">
+      <Banner color="info" actions={<Button variant="ghost" size="sm">View</Button>}>
+        New: assign tasks directly from the calendar view.
+      </Banner>
+    </div>
+  )
+}
+
+export function BannerVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="color">
+        <Banner color="info">Informational system announcement.</Banner>
+        <Banner color="success">Your export is ready to download.</Banner>
+        <Banner color="warning">Scheduled maintenance on Sunday 2am–4am UTC.</Banner>
+        <Banner color="error">We could not process your last payment.</Banner>
+        <Banner color="neutral">A neutral, low-emphasis notice.</Banner>
+      </Block>
+
+      <Block title="with actions">
+        <Banner color="success" actions={<Button variant="ghost" size="sm">View report</Button>}>
+          Your monthly report has been generated.
+        </Banner>
+      </Block>
+
+      <Block title="dismissable (onDismiss)">
+        <Banner color="info" onDismiss={() => {}}>
+          Dismiss me — I animate away.
+        </Banner>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col gap-ds-04 overflow-hidden rounded-control">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/button-group.preview.tsx
+++ b/apps/site/content/components/button-group.preview.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { IconBold, IconItalic, IconUnderline } from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { ButtonGroup } from '@devalok/shilp-sutra/ui/button-group'
+
+export function ButtonGroupHero() {
+  return (
+    <ButtonGroup variant="outline">
+      <Button>Day</Button>
+      <Button>Week</Button>
+      <Button>Month</Button>
+    </ButtonGroup>
+  )
+}
+
+export function ButtonGroupVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="attached (default)">
+        <ButtonGroup variant="soft">
+          <Button>Left</Button>
+          <Button>Center</Button>
+          <Button>Right</Button>
+        </ButtonGroup>
+      </Block>
+
+      <Block title="attached={false}">
+        <ButtonGroup variant="soft" attached={false}>
+          <Button>Copy</Button>
+          <Button>Paste</Button>
+          <Button>Cut</Button>
+        </ButtonGroup>
+      </Block>
+
+      <Block title="orientation=vertical">
+        <ButtonGroup variant="outline" orientation="vertical">
+          <Button startIcon={<IconBold />}>Bold</Button>
+          <Button startIcon={<IconItalic />}>Italic</Button>
+          <Button startIcon={<IconUnderline />}>Underline</Button>
+        </ButtonGroup>
+      </Block>
+
+      <Block title="color=accent">
+        <ButtonGroup variant="solid" color="accent">
+          <Button>One</Button>
+          <Button>Two</Button>
+          <Button>Three</Button>
+        </ButtonGroup>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-start gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/code.preview.tsx
+++ b/apps/site/content/components/code.preview.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Code } from '@devalok/shilp-sutra/ui/code'
+
+export function CodeHero() {
+  return (
+    <p className="text-body-md text-surface-fg">
+      Install with <Code>pnpm add @devalok/shilp-sutra</Code> to get started.
+    </p>
+  )
+}
+
+export function CodeVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title='variant="inline"'>
+        <p className="text-body-md text-surface-fg">
+          Pass <Code>loading={'{true}'}</Code> to show the spinner.
+        </p>
+      </Block>
+
+      <Block title='variant="block"'>
+        <Code variant="block">{`const greeting = "Hello, world!"
+console.log(greeting)`}</Code>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/collapsible.preview.tsx
+++ b/apps/site/content/components/collapsible.preview.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { IconChevronDown } from '@tabler/icons-react'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@devalok/shilp-sutra/ui/collapsible'
+
+export function CollapsibleHero() {
+  return (
+    <div className="w-full max-w-md">
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger className="flex w-full items-center justify-between rounded-control border border-surface-border-subtle bg-surface-raised px-ds-05 py-ds-03 text-body-md font-medium text-surface-fg">
+          Show advanced settings
+          <IconChevronDown size={16} />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="px-ds-05 py-ds-03 text-body-sm text-surface-fg-subtle">
+          These options are hidden by default to keep the form focused. Expand to
+          fine-tune caching, retries, and timeouts.
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  )
+}
+
+export function CollapsibleVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="defaultOpen">
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger className="flex w-full items-center justify-between rounded-control border border-surface-border-subtle bg-surface-raised px-ds-05 py-ds-03 text-body-md font-medium text-surface-fg">
+            Open by default
+            <IconChevronDown size={16} />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="px-ds-05 py-ds-03 text-body-sm text-surface-fg-subtle">
+            Content is visible on first render.
+          </CollapsibleContent>
+        </Collapsible>
+      </Block>
+
+      <Block title="closed initially">
+        <Collapsible>
+          <CollapsibleTrigger className="flex w-full items-center justify-between rounded-control border border-surface-border-subtle bg-surface-raised px-ds-05 py-ds-03 text-body-md font-medium text-surface-fg">
+            Click to expand
+            <IconChevronDown size={16} />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="px-ds-05 py-ds-03 text-body-sm text-surface-fg-subtle">
+            Content revealed on interaction.
+          </CollapsibleContent>
+        </Collapsible>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/color-input.preview.tsx
+++ b/apps/site/content/components/color-input.preview.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import * as React from 'react'
+import { ColorInput } from '@devalok/shilp-sutra/ui/color-input'
+
+export function ColorInputHero() {
+  const [color, setColor] = React.useState('#c53637')
+  return (
+    <div className="flex items-center gap-ds-04">
+      <ColorInput value={color} onChange={setColor} />
+      <span className="font-mono text-body-sm text-surface-fg-subtle">{color}</span>
+    </div>
+  )
+}
+
+export function ColorInputVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="variant=default">
+        <ControlledColorInput initial="#1479b0" />
+      </Block>
+
+      <Block title="variant=inline">
+        <ControlledColorInput initial="#308639" variant="inline" />
+      </Block>
+
+      <Block title="defaultFormat=rgb">
+        <ControlledColorInput initial="#df911a" defaultFormat="rgb" />
+      </Block>
+
+      <Block title="disabled">
+        <ColorInput value="#7d5fad" disabled />
+      </Block>
+    </div>
+  )
+}
+
+function ControlledColorInput({
+  initial,
+  variant,
+  defaultFormat,
+}: {
+  initial: string
+  variant?: 'default' | 'inline'
+  defaultFormat?: 'hex' | 'rgb' | 'hsl'
+}) {
+  const [color, setColor] = React.useState(initial)
+  return <ColorInput value={color} onChange={setColor} variant={variant} defaultFormat={defaultFormat} />
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/color-swatch.preview.tsx
+++ b/apps/site/content/components/color-swatch.preview.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { ColorSwatch } from '@devalok/shilp-sutra/ui/color-swatch'
+
+export function ColorSwatchHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-03">
+      <ColorSwatch color="#c53637" size="lg" />
+      <ColorSwatch color="#df911a" size="lg" />
+      <ColorSwatch color="#308639" size="lg" />
+      <ColorSwatch color="#1479b0" size="lg" />
+      <ColorSwatch color="#7d5fad" size="lg" />
+    </div>
+  )
+}
+
+export function ColorSwatchVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="size">
+        <ColorSwatch color="#1479b0" size="sm" />
+        <ColorSwatch color="#1479b0" size="md" />
+        <ColorSwatch color="#1479b0" size="lg" />
+      </Block>
+
+      <Block title="shape">
+        <ColorSwatch color="#308639" shape="circle" size="lg" />
+        <ColorSwatch color="#308639" shape="rounded" size="lg" />
+        <ColorSwatch color="#308639" shape="square" size="lg" />
+      </Block>
+
+      <Block title="ring (for light colors)">
+        <ColorSwatch color="#ffffff" size="lg" ring />
+        <ColorSwatch color="#f5f5f5" size="lg" ring />
+      </Block>
+
+      <Block title="checkerboard (transparency)">
+        <ColorSwatch color="rgba(197,54,55,0.5)" size="lg" checkerboard />
+        <ColorSwatch color="rgba(20,121,176,0.35)" size="lg" checkerboard />
+      </Block>
+
+      <Block title="copyable">
+        <ColorSwatch color="#c53637" size="lg" copyable />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/confirm-dialog.preview.tsx
+++ b/apps/site/content/components/confirm-dialog.preview.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import * as React from 'react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { ConfirmDialog } from '@devalok/shilp-sutra/composed/confirm-dialog'
+
+export function ConfirmDialogHero() {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Button variant="soft" color="error" onClick={() => setOpen(true)}>
+        Delete workspace
+      </Button>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Delete this workspace?"
+        description="Everyone loses access and all boards are archived. This cannot be undone."
+        confirmText="Delete workspace"
+        cancelText="Keep it"
+        color="error"
+        onConfirm={() => setOpen(false)}
+      />
+    </>
+  )
+}
+
+export function ConfirmDialogVariants() {
+  const [accentOpen, setAccentOpen] = React.useState(false)
+  const [loadingOpen, setLoadingOpen] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+
+  const runPublish = () => {
+    setLoading(true)
+    setTimeout(() => {
+      setLoading(false)
+      setLoadingOpen(false)
+    }, 1400)
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title='color="accent"'>
+        <Button variant="soft" onClick={() => setAccentOpen(true)}>Publish now</Button>
+        <ConfirmDialog
+          open={accentOpen}
+          onOpenChange={setAccentOpen}
+          title="Publish this release?"
+          description="It becomes visible to everyone in the organization immediately."
+          confirmText="Publish"
+          color="accent"
+          onConfirm={() => setAccentOpen(false)}
+        />
+      </Block>
+
+      <Block title="async loading state">
+        <Button variant="soft" onClick={() => setLoadingOpen(true)}>Deploy</Button>
+        <ConfirmDialog
+          open={loadingOpen}
+          onOpenChange={(v) => !loading && setLoadingOpen(v)}
+          title="Deploy to production?"
+          description="The confirm button spins while the request is in flight."
+          confirmText="Deploy"
+          loading={loading}
+          onConfirm={runPublish}
+        />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/content-card.preview.tsx
+++ b/apps/site/content/components/content-card.preview.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { ContentCard } from '@devalok/shilp-sutra/composed/content-card'
+
+export function ContentCardHero() {
+  return (
+    <div className="w-full max-w-md">
+      <ContentCard
+        headerTitle="Monthly usage"
+        headerActions={<Button variant="ghost" size="sm">Export</Button>}
+        footer={<span className="text-body-sm text-surface-fg-subtle">Updated 5 minutes ago</span>}
+      >
+        <p className="text-body-md text-surface-fg-subtle">
+          Your team used 3,240 of 5,000 build minutes this month.
+        </p>
+      </ContentCard>
+    </div>
+  )
+}
+
+export function ContentCardVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="variant=default">
+        <ContentCard>
+          <p className="text-body-md text-surface-fg">Default raised card surface.</p>
+        </ContentCard>
+      </Block>
+
+      <Block title="variant=outline">
+        <ContentCard variant="outline">
+          <p className="text-body-md text-surface-fg">Bordered, transparent background.</p>
+        </ContentCard>
+      </Block>
+
+      <Block title="variant=ghost">
+        <ContentCard variant="ghost">
+          <p className="text-body-md text-surface-fg">No border until hover.</p>
+        </ContentCard>
+      </Block>
+
+      <Block title="with header + footer">
+        <ContentCard
+          headerTitle="Billing"
+          footer={<Button size="sm">Manage plan</Button>}
+        >
+          <p className="text-body-md text-surface-fg-subtle">Pro plan · renews July 30.</p>
+        </ContentCard>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/context-menu.preview.tsx
+++ b/apps/site/content/components/context-menu.preview.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import * as React from 'react'
+import {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@devalok/shilp-sutra/ui/context-menu'
+
+export function ContextMenuHero() {
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger className="flex h-32 w-full max-w-md items-center justify-center rounded-control border border-dashed border-surface-border-strong text-body-sm text-surface-fg-muted select-none">
+        Right-click anywhere here
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <ContextMenuItem>
+          Back
+          <ContextMenuShortcut>⌘[</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem>
+          Forward
+          <ContextMenuShortcut>⌘]</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem>Reload</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem>Save as…</ContextMenuItem>
+        <ContextMenuItem className="text-error-11">Delete</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}
+
+export function ContextMenuVariants() {
+  const [bookmarks, setBookmarks] = React.useState(true)
+
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="label · checkbox · submenu">
+        <ContextMenu>
+          <ContextMenuTrigger className="flex h-24 w-full items-center justify-center rounded-control border border-dashed border-surface-border-strong text-body-sm text-surface-fg-muted select-none">
+            Right-click target
+          </ContextMenuTrigger>
+          <ContextMenuContent className="w-56">
+            <ContextMenuLabel>View</ContextMenuLabel>
+            <ContextMenuCheckboxItem
+              checked={bookmarks}
+              onCheckedChange={setBookmarks}
+            >
+              Show bookmarks bar
+            </ContextMenuCheckboxItem>
+            <ContextMenuSeparator />
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Share</ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                <ContextMenuItem>Copy link</ContextMenuItem>
+                <ContextMenuItem>Email</ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          </ContextMenuContent>
+        </ContextMenu>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/deadline-indicator.preview.tsx
+++ b/apps/site/content/components/deadline-indicator.preview.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { DeadlineIndicator } from '@devalok/shilp-sutra/composed/deadline-indicator'
+
+const HOUR = 60 * 60 * 1000
+
+export function DeadlineIndicatorHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-05">
+      <DeadlineIndicator deadline={new Date(Date.now() + 48 * HOUR)} showIcon />
+      <DeadlineIndicator deadline={new Date(Date.now() + 3 * HOUR)} showIcon />
+      <DeadlineIndicator deadline={new Date(Date.now() - 2 * HOUR)} showIcon />
+    </div>
+  )
+}
+
+export function DeadlineIndicatorVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="urgency (color reflects time left)">
+        <DeadlineIndicator deadline={new Date(Date.now() + 72 * HOUR)} showIcon />
+        <DeadlineIndicator deadline={new Date(Date.now() + 12 * HOUR)} showIcon />
+        <DeadlineIndicator deadline={new Date(Date.now() + 2 * HOUR)} showIcon />
+        <DeadlineIndicator deadline={new Date(Date.now() - HOUR)} showIcon />
+      </Block>
+
+      <Block title="format=absolute">
+        <DeadlineIndicator deadline={new Date(Date.now() + 30 * HOUR)} format="absolute" showIcon />
+      </Block>
+
+      <Block title="no icon">
+        <DeadlineIndicator deadline={new Date(Date.now() + 5 * HOUR)} />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-04">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/dialog.preview.tsx
+++ b/apps/site/content/components/dialog.preview.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@devalok/shilp-sutra/ui/dialog'
+
+export function DialogHero() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button>Edit profile</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit profile</DialogTitle>
+          <DialogDescription>
+            Make changes to your account here. Click save when you are done.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="soft">Cancel</Button>
+          </DialogClose>
+          <Button>Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function DialogVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="destructive action">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="soft" color="error">Delete project</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Are you absolutely sure?</DialogTitle>
+              <DialogDescription>
+                This permanently deletes the project and all of its data. This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="soft">Cancel</Button>
+              </DialogClose>
+              <Button color="error">Delete</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Block>
+
+      <Block title="responsive={false} (always centered)">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline">Open centered</Button>
+          </DialogTrigger>
+          <DialogContent responsive={false}>
+            <DialogHeader>
+              <DialogTitle>Centered on every viewport</DialogTitle>
+              <DialogDescription>
+                With responsive disabled the panel stays a centered modal instead of a full-screen takeover on mobile.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="soft">Got it</Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/dropdown-menu.preview.tsx
+++ b/apps/site/content/components/dropdown-menu.preview.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import * as React from 'react'
+import {
+  IconCreditCard,
+  IconDotsVertical,
+  IconLogout,
+  IconSettings,
+  IconUser,
+  IconUsers,
+} from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@devalok/shilp-sutra/ui/dropdown-menu'
+
+export function DropdownMenuHero() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">My account</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuLabel>My account</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <IconUser />
+          Profile
+          <DropdownMenuShortcut>⌘P</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <IconCreditCard />
+          Billing
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <IconSettings />
+          Settings
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-error-11">
+          <IconLogout />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export function DropdownMenuVariants() {
+  const [showActivity, setShowActivity] = React.useState(true)
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="icon trigger + submenu">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Open menu">
+              <IconDotsVertical />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem>Rename</DropdownMenuItem>
+            <DropdownMenuItem>Duplicate</DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <DropdownMenuItem>
+                  <IconUsers />
+                  Shared
+                </DropdownMenuItem>
+                <DropdownMenuItem>Archive</DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Block>
+
+      <Block title="checkbox item">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="soft" size="sm">View options</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-48">
+            <DropdownMenuCheckboxItem
+              checked={showActivity}
+              onCheckedChange={setShowActivity}
+            >
+              Show activity bar
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/empty-state.preview.tsx
+++ b/apps/site/content/components/empty-state.preview.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { IconFolderOff, IconInbox, IconSearch } from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { EmptyState } from '@devalok/shilp-sutra/composed/empty-state'
+
+export function EmptyStateHero() {
+  return (
+    <div className="w-full max-w-md">
+      <EmptyState
+        icon={<IconInbox />}
+        title="No messages yet"
+        description="When teammates send you a message, it will show up here."
+        action={<Button>Start a conversation</Button>}
+      />
+    </div>
+  )
+}
+
+export function EmptyStateVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="with action">
+        <EmptyState
+          icon={<IconFolderOff />}
+          title="No projects"
+          description="Create your first project to get going."
+          action={<Button variant="soft">New project</Button>}
+        />
+      </Block>
+
+      <Block title="no description">
+        <EmptyState icon={<IconSearch />} title="No results found" />
+      </Block>
+
+      <Block title="compact">
+        <EmptyState
+          compact
+          icon={<IconInbox />}
+          title="Inbox zero"
+          description="You are all caught up."
+        />
+      </Block>
+
+      <Block title="default chakra icon">
+        <EmptyState title="Nothing here yet" description="Falls back to the Devalok glyph." />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/file-upload.preview.tsx
+++ b/apps/site/content/components/file-upload.preview.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import * as React from 'react'
+import { FileUpload } from '@devalok/shilp-sutra/ui/file-upload'
+
+export function FileUploadHero() {
+  const [names, setNames] = React.useState<string[]>([])
+  return (
+    <div className="w-full max-w-md">
+      <FileUpload
+        onFiles={(files) => setNames(files.map((f) => f.name))}
+        label="Drop files here or click to browse"
+        sublabel="PNG, JPG, PDF up to 10MB"
+      />
+      {names.length > 0 && (
+        <p className="mt-ds-03 text-body-sm text-surface-fg-subtle">
+          Selected: {names.join(', ')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function FileUploadVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="drop zone">
+        <FileUpload onFiles={() => {}} />
+      </Block>
+
+      <Block title="compact (inline button)">
+        <FileUpload compact onFiles={() => {}} label="Attach files" />
+      </Block>
+
+      <Block title="uploading with progress">
+        <FileUpload onFiles={() => {}} uploading progress={64} />
+      </Block>
+
+      <Block title="error">
+        <FileUpload onFiles={() => {}} error="File type is not accepted" />
+      </Block>
+
+      <Block title="disabled">
+        <FileUpload onFiles={() => {}} disabled />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/hover-card.preview.tsx
+++ b/apps/site/content/components/hover-card.preview.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Avatar, AvatarFallback } from '@devalok/shilp-sutra/ui/avatar'
+import { Link } from '@devalok/shilp-sutra/ui/link'
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@devalok/shilp-sutra/ui/hover-card'
+
+export function HoverCardHero() {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <Link href="#">@aisha</Link>
+      </HoverCardTrigger>
+      <HoverCardContent>
+        <div className="flex items-center gap-ds-03">
+          <Avatar>
+            <AvatarFallback colorSeed="Aisha Kapoor">AK</AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col">
+            <span className="text-body-md font-semibold text-surface-fg">Aisha Kapoor</span>
+            <span className="text-body-sm text-surface-fg-subtle">Design Lead · joined 2024</span>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+export function HoverCardVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="align + side">
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <Link href="#">Hover for details</Link>
+          </HoverCardTrigger>
+          <HoverCardContent align="start" side="bottom">
+            <p className="text-body-sm text-surface-fg-subtle">
+              HoverCard is pointer-only — use Popover for keyboard-essential content.
+            </p>
+          </HoverCardContent>
+        </HoverCard>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/icon-button.preview.tsx
+++ b/apps/site/content/components/icon-button.preview.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { IconHeart, IconPlus, IconTrash, IconX } from '@tabler/icons-react'
+import { IconButton } from '@devalok/shilp-sutra/ui/icon-button'
+
+export function IconButtonHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-03">
+      <IconButton icon={<IconPlus />} aria-label="Create new" />
+      <IconButton icon={<IconHeart />} variant="soft" aria-label="Favourite" />
+      <IconButton icon={<IconX />} variant="ghost" shape="circle" aria-label="Close" />
+      <IconButton icon={<IconTrash />} variant="soft" color="error" aria-label="Delete" />
+    </div>
+  )
+}
+
+export function IconButtonVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="variant">
+        <IconButton icon={<IconPlus />} variant="solid" aria-label="Solid" />
+        <IconButton icon={<IconPlus />} variant="soft" aria-label="Soft" />
+        <IconButton icon={<IconPlus />} variant="outline" aria-label="Outline" />
+        <IconButton icon={<IconPlus />} variant="ghost" aria-label="Ghost" />
+      </Block>
+
+      <Block title="shape">
+        <IconButton icon={<IconHeart />} shape="square" aria-label="Square" />
+        <IconButton icon={<IconHeart />} shape="circle" aria-label="Circle" />
+      </Block>
+
+      <Block title="size">
+        <IconButton icon={<IconPlus />} size="sm" aria-label="Small" />
+        <IconButton icon={<IconPlus />} size="md" aria-label="Medium" />
+        <IconButton icon={<IconPlus />} size="lg" aria-label="Large" />
+      </Block>
+
+      <Block title="disabled / loading">
+        <IconButton icon={<IconPlus />} disabled aria-label="Disabled" />
+        <IconButton icon={<IconPlus />} loading aria-label="Loading" />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/input-otp.preview.tsx
+++ b/apps/site/content/components/input-otp.preview.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import * as React from 'react'
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSeparator,
+  InputOTPSlot,
+} from '@devalok/shilp-sutra/ui/input-otp'
+
+export function InputOtpHero() {
+  const [value, setValue] = React.useState('')
+  return (
+    <div className="flex flex-col gap-ds-03">
+      <InputOTP maxLength={6} value={value} onChange={setValue}>
+        <InputOTPGroup>
+          <InputOTPSlot index={0} />
+          <InputOTPSlot index={1} />
+          <InputOTPSlot index={2} />
+        </InputOTPGroup>
+        <InputOTPSeparator />
+        <InputOTPGroup>
+          <InputOTPSlot index={3} />
+          <InputOTPSlot index={4} />
+          <InputOTPSlot index={5} />
+        </InputOTPGroup>
+      </InputOTP>
+      <span className="text-body-sm text-surface-fg-subtle">
+        Entered: {value || '—'}
+      </span>
+    </div>
+  )
+}
+
+export function InputOtpVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="4 slots, no separator">
+        <InputOTP maxLength={4}>
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+            <InputOTPSlot index={3} />
+          </InputOTPGroup>
+        </InputOTP>
+      </Block>
+
+      <Block title="6 slots with separator">
+        <InputOTP maxLength={6}>
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+          </InputOTPGroup>
+          <InputOTPSeparator />
+          <InputOTPGroup>
+            <InputOTPSlot index={3} />
+            <InputOTPSlot index={4} />
+            <InputOTPSlot index={5} />
+          </InputOTPGroup>
+        </InputOTP>
+      </Block>
+
+      <Block title="error state">
+        <InputOTP maxLength={4} state="error">
+          <InputOTPGroup>
+            <InputOTPSlot index={0} />
+            <InputOTPSlot index={1} />
+            <InputOTPSlot index={2} />
+            <InputOTPSlot index={3} />
+          </InputOTPGroup>
+        </InputOTP>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/link.preview.tsx
+++ b/apps/site/content/components/link.preview.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { Link } from '@devalok/shilp-sutra/ui/link'
+
+export function LinkHero() {
+  return (
+    <p className="text-body-md text-surface-fg">
+      Read the <Link href="#">getting started guide</Link> to set up your first project.
+    </p>
+  )
+}
+
+export function LinkVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="inline (default)">
+        <p className="text-body-md text-surface-fg">
+          This paragraph has an <Link href="#">inline link</Link> that flows with the text.
+        </p>
+      </Block>
+
+      <Block title="inline={false} (block)">
+        <Link href="#" inline={false}>Standalone block link</Link>
+        <Link href="#" inline={false}>Another block link</Link>
+      </Block>
+
+      <Block title="external">
+        <Link href="https://devalok.in" target="_blank" rel="noreferrer">
+          Visit devalok.in
+        </Link>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/menubar.preview.tsx
+++ b/apps/site/content/components/menubar.preview.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import * as React from 'react'
+import {
+  Menubar,
+  MenubarCheckboxItem,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarSub,
+  MenubarSubContent,
+  MenubarSubTrigger,
+  MenubarTrigger,
+} from '@devalok/shilp-sutra/ui/menubar'
+
+export function MenubarHero() {
+  return (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>
+            New file <MenubarShortcut>⌘N</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem>
+            New window <MenubarShortcut>⌘⇧N</MenubarShortcut>
+          </MenubarItem>
+          <MenubarSeparator />
+          <MenubarSub>
+            <MenubarSubTrigger>Share</MenubarSubTrigger>
+            <MenubarSubContent>
+              <MenubarItem>Email link</MenubarItem>
+              <MenubarItem>Copy link</MenubarItem>
+            </MenubarSubContent>
+          </MenubarSub>
+          <MenubarSeparator />
+          <MenubarItem>
+            Print <MenubarShortcut>⌘P</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger>Edit</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>
+            Undo <MenubarShortcut>⌘Z</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem>
+            Redo <MenubarShortcut>⌘⇧Z</MenubarShortcut>
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarCheckboxItem checked>Always show bookmarks</MenubarCheckboxItem>
+          <MenubarCheckboxItem>Show full URLs</MenubarCheckboxItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  )
+}
+
+export function MenubarVariants() {
+  const [wordWrap, setWordWrap] = React.useState(true)
+
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="checkbox items">
+        <Menubar>
+          <MenubarMenu>
+            <MenubarTrigger>Preferences</MenubarTrigger>
+            <MenubarContent>
+              <MenubarCheckboxItem checked={wordWrap} onCheckedChange={setWordWrap}>
+                Word wrap
+              </MenubarCheckboxItem>
+              <MenubarCheckboxItem>Minimap</MenubarCheckboxItem>
+              <MenubarSeparator />
+              <MenubarItem>Reset to defaults</MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+        </Menubar>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/navigation-menu.preview.tsx
+++ b/apps/site/content/components/navigation-menu.preview.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from '@devalok/shilp-sutra/ui/navigation-menu'
+
+export function NavigationMenuHero() {
+  return (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-72 gap-ds-01 p-ds-03">
+              <MenuLink title="Analytics" href="#analytics">
+                Dashboards, funnels, and retention out of the box.
+              </MenuLink>
+              <MenuLink title="Automations" href="#automations">
+                Trigger workflows from any event in your product.
+              </MenuLink>
+              <MenuLink title="Data pipeline" href="#pipeline">
+                Stream clean events to your warehouse.
+              </MenuLink>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Resources</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid w-72 gap-ds-01 p-ds-03">
+              <MenuLink title="Documentation" href="#docs">
+                Guides, recipes, and the full API reference.
+              </MenuLink>
+              <MenuLink title="Changelog" href="#changelog">
+                Everything we shipped, release by release.
+              </MenuLink>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="#pricing"
+            className="inline-flex h-ds-sm-plus w-max items-center rounded-control px-ds-05 py-ds-03 text-body-md font-medium transition-colors hover:bg-surface-raised-hover"
+          >
+            Pricing
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  )
+}
+
+export function NavigationMenuVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="single trigger with rich content">
+        <NavigationMenu>
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <NavigationMenuTrigger>Company</NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="grid w-64 gap-ds-01 p-ds-03">
+                  <MenuLink title="About" href="#about">
+                    Who we are and what we are building.
+                  </MenuLink>
+                  <MenuLink title="Careers" href="#careers">
+                    Open roles across design and engineering.
+                  </MenuLink>
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      </Block>
+    </div>
+  )
+}
+
+function MenuLink({ title, href, children }: { title: string; href: string; children: React.ReactNode }) {
+  return (
+    <li>
+      <NavigationMenuLink
+        href={href}
+        className="block rounded-control p-ds-03 transition-colors hover:bg-surface-raised-hover"
+      >
+        <span className="block text-body-md font-medium text-surface-fg">{title}</span>
+        <span className="block text-body-sm text-surface-fg-muted">{children}</span>
+      </NavigationMenuLink>
+    </li>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/page-header.preview.tsx
+++ b/apps/site/content/components/page-header.preview.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { PageHeader } from '@devalok/shilp-sutra/composed/page-header'
+
+export function PageHeaderHero() {
+  return (
+    <div className="w-full">
+      <PageHeader
+        title="Projects"
+        subtitle="Everything your team is shipping this quarter."
+        actions={
+          <>
+            <Button variant="soft">Filter</Button>
+            <Button>New project</Button>
+          </>
+        }
+      />
+    </div>
+  )
+}
+
+export function PageHeaderVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="with breadcrumbs">
+        <PageHeader
+          breadcrumbs={[
+            { label: 'Home', href: '#' },
+            { label: 'Projects', href: '#' },
+            { label: 'Orbit redesign' },
+          ]}
+          title="Orbit redesign"
+          subtitle="A ground-up refresh of the marketing surface."
+        />
+      </Block>
+
+      <Block title="title only">
+        <PageHeader title="Settings" />
+      </Block>
+
+      <Block title="with actions">
+        <PageHeader
+          title="Team"
+          actions={<Button>Invite member</Button>}
+        />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/popover.preview.tsx
+++ b/apps/site/content/components/popover.preview.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@devalok/shilp-sutra/ui/popover'
+
+export function PopoverHero() {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Dimensions</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <div className="flex flex-col gap-ds-03">
+          <div className="flex flex-col gap-ds-01">
+            <span className="text-body-md font-semibold text-surface-fg">Dimensions</span>
+            <span className="text-body-sm text-surface-fg-muted">Set the width and height for the layer.</span>
+          </div>
+          <div className="grid grid-cols-[auto_1fr] items-center gap-x-ds-04 gap-y-ds-02 text-body-sm">
+            <span className="text-surface-fg-muted">Width</span>
+            <span className="text-surface-fg">100%</span>
+            <span className="text-surface-fg-muted">Height</span>
+            <span className="text-surface-fg">auto</span>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export function PopoverVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-ds-06">
+      {(['start', 'center', 'end'] as const).map((align) => (
+        <Block key={align} title={`align="${align}"`}>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="soft" size="sm">{align}</Button>
+            </PopoverTrigger>
+            <PopoverContent align={align} className="w-56">
+              <span className="text-body-sm text-surface-fg-muted">
+                Content aligned to the {align} of the trigger.
+              </span>
+            </PopoverContent>
+          </Popover>
+        </Block>
+      ))}
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/priority-indicator.preview.tsx
+++ b/apps/site/content/components/priority-indicator.preview.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { PriorityIndicator } from '@devalok/shilp-sutra/composed/priority-indicator'
+
+export function PriorityIndicatorHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-05">
+      <PriorityIndicator priority="LOW" />
+      <PriorityIndicator priority="MEDIUM" />
+      <PriorityIndicator priority="HIGH" />
+      <PriorityIndicator priority="URGENT" />
+    </div>
+  )
+}
+
+export function PriorityIndicatorVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="display=full (default)">
+        <PriorityIndicator priority="LOW" />
+        <PriorityIndicator priority="MEDIUM" />
+        <PriorityIndicator priority="HIGH" />
+        <PriorityIndicator priority="URGENT" />
+      </Block>
+
+      <Block title="display=compact (icon only)">
+        <PriorityIndicator priority="LOW" display="compact" />
+        <PriorityIndicator priority="MEDIUM" display="compact" />
+        <PriorityIndicator priority="HIGH" display="compact" />
+        <PriorityIndicator priority="URGENT" display="compact" />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-04">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/progress-ring.preview.tsx
+++ b/apps/site/content/components/progress-ring.preview.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { MultiProgressRing, ProgressRing } from '@devalok/shilp-sutra/ui/progress-ring'
+
+export function ProgressRingHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-06">
+      <ProgressRing value={72} size="lg" showValue />
+      <ProgressRing value={40} size="lg" color="warning" showValue />
+      <MultiProgressRing
+        size="lg"
+        rings={[
+          { value: 80, color: 'error', label: 'Move' },
+          { value: 55, color: 'success', label: 'Exercise' },
+          { value: 30, color: 'info', label: 'Stand' },
+        ]}
+      />
+    </div>
+  )
+}
+
+export function ProgressRingVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="size">
+        <ProgressRing value={60} size="sm" showValue />
+        <ProgressRing value={60} size="md" showValue />
+        <ProgressRing value={60} size="lg" showValue />
+      </Block>
+
+      <Block title="color">
+        <ProgressRing value={65} color="default" showValue />
+        <ProgressRing value={65} color="success" showValue />
+        <ProgressRing value={65} color="warning" showValue />
+        <ProgressRing value={65} color="error" showValue />
+      </Block>
+
+      <Block title="custom max">
+        <ProgressRing value={3} max={12} size="lg" color="info" showValue />
+      </Block>
+
+      <Block title="MultiProgressRing">
+        <MultiProgressRing
+          size="lg"
+          rings={[
+            { value: 90, color: 'error' },
+            { value: 50, color: 'success' },
+          ]}
+        />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-05">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/responsive-modal.preview.tsx
+++ b/apps/site/content/components/responsive-modal.preview.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  ResponsiveModal,
+  ResponsiveModalBody,
+  ResponsiveModalClose,
+  ResponsiveModalContent,
+  ResponsiveModalDescription,
+  ResponsiveModalFooter,
+  ResponsiveModalHeader,
+  ResponsiveModalTitle,
+  ResponsiveModalTrigger,
+} from '@devalok/shilp-sutra/composed/responsive-modal'
+
+export function ResponsiveModalHero() {
+  return (
+    <ResponsiveModal>
+      <ResponsiveModalTrigger asChild>
+        <Button>Filter results</Button>
+      </ResponsiveModalTrigger>
+      <ResponsiveModalContent>
+        <ResponsiveModalHeader>
+          <ResponsiveModalTitle>Filters</ResponsiveModalTitle>
+          <ResponsiveModalDescription>
+            Narrow the result set. Centered dialog on desktop, bottom sheet on mobile.
+          </ResponsiveModalDescription>
+        </ResponsiveModalHeader>
+        <ResponsiveModalBody>
+          <div className="flex flex-col gap-ds-03 text-body-sm text-surface-fg-muted">
+            <p>Status, owner, and date range controls would live in this scrollable body.</p>
+            <p>Resize the window below 768px to see it become a drag-to-dismiss bottom sheet.</p>
+          </div>
+        </ResponsiveModalBody>
+        <ResponsiveModalFooter>
+          <ResponsiveModalClose asChild>
+            <Button variant="soft">Cancel</Button>
+          </ResponsiveModalClose>
+          <Button>Apply filters</Button>
+        </ResponsiveModalFooter>
+      </ResponsiveModalContent>
+    </ResponsiveModal>
+  )
+}
+
+export function ResponsiveModalVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="snapPoints={[0.5, 0.9]} (mobile rest heights)">
+        <ResponsiveModal>
+          <ResponsiveModalTrigger asChild>
+            <Button variant="outline">Open with snap points</Button>
+          </ResponsiveModalTrigger>
+          <ResponsiveModalContent snapPoints={[0.5, 0.9]}>
+            <ResponsiveModalHeader>
+              <ResponsiveModalTitle>Snap-point sheet</ResponsiveModalTitle>
+              <ResponsiveModalDescription>
+                On mobile the sheet rests at 50% and 90% of the viewport and can be dragged between them.
+              </ResponsiveModalDescription>
+            </ResponsiveModalHeader>
+            <ResponsiveModalBody>
+              <p className="text-body-sm text-surface-fg-muted">
+                Snap points are ignored on desktop, where this stays a centered dialog.
+              </p>
+            </ResponsiveModalBody>
+            <ResponsiveModalFooter>
+              <ResponsiveModalClose asChild>
+                <Button variant="soft">Done</Button>
+              </ResponsiveModalClose>
+            </ResponsiveModalFooter>
+          </ResponsiveModalContent>
+        </ResponsiveModal>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/sheet.preview.tsx
+++ b/apps/site/content/components/sheet.preview.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@devalok/shilp-sutra/ui/sheet'
+
+export function SheetHero() {
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open settings</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Account settings</SheetTitle>
+          <SheetDescription>Manage your profile and workspace preferences.</SheetDescription>
+        </SheetHeader>
+        <SheetFooter className="mt-ds-06">
+          <SheetClose asChild>
+            <Button variant="soft">Cancel</Button>
+          </SheetClose>
+          <Button>Save</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+export function SheetVariants() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-ds-06">
+      {(['left', 'right', 'top', 'bottom'] as const).map((side) => (
+        <Block key={side} title={`side="${side}"`}>
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant="soft" size="sm">{side}</Button>
+            </SheetTrigger>
+            <SheetContent side={side}>
+              <SheetHeader>
+                <SheetTitle>From the {side}</SheetTitle>
+                <SheetDescription>The panel slides in from the {side} edge of the screen.</SheetDescription>
+              </SheetHeader>
+            </SheetContent>
+          </Sheet>
+        </Block>
+      ))}
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/simple-tooltip.preview.tsx
+++ b/apps/site/content/components/simple-tooltip.preview.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { IconInfoCircle } from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import { SimpleTooltip } from '@devalok/shilp-sutra/composed/simple-tooltip'
+
+export function SimpleTooltipHero() {
+  return (
+    <SimpleTooltip content="Copy the install command to your clipboard">
+      <Button variant="outline">Hover me</Button>
+    </SimpleTooltip>
+  )
+}
+
+export function SimpleTooltipVariants() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-ds-06">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <Block key={side} title={`side="${side}"`}>
+          <SimpleTooltip content={`Shows on the ${side}`} side={side}>
+            <Button variant="soft" size="icon" aria-label={`Info ${side}`}>
+              <IconInfoCircle />
+            </Button>
+          </SimpleTooltip>
+        </Block>
+      ))}
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/split-button.preview.tsx
+++ b/apps/site/content/components/split-button.preview.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { SplitButton } from '@devalok/shilp-sutra/ui/split-button'
+
+function DropdownItems() {
+  return (
+    <div className="flex flex-col">
+      <button className="rounded-control-inner px-ds-03 py-ds-02 text-left text-body-sm text-surface-fg hover:bg-surface-raised-hover">
+        Save and duplicate
+      </button>
+      <button className="rounded-control-inner px-ds-03 py-ds-02 text-left text-body-sm text-surface-fg hover:bg-surface-raised-hover">
+        Save as template
+      </button>
+      <button className="rounded-control-inner px-ds-03 py-ds-02 text-left text-body-sm text-surface-fg hover:bg-surface-raised-hover">
+        Save and close
+      </button>
+    </div>
+  )
+}
+
+export function SplitButtonHero() {
+  return (
+    <SplitButton onClick={() => {}} dropdownContent={<DropdownItems />}>
+      Save changes
+    </SplitButton>
+  )
+}
+
+export function SplitButtonVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="variant">
+        <SplitButton variant="solid" onClick={() => {}} dropdownContent={<DropdownItems />}>Solid</SplitButton>
+        <SplitButton variant="soft" onClick={() => {}} dropdownContent={<DropdownItems />}>Soft</SplitButton>
+        <SplitButton variant="outline" onClick={() => {}} dropdownContent={<DropdownItems />}>Outline</SplitButton>
+      </Block>
+
+      <Block title="color">
+        <SplitButton color="accent" onClick={() => {}} dropdownContent={<DropdownItems />}>Accent</SplitButton>
+        <SplitButton color="success" onClick={() => {}} dropdownContent={<DropdownItems />}>Success</SplitButton>
+        <SplitButton color="error" onClick={() => {}} dropdownContent={<DropdownItems />}>Error</SplitButton>
+      </Block>
+
+      <Block title="size">
+        <SplitButton size="sm" onClick={() => {}} dropdownContent={<DropdownItems />}>Small</SplitButton>
+        <SplitButton size="md" onClick={() => {}} dropdownContent={<DropdownItems />}>Medium</SplitButton>
+      </Block>
+
+      <Block title="triggerSide=left">
+        <SplitButton triggerSide="left" onClick={() => {}} dropdownContent={<DropdownItems />}>Export</SplitButton>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/stat-flash.preview.tsx
+++ b/apps/site/content/components/stat-flash.preview.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { IconActivity, IconChartBar, IconFolder, IconUsers } from '@tabler/icons-react'
+import { StatFlash } from '@devalok/shilp-sutra'
+
+export function StatFlashHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-05">
+      <StatFlash icon={<IconFolder />} flash="up" />
+      <StatFlash icon={<IconUsers />} flash="record" />
+      <StatFlash icon={<IconChartBar />} flash="down" />
+    </div>
+  )
+}
+
+export function StatFlashVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="preset flash">
+        <StatFlash icon={<IconFolder />} flash="up" />
+        <StatFlash icon={<IconFolder />} flash="down" />
+        <StatFlash icon={<IconFolder />} flash="goal" />
+        <StatFlash icon={<IconFolder />} flash="record" />
+        <StatFlash icon={<IconFolder />} flash="alert" />
+        <StatFlash icon={<IconFolder />} flash="live" />
+      </Block>
+
+      <Block title="fill=solid">
+        <StatFlash icon={<IconActivity />} flash="up" fill="solid" />
+        <StatFlash icon={<IconActivity />} flash="live" fill="solid" />
+      </Block>
+
+      <Block title="explicit { tone, icon }">
+        <StatFlash icon={<IconActivity />} flash={{ tone: 'info', icon: <IconChartBar /> }} />
+      </Block>
+
+      <Block title="speed">
+        <StatFlash icon={<IconFolder />} flash="up" speed="fast" />
+        <StatFlash icon={<IconFolder />} flash="up" speed="slow" />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-05">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/status-badge.preview.tsx
+++ b/apps/site/content/components/status-badge.preview.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { StatusBadge } from '@devalok/shilp-sutra/composed/status-badge'
+
+export function StatusBadgeHero() {
+  return (
+    <div className="flex flex-wrap items-center gap-ds-03">
+      <StatusBadge status="active" />
+      <StatusBadge status="pending" />
+      <StatusBadge status="in-progress" />
+      <StatusBadge status="completed" />
+    </div>
+  )
+}
+
+export function StatusBadgeVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="status vocabulary">
+        <StatusBadge status="active" />
+        <StatusBadge status="pending" />
+        <StatusBadge status="approved" />
+        <StatusBadge status="rejected" />
+        <StatusBadge status="blocked" />
+        <StatusBadge status="review" />
+        <StatusBadge status="cancelled" />
+        <StatusBadge status="draft" />
+      </Block>
+
+      <Block title="size">
+        <StatusBadge status="active" size="sm" />
+        <StatusBadge status="active" size="md" />
+      </Block>
+
+      <Block title="custom label & hideDot">
+        <StatusBadge status="completed" label="Shipped" />
+        <StatusBadge status="pending" hideDot />
+      </Block>
+
+      <Block title="clickable (chevron)">
+        <StatusBadge status="in-progress" onClick={() => {}} />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-03">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/table-row-link.preview.tsx
+++ b/apps/site/content/components/table-row-link.preview.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@devalok/shilp-sutra/ui/table'
+import { TableRowLink } from '@devalok/shilp-sutra/ui/table-row-link'
+
+const ROWS = [
+  { id: 'orbit', name: 'Orbit redesign', status: 'Active' },
+  { id: 'karm', name: 'Karm mobile app', status: 'Review' },
+  { id: 'setu', name: 'Setu brand kit', status: 'Draft' },
+]
+
+export function TableRowLinkHero() {
+  return (
+    <div className="w-full rounded-surface border border-surface-border-subtle bg-surface-raised">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Project</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {ROWS.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell className="relative">
+                <TableRowLink href={`#/projects/${row.id}`}>{row.name}</TableRowLink>
+              </TableCell>
+              <TableCell>
+                <Badge variant="soft" color={row.status === 'Active' ? 'success' : 'neutral'}>
+                  {row.status}
+                </Badge>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export function TableRowLinkVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="stretch (default — whole row is the click target)">
+        <div className="w-full rounded-surface border border-surface-border-subtle bg-surface-raised">
+          <Table>
+            <TableBody>
+              {ROWS.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="relative">
+                    <TableRowLink href={`#/projects/${row.id}`}>{row.name}</TableRowLink>
+                  </TableCell>
+                  <TableCell>{row.status}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </Block>
+
+      <Block title="stretch={false} (title-only, text stays selectable)">
+        <div className="w-full rounded-surface border border-surface-border-subtle bg-surface-raised">
+          <Table>
+            <TableBody>
+              {ROWS.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell className="relative">
+                    <TableRowLink href={`#/projects/${row.id}`} stretch={false}>
+                      {row.name}
+                    </TableRowLink>
+                  </TableCell>
+                  <TableCell>{row.status}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/table.preview.tsx
+++ b/apps/site/content/components/table.preview.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { Badge } from '@devalok/shilp-sutra/ui/badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@devalok/shilp-sutra/ui/table'
+
+const ROWS = [
+  { name: 'Orbit redesign', owner: 'Aisha Kapoor', status: 'Active', hours: 128 },
+  { name: 'Karm mobile app', owner: 'Ben Carter', status: 'Review', hours: 64 },
+  { name: 'Setu brand kit', owner: 'Chen Wei', status: 'Draft', hours: 12 },
+]
+
+export function TableHero() {
+  return (
+    <div className="w-full rounded-surface border border-surface-border-subtle bg-surface-raised">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Project</TableHead>
+            <TableHead>Owner</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead numeric>Hours</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {ROWS.map((row) => (
+            <TableRow key={row.name}>
+              <TableCell className="font-medium text-surface-fg">{row.name}</TableCell>
+              <TableCell>{row.owner}</TableCell>
+              <TableCell>
+                <Badge variant="soft" color={row.status === 'Active' ? 'success' : 'neutral'}>
+                  {row.status}
+                </Badge>
+              </TableCell>
+              <TableCell numeric>{row.hours}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export function TableVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title="density=compact">
+        <DemoTable density="compact" />
+      </Block>
+
+      <Block title="density=comfortable">
+        <DemoTable density="comfortable" />
+      </Block>
+
+      <Block title="striped">
+        <DemoTable striped />
+      </Block>
+    </div>
+  )
+}
+
+function DemoTable({
+  density,
+  striped,
+}: {
+  density?: 'compact' | 'standard' | 'comfortable'
+  striped?: boolean
+}) {
+  return (
+    <div className="w-full rounded-surface border border-surface-border-subtle bg-surface-raised">
+      <Table density={density} striped={striped}>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Project</TableHead>
+            <TableHead>Owner</TableHead>
+            <TableHead numeric>Hours</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {ROWS.map((row) => (
+            <TableRow key={row.name}>
+              <TableCell className="font-medium text-surface-fg">{row.name}</TableCell>
+              <TableCell>{row.owner}</TableCell>
+              <TableCell numeric>{row.hours}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/tooltip.preview.tsx
+++ b/apps/site/content/components/tooltip.preview.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { IconInfoCircle } from '@tabler/icons-react'
+import { Button } from '@devalok/shilp-sutra/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@devalok/shilp-sutra/ui/tooltip'
+
+export function TooltipHero() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover me</Button>
+        </TooltipTrigger>
+        <TooltipContent>Copies the install command to your clipboard</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export function TooltipVariants() {
+  return (
+    <TooltipProvider>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-ds-06">
+        {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+          <Block key={side} title={`side="${side}"`}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="soft" size="icon" aria-label={`Info ${side}`}>
+                  <IconInfoCircle />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side={side}>Shows on the {side}</TooltipContent>
+            </Tooltip>
+          </Block>
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-wrap items-center gap-ds-02">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/tree-view.preview.tsx
+++ b/apps/site/content/components/tree-view.preview.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { IconFile, IconFolder } from '@tabler/icons-react'
+import { TreeView } from '@devalok/shilp-sutra/ui/tree-view'
+
+const ITEMS = [
+  {
+    id: 'src',
+    label: 'src',
+    icon: IconFolder,
+    children: [
+      {
+        id: 'components',
+        label: 'components',
+        icon: IconFolder,
+        children: [
+          { id: 'button', label: 'button.tsx', icon: IconFile },
+          { id: 'card', label: 'card.tsx', icon: IconFile },
+        ],
+      },
+      { id: 'index', label: 'index.ts', icon: IconFile },
+    ],
+  },
+  {
+    id: 'public',
+    label: 'public',
+    icon: IconFolder,
+    children: [{ id: 'logo', label: 'logo.svg', icon: IconFile }],
+  },
+  { id: 'readme', label: 'README.md', icon: IconFile },
+]
+
+export function TreeViewHero() {
+  return (
+    <div className="w-full max-w-sm rounded-surface border border-surface-border-subtle bg-surface-raised p-ds-03">
+      <TreeView items={ITEMS} defaultExpanded={['src', 'components']} />
+    </div>
+  )
+}
+
+export function TreeViewVariants() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-ds-06">
+      <Block title="collapsed by default">
+        <TreeView items={ITEMS} />
+      </Block>
+
+      <Block title="checkboxes + multiSelect">
+        <TreeView items={ITEMS} defaultExpanded={['src']} checkboxes multiSelect />
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/content/components/truncated-text.preview.tsx
+++ b/apps/site/content/components/truncated-text.preview.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { TruncatedText } from '@devalok/shilp-sutra/ui/truncated-text'
+
+export function TruncatedTextHero() {
+  return (
+    <div className="w-full max-w-xs">
+      <TruncatedText>
+        This is a long project title that will not fit on a single line and gets clipped with an ellipsis.
+      </TruncatedText>
+    </div>
+  )
+}
+
+export function TruncatedTextVariants() {
+  return (
+    <div className="grid grid-cols-1 gap-ds-06">
+      <Block title='mode="end" (default)'>
+        <div className="w-full max-w-[240px]">
+          <TruncatedText>
+            A single-line label that trails off at the end when it overflows.
+          </TruncatedText>
+        </div>
+      </Block>
+
+      <Block title='mode="middle" (filenames)'>
+        <div className="w-full max-w-[240px]">
+          <TruncatedText mode="middle">quarterly-financial-report-2026-final-v2.pdf</TruncatedText>
+        </div>
+      </Block>
+
+      <Block title='mode="clamp" lines={2}'>
+        <div className="w-full max-w-[240px]">
+          <TruncatedText mode="clamp" lines={2}>
+            A longer description that wraps across multiple lines and is clamped to two lines before it is cut off with an ellipsis at the end.
+          </TruncatedText>
+        </div>
+      </Block>
+    </div>
+  )
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-ds-03 p-ds-05 rounded-control border border-surface-border-subtle bg-surface-raised">
+      <span className="text-ds-xs font-mono text-surface-fg-subtle">{title}</span>
+      <div className="flex flex-col text-body-md text-surface-fg">{children}</div>
+    </div>
+  )
+}

--- a/apps/site/lib/preview-registry.tsx
+++ b/apps/site/lib/preview-registry.tsx
@@ -1,103 +1,160 @@
 /**
  * Live-preview registry — maps a component slug to its hand-curated preview.
- *
- * Static imports. Each preview file starts with `"use client"` so the React
- * components stay client-side, but the registry itself is plain server-safe
- * data (a slug → component map). Server components import this directly
- * and render the matching preview into the detail page.
- *
- * Adding a preview:
- *   1. Create apps/site/content/components/<slug>.preview.tsx (use client)
- *   2. Export named hero + variants components
- *   3. Add the slug to PREVIEW_MAP below
+ * GENERATED shape (slug -> { Hero, Variants }); edit the .preview.tsx files, then
+ * re-run the generator in this file's history. Server-safe data map.
  */
-import type { ComponentType } from 'react'
+import type { ComponentType } from "react"
 
-import { AccordionHero, AccordionVariants } from '@/content/components/accordion.preview'
-import { AlertHero, AlertVariants } from '@/content/components/alert.preview'
-import { AvatarHero, AvatarVariants } from '@/content/components/avatar.preview'
-import { BadgeHero, BadgeVariants } from '@/content/components/badge.preview'
-import { BreadcrumbHero, BreadcrumbVariants } from '@/content/components/breadcrumb.preview'
-import { ButtonHero, ButtonVariants } from '@/content/components/button.preview'
-import { CardHero, CardVariants } from '@/content/components/card.preview'
-import { CheckboxHero, CheckboxVariants } from '@/content/components/checkbox.preview'
-import { ComboboxHero, ComboboxVariants } from '@/content/components/combobox.preview'
-import { DotHero, DotVariants } from '@/content/components/dot.preview'
-import { InputHero, InputVariants } from '@/content/components/input.preview'
-import { LabelHero, LabelVariants } from '@/content/components/label.preview'
-import { NumberInputHero, NumberInputVariants } from '@/content/components/number-input.preview'
-import { PaginationHero, PaginationVariants } from '@/content/components/pagination.preview'
-import { ProgressHero, ProgressVariants } from '@/content/components/progress.preview'
-import { RadioHero, RadioVariants } from '@/content/components/radio.preview'
-import { SearchInputHero, SearchInputVariants } from '@/content/components/search-input.preview'
-import {
-  SegmentedControlHero,
-  SegmentedControlVariants,
-} from '@/content/components/segmented-control.preview'
-import { SelectHero, SelectVariants } from '@/content/components/select.preview'
-import { SeparatorHero, SeparatorVariants } from '@/content/components/separator.preview'
-import { SkeletonHero, SkeletonVariants } from '@/content/components/skeleton.preview'
-import { SliderHero, SliderVariants } from '@/content/components/slider.preview'
-import { SpinnerHero, SpinnerVariants } from '@/content/components/spinner.preview'
-import { StatCardHero, StatCardVariants } from '@/content/components/stat-card.preview'
-import { StepperHero, StepperVariants } from '@/content/components/stepper.preview'
-import { SwitchHero, SwitchVariants } from '@/content/components/switch.preview'
-import { TabsHero, TabsVariants } from '@/content/components/tabs.preview'
-import { TextareaHero, TextareaVariants } from '@/content/components/textarea.preview'
-import { ToggleHero, ToggleVariants } from '@/content/components/toggle.preview'
-import { ToggleGroupHero, ToggleGroupVariants } from '@/content/components/toggle-group.preview'
+import { AccordionHero, AccordionVariants } from "@/content/components/accordion.preview"
+import { AlertDialogHero, AlertDialogVariants } from "@/content/components/alert-dialog.preview"
+import { AlertHero, AlertVariants } from "@/content/components/alert.preview"
+import { AutocompleteHero, AutocompleteVariants } from "@/content/components/autocomplete.preview"
+import { AvatarGroupHero, AvatarGroupVariants } from "@/content/components/avatar-group.preview"
+import { AvatarHero, AvatarVariants } from "@/content/components/avatar.preview"
+import { BadgeGroupHero, BadgeGroupVariants } from "@/content/components/badge-group.preview"
+import { BadgeHero, BadgeVariants } from "@/content/components/badge.preview"
+import { BannerHero, BannerVariants } from "@/content/components/banner.preview"
+import { BreadcrumbHero, BreadcrumbVariants } from "@/content/components/breadcrumb.preview"
+import { ButtonGroupHero, ButtonGroupVariants } from "@/content/components/button-group.preview"
+import { ButtonHero, ButtonVariants } from "@/content/components/button.preview"
+import { CardHero, CardVariants } from "@/content/components/card.preview"
+import { CheckboxHero, CheckboxVariants } from "@/content/components/checkbox.preview"
+import { CodeHero, CodeVariants } from "@/content/components/code.preview"
+import { CollapsibleHero, CollapsibleVariants } from "@/content/components/collapsible.preview"
+import { ColorInputHero, ColorInputVariants } from "@/content/components/color-input.preview"
+import { ColorSwatchHero, ColorSwatchVariants } from "@/content/components/color-swatch.preview"
+import { ComboboxHero, ComboboxVariants } from "@/content/components/combobox.preview"
+import { ConfirmDialogHero, ConfirmDialogVariants } from "@/content/components/confirm-dialog.preview"
+import { ContentCardHero, ContentCardVariants } from "@/content/components/content-card.preview"
+import { ContextMenuHero, ContextMenuVariants } from "@/content/components/context-menu.preview"
+import { DeadlineIndicatorHero, DeadlineIndicatorVariants } from "@/content/components/deadline-indicator.preview"
+import { DialogHero, DialogVariants } from "@/content/components/dialog.preview"
+import { DotHero, DotVariants } from "@/content/components/dot.preview"
+import { DropdownMenuHero, DropdownMenuVariants } from "@/content/components/dropdown-menu.preview"
+import { EmptyStateHero, EmptyStateVariants } from "@/content/components/empty-state.preview"
+import { FileUploadHero, FileUploadVariants } from "@/content/components/file-upload.preview"
+import { HoverCardHero, HoverCardVariants } from "@/content/components/hover-card.preview"
+import { IconButtonHero, IconButtonVariants } from "@/content/components/icon-button.preview"
+import { InputOtpHero, InputOtpVariants } from "@/content/components/input-otp.preview"
+import { InputHero, InputVariants } from "@/content/components/input.preview"
+import { LabelHero, LabelVariants } from "@/content/components/label.preview"
+import { LinkHero, LinkVariants } from "@/content/components/link.preview"
+import { MenubarHero, MenubarVariants } from "@/content/components/menubar.preview"
+import { NavigationMenuHero, NavigationMenuVariants } from "@/content/components/navigation-menu.preview"
+import { NumberInputHero, NumberInputVariants } from "@/content/components/number-input.preview"
+import { PageHeaderHero, PageHeaderVariants } from "@/content/components/page-header.preview"
+import { PaginationHero, PaginationVariants } from "@/content/components/pagination.preview"
+import { PopoverHero, PopoverVariants } from "@/content/components/popover.preview"
+import { PriorityIndicatorHero, PriorityIndicatorVariants } from "@/content/components/priority-indicator.preview"
+import { ProgressRingHero, ProgressRingVariants } from "@/content/components/progress-ring.preview"
+import { ProgressHero, ProgressVariants } from "@/content/components/progress.preview"
+import { RadioHero, RadioVariants } from "@/content/components/radio.preview"
+import { ResponsiveModalHero, ResponsiveModalVariants } from "@/content/components/responsive-modal.preview"
+import { SearchInputHero, SearchInputVariants } from "@/content/components/search-input.preview"
+import { SegmentedControlHero, SegmentedControlVariants } from "@/content/components/segmented-control.preview"
+import { SelectHero, SelectVariants } from "@/content/components/select.preview"
+import { SeparatorHero, SeparatorVariants } from "@/content/components/separator.preview"
+import { SheetHero, SheetVariants } from "@/content/components/sheet.preview"
+import { SimpleTooltipHero, SimpleTooltipVariants } from "@/content/components/simple-tooltip.preview"
+import { SkeletonHero, SkeletonVariants } from "@/content/components/skeleton.preview"
+import { SliderHero, SliderVariants } from "@/content/components/slider.preview"
+import { SpinnerHero, SpinnerVariants } from "@/content/components/spinner.preview"
+import { SplitButtonHero, SplitButtonVariants } from "@/content/components/split-button.preview"
+import { StatCardHero, StatCardVariants } from "@/content/components/stat-card.preview"
+import { StatFlashHero, StatFlashVariants } from "@/content/components/stat-flash.preview"
+import { StatusBadgeHero, StatusBadgeVariants } from "@/content/components/status-badge.preview"
+import { StepperHero, StepperVariants } from "@/content/components/stepper.preview"
+import { SwitchHero, SwitchVariants } from "@/content/components/switch.preview"
+import { TableRowLinkHero, TableRowLinkVariants } from "@/content/components/table-row-link.preview"
+import { TableHero, TableVariants } from "@/content/components/table.preview"
+import { TabsHero, TabsVariants } from "@/content/components/tabs.preview"
+import { TextareaHero, TextareaVariants } from "@/content/components/textarea.preview"
+import { ToggleGroupHero, ToggleGroupVariants } from "@/content/components/toggle-group.preview"
+import { ToggleHero, ToggleVariants } from "@/content/components/toggle.preview"
+import { TooltipHero, TooltipVariants } from "@/content/components/tooltip.preview"
+import { TreeViewHero, TreeViewVariants } from "@/content/components/tree-view.preview"
+import { TruncatedTextHero, TruncatedTextVariants } from "@/content/components/truncated-text.preview"
 
-export type ComponentPreview = {
-  Hero: ComponentType
-  Variants?: ComponentType
-}
+export type ComponentPreview = { Hero: ComponentType; Variants?: ComponentType }
 
 const PREVIEW_MAP: Record<string, ComponentPreview> = {
-  // Buttons & actions
-  button: { Hero: ButtonHero, Variants: ButtonVariants },
-  toggle: { Hero: ToggleHero, Variants: ToggleVariants },
-  'toggle-group': { Hero: ToggleGroupHero, Variants: ToggleGroupVariants },
-  'segmented-control': { Hero: SegmentedControlHero, Variants: SegmentedControlVariants },
-  // Forms & inputs
-  input: { Hero: InputHero, Variants: InputVariants },
-  textarea: { Hero: TextareaHero, Variants: TextareaVariants },
-  checkbox: { Hero: CheckboxHero, Variants: CheckboxVariants },
-  switch: { Hero: SwitchHero, Variants: SwitchVariants },
-  radio: { Hero: RadioHero, Variants: RadioVariants },
-  label: { Hero: LabelHero, Variants: LabelVariants },
-  select: { Hero: SelectHero, Variants: SelectVariants },
-  combobox: { Hero: ComboboxHero, Variants: ComboboxVariants },
-  slider: { Hero: SliderHero, Variants: SliderVariants },
-  'number-input': { Hero: NumberInputHero, Variants: NumberInputVariants },
-  'search-input': { Hero: SearchInputHero, Variants: SearchInputVariants },
-  // Data display
-  card: { Hero: CardHero, Variants: CardVariants },
-  badge: { Hero: BadgeHero, Variants: BadgeVariants },
-  avatar: { Hero: AvatarHero, Variants: AvatarVariants },
-  dot: { Hero: DotHero, Variants: DotVariants },
-  'stat-card': { Hero: StatCardHero, Variants: StatCardVariants },
-  skeleton: { Hero: SkeletonHero, Variants: SkeletonVariants },
-  // Feedback
-  alert: { Hero: AlertHero, Variants: AlertVariants },
-  progress: { Hero: ProgressHero, Variants: ProgressVariants },
-  spinner: { Hero: SpinnerHero, Variants: SpinnerVariants },
-  // Navigation
-  tabs: { Hero: TabsHero, Variants: TabsVariants },
   accordion: { Hero: AccordionHero, Variants: AccordionVariants },
+  "alert-dialog": { Hero: AlertDialogHero, Variants: AlertDialogVariants },
+  alert: { Hero: AlertHero, Variants: AlertVariants },
+  autocomplete: { Hero: AutocompleteHero, Variants: AutocompleteVariants },
+  "avatar-group": { Hero: AvatarGroupHero, Variants: AvatarGroupVariants },
+  avatar: { Hero: AvatarHero, Variants: AvatarVariants },
+  "badge-group": { Hero: BadgeGroupHero, Variants: BadgeGroupVariants },
+  badge: { Hero: BadgeHero, Variants: BadgeVariants },
+  banner: { Hero: BannerHero, Variants: BannerVariants },
   breadcrumb: { Hero: BreadcrumbHero, Variants: BreadcrumbVariants },
+  "button-group": { Hero: ButtonGroupHero, Variants: ButtonGroupVariants },
+  button: { Hero: ButtonHero, Variants: ButtonVariants },
+  card: { Hero: CardHero, Variants: CardVariants },
+  checkbox: { Hero: CheckboxHero, Variants: CheckboxVariants },
+  code: { Hero: CodeHero, Variants: CodeVariants },
+  collapsible: { Hero: CollapsibleHero, Variants: CollapsibleVariants },
+  "color-input": { Hero: ColorInputHero, Variants: ColorInputVariants },
+  "color-swatch": { Hero: ColorSwatchHero, Variants: ColorSwatchVariants },
+  combobox: { Hero: ComboboxHero, Variants: ComboboxVariants },
+  "confirm-dialog": { Hero: ConfirmDialogHero, Variants: ConfirmDialogVariants },
+  "content-card": { Hero: ContentCardHero, Variants: ContentCardVariants },
+  "context-menu": { Hero: ContextMenuHero, Variants: ContextMenuVariants },
+  "deadline-indicator": { Hero: DeadlineIndicatorHero, Variants: DeadlineIndicatorVariants },
+  dialog: { Hero: DialogHero, Variants: DialogVariants },
+  dot: { Hero: DotHero, Variants: DotVariants },
+  "dropdown-menu": { Hero: DropdownMenuHero, Variants: DropdownMenuVariants },
+  "empty-state": { Hero: EmptyStateHero, Variants: EmptyStateVariants },
+  "file-upload": { Hero: FileUploadHero, Variants: FileUploadVariants },
+  "hover-card": { Hero: HoverCardHero, Variants: HoverCardVariants },
+  "icon-button": { Hero: IconButtonHero, Variants: IconButtonVariants },
+  "input-otp": { Hero: InputOtpHero, Variants: InputOtpVariants },
+  input: { Hero: InputHero, Variants: InputVariants },
+  label: { Hero: LabelHero, Variants: LabelVariants },
+  link: { Hero: LinkHero, Variants: LinkVariants },
+  menubar: { Hero: MenubarHero, Variants: MenubarVariants },
+  "navigation-menu": { Hero: NavigationMenuHero, Variants: NavigationMenuVariants },
+  "number-input": { Hero: NumberInputHero, Variants: NumberInputVariants },
+  "page-header": { Hero: PageHeaderHero, Variants: PageHeaderVariants },
   pagination: { Hero: PaginationHero, Variants: PaginationVariants },
-  stepper: { Hero: StepperHero, Variants: StepperVariants },
+  popover: { Hero: PopoverHero, Variants: PopoverVariants },
+  "priority-indicator": { Hero: PriorityIndicatorHero, Variants: PriorityIndicatorVariants },
+  "progress-ring": { Hero: ProgressRingHero, Variants: ProgressRingVariants },
+  progress: { Hero: ProgressHero, Variants: ProgressVariants },
+  radio: { Hero: RadioHero, Variants: RadioVariants },
+  "responsive-modal": { Hero: ResponsiveModalHero, Variants: ResponsiveModalVariants },
+  "search-input": { Hero: SearchInputHero, Variants: SearchInputVariants },
+  "segmented-control": { Hero: SegmentedControlHero, Variants: SegmentedControlVariants },
+  select: { Hero: SelectHero, Variants: SelectVariants },
   separator: { Hero: SeparatorHero, Variants: SeparatorVariants },
+  sheet: { Hero: SheetHero, Variants: SheetVariants },
+  "simple-tooltip": { Hero: SimpleTooltipHero, Variants: SimpleTooltipVariants },
+  skeleton: { Hero: SkeletonHero, Variants: SkeletonVariants },
+  slider: { Hero: SliderHero, Variants: SliderVariants },
+  spinner: { Hero: SpinnerHero, Variants: SpinnerVariants },
+  "split-button": { Hero: SplitButtonHero, Variants: SplitButtonVariants },
+  "stat-card": { Hero: StatCardHero, Variants: StatCardVariants },
+  "stat-flash": { Hero: StatFlashHero, Variants: StatFlashVariants },
+  "status-badge": { Hero: StatusBadgeHero, Variants: StatusBadgeVariants },
+  stepper: { Hero: StepperHero, Variants: StepperVariants },
+  switch: { Hero: SwitchHero, Variants: SwitchVariants },
+  "table-row-link": { Hero: TableRowLinkHero, Variants: TableRowLinkVariants },
+  table: { Hero: TableHero, Variants: TableVariants },
+  tabs: { Hero: TabsHero, Variants: TabsVariants },
+  textarea: { Hero: TextareaHero, Variants: TextareaVariants },
+  "toggle-group": { Hero: ToggleGroupHero, Variants: ToggleGroupVariants },
+  toggle: { Hero: ToggleHero, Variants: ToggleVariants },
+  tooltip: { Hero: TooltipHero, Variants: TooltipVariants },
+  "tree-view": { Hero: TreeViewHero, Variants: TreeViewVariants },
+  "truncated-text": { Hero: TruncatedTextHero, Variants: TruncatedTextVariants },
 }
 
 export function hasPreview(slug: string): boolean {
   return slug in PREVIEW_MAP
 }
-
 export function getPreviewSlugs(): string[] {
   return Object.keys(PREVIEW_MAP)
 }
-
 export function getPreview(slug: string): ComponentPreview | null {
   return PREVIEW_MAP[slug] ?? null
 }


### PR DESCRIPTION
Component previews 30 → 69: +12 overlay demos (dialog/sheet/popover/dropdown/context/menubar/nav, alert+confirm dialog, responsive-modal, simple-tooltip, autocomplete) + 27 form/data/display/nav (icon-button, split-button, button/avatar/badge-group, code, banner, collapsible, empty-state, link, status-badge, progress-ring, stat-flash, file-upload, input-otp, color-input/-swatch, table, table-row-link, tree-view, truncated-text, page-header, content-card, priority/deadline-indicator, tooltip, hover-card). chip excluded (removed v0.32). All from real CVA source. Index cards badge 'live preview'. tsc + build (167 pages) + lint clean.