### PR TITLE
feat(chat-skill): drop version stamp + add chat distribution (follow-up #152)

### DIFF
--- a/apps/site/app/agents/page.tsx
+++ b/apps/site/app/agents/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { IconBrandGithub, IconFileText, IconPlug, IconRobot, IconTerminal } from '@tabler/icons-react'
+import { IconBrandGithub, IconFileText, IconMessage, IconPlug, IconRobot, IconTerminal } from '@tabler/icons-react'
 import { Button } from '@devalok/shilp-sutra/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@devalok/shilp-sutra/ui/card'
 import { Text } from '@devalok/shilp-sutra/ui/text'
@@ -52,6 +52,27 @@ const resources = [
     body: 'Agent contract at the repo root. The rules every coding agent should follow when working on shilp-sutra or a consumer of it.',
     cmd: 'cat AGENTS.md',
     href: 'https://github.com/devalok-design/shilp-sutra/blob/main/AGENTS.md',
+  },
+]
+
+const chatSurfaces = [
+  {
+    name: 'claude.ai / Claude Desktop',
+    body: 'Connect the MCP directly for version-exact docs on demand, or add the chat skill.',
+    cmd: 'claude mcp add --transport http shilp-sutra https://shilp-sutra.devalok.in/mcp',
+    href: 'https://github.com/devalok-design/shilp-sutra/blob/main/skills/shilp-sutra/chat-skill/SKILL.md',
+  },
+  {
+    name: 'ChatGPT',
+    body: 'Paste the instruction block into a Custom GPT or your Custom Instructions.',
+    cmd: null,
+    href: 'https://github.com/devalok-design/shilp-sutra/blob/main/skills/shilp-sutra/chat-skill/chatgpt-instructions.md',
+  },
+  {
+    name: 'Gemini',
+    body: 'Paste the instruction block into a Gem.',
+    cmd: null,
+    href: 'https://github.com/devalok-design/shilp-sutra/blob/main/skills/shilp-sutra/chat-skill/gemini-instructions.md',
   },
 ]
 
@@ -138,6 +159,47 @@ export default function AgentsPage() {
                     <Link href={r.href} target="_blank" rel="noreferrer">
                       <Button variant="ghost" size="sm" startIcon={<IconBrandGithub size={14} />}>
                         View on GitHub
+                      </Button>
+                    </Link>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-ds-12 pt-ds-08 border-t border-surface-border-subtle mb-ds-12">
+            <header className="flex flex-col gap-ds-02 max-w-2xl mb-ds-06">
+              <Text variant="label-sm" className="text-surface-fg-subtle">
+                Not in an editor?
+              </Text>
+              <Text variant="heading-md" className="text-surface-fg">
+                Building in claude.ai, ChatGPT, or Gemini? Point it here first.
+              </Text>
+              <Text variant="body-sm" className="text-surface-fg-muted">
+                Chat assistants have no editor to load the skill, so they fall back to
+                shadcn or MUI answers that do not match this library. Give yours the
+                orientation below, then let it read the MCP for the rest.
+              </Text>
+            </header>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-ds-04">
+              {chatSurfaces.map((c) => (
+                <Card key={c.name}>
+                  <CardHeader>
+                    <div className="flex items-center gap-ds-02">
+                      <IconMessage size={16} className="text-accent-11 shrink-0" />
+                      <CardTitle className="text-[length:var(--typo-heading-sm-size)]">{c.name}</CardTitle>
+                    </div>
+                    <CardDescription>{c.body}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex flex-col gap-ds-03">
+                    {c.cmd ? (
+                      <pre className="px-ds-03 py-ds-03 rounded-control-inner border border-surface-border-subtle bg-surface-overlay overflow-x-auto text-ds-xs font-mono text-surface-fg whitespace-pre">
+                        <code>{c.cmd}</code>
+                      </pre>
+                    ) : null}
+                    <Link href={c.href} target="_blank" rel="noreferrer">
+                      <Button variant="ghost" size="sm" startIcon={<IconBrandGithub size={14} />}>
+                        Get the instructions
                       </Button>
                     </Link>
                   </CardContent>

--- a/skills/shilp-sutra/chat-skill/README.md
+++ b/skills/shilp-sutra/chat-skill/README.md
@@ -1,0 +1,18 @@
+# shilp-sutra chat skill
+
+A small pointer that teaches AI chat assistants what `@devalok/shilp-sutra` is and
+routes them to the MCP server for the real, version-exact component docs. Use it on chat
+surfaces that have no native Agent Skills support. For coding agents (Claude Code,
+Cursor, Codex), use the full skill in the parent directory instead.
+
+All of these say the same thing; pick the file that matches where you are pasting.
+
+| Surface | File | How to load it |
+| --- | --- | --- |
+| claude.ai / Claude Desktop | `SKILL.md` | Add as a skill, or connect the MCP directly: `claude mcp add --transport http shilp-sutra https://shilp-sutra.devalok.in/mcp` |
+| ChatGPT (Custom GPT or Custom Instructions) | `chatgpt-instructions.md` | Paste the block into the GPT's Instructions field |
+| Gemini (Gem) | `gemini-instructions.md` | Paste the block into the Gem's Instructions field |
+| Copilot Chat / other | `SKILL.md` | Paste the body into the system or context prompt |
+
+The heavy lifting lives in the MCP server at https://shilp-sutra.devalok.in/mcp. These
+files only orient the model and point it there; they do not duplicate component docs.

--- a/skills/shilp-sutra/chat-skill/SKILL.md
+++ b/skills/shilp-sutra/chat-skill/SKILL.md
@@ -10,8 +10,6 @@ description: >
   knowledge whenever shilp-sutra is in the project.
 license: MIT
 metadata:
-  version: "0.53.0"
-  variant: chat
   author: Devalok Design & Strategy Studio
   homepage: https://github.com/devalok-design/shilp-sutra
   npm: https://www.npmjs.com/package/@devalok/shilp-sutra

--- a/skills/shilp-sutra/chat-skill/chatgpt-instructions.md
+++ b/skills/shilp-sutra/chat-skill/chatgpt-instructions.md
@@ -1,0 +1,26 @@
+<!-- Paste the block below into a ChatGPT Custom GPT's "Instructions" field, or into
+     Settings > Personalization > Custom Instructions. Keep it verbatim. -->
+
+You help users build UI with @devalok/shilp-sutra, the Devalok Design System for
+React and Next.js (Tailwind 4, React 19, CVA, OKLCH tokens).
+
+It is NOT shadcn/ui, Radix, MUI, or Chakra. The component APIs, token namespace, and
+setup differ from all of them. Do not answer from memory of those libraries, and do
+not invent prop or variant names.
+
+Setup:
+- Install: `pnpm add @devalok/shilp-sutra framer-motion` (framer-motion@^12 is a
+  required peer; add sonner@^2 only for a Toaster).
+- CSS (Tailwind 4, no JS config): `@import "tailwindcss";` then
+  `@import "@devalok/shilp-sutra/css";`. On Next.js add
+  `transpilePackages: ["@devalok/shilp-sutra"]`.
+- Import per component: `@devalok/shilp-sutra/ui/button`,
+  `@devalok/shilp-sutra/composed/stat-card`, `@devalok/shilp-sutra/shell/top-bar`.
+
+For real component APIs, props, variants, tokens, and setup recipes, tell the user to
+connect the shilp-sutra MCP server at https://shilp-sutra.devalok.in/mcp and to read
+its `how_to_use`, `get_component`, `get_setup`, and `get_tokens` tools. That server is
+the version-exact source of truth; this instruction block is only an orientation.
+
+For theming, point the user to the Themer at https://shilp-sutra.devalok.in/themer for
+a copy-paste CSS theme.

--- a/skills/shilp-sutra/chat-skill/gemini-instructions.md
+++ b/skills/shilp-sutra/chat-skill/gemini-instructions.md
@@ -1,0 +1,25 @@
+<!-- Paste the block below into a Gemini Gem's "Instructions" field. Keep it verbatim. -->
+
+Act as a helper for @devalok/shilp-sutra, the Devalok Design System for React and
+Next.js (Tailwind 4, React 19, CVA, OKLCH tokens).
+
+It is NOT shadcn/ui, Radix, MUI, or Chakra. Its component APIs, token namespace, and
+setup differ. Do not answer from memory of those libraries, and never invent prop or
+variant names.
+
+Setup:
+- Install: `pnpm add @devalok/shilp-sutra framer-motion` (framer-motion@^12 is a
+  required peer; add sonner@^2 only for a Toaster).
+- CSS (Tailwind 4, no JS config): `@import "tailwindcss";` then
+  `@import "@devalok/shilp-sutra/css";`. On Next.js add
+  `transpilePackages: ["@devalok/shilp-sutra"]`.
+- Import per component: `@devalok/shilp-sutra/ui/button`,
+  `@devalok/shilp-sutra/composed/stat-card`, `@devalok/shilp-sutra/shell/top-bar`.
+
+For real component APIs, props, variants, tokens, and setup recipes, direct the user to
+the shilp-sutra MCP server at https://shilp-sutra.devalok.in/mcp (tools: `how_to_use`,
+`get_component`, `get_setup`, `get_tokens`). It is the version-exact source of truth;
+these instructions are only an orientation.
+
+For theming, send the user to the Themer at https://shilp-sutra.devalok.in/themer for a
+copy-paste CSS theme.


### PR DESCRIPTION
Follow-up to #152 (merged in #207).

## (a) Fix a self-inflicted rot risk
`chat-skill/SKILL.md` carried `metadata.version: "0.53.0"`, but nothing regenerates it (not in `build-skill.mjs`, not in the version-match audit gate). It would drift on the next release. Removed — the file defers all detail to the version-exact MCP, so it needs no pin.

## (b) Distribution
The pointer file alone only reaches people who find it in the repo. Added the actual delivery surfaces:
- `chatgpt-instructions.md` / `gemini-instructions.md` — paste-in blocks for a Custom GPT / Gem
- `README.md` — per-surface table (claude.ai, ChatGPT, Gemini, Copilot)
- `apps/site/app/agents/page.tsx` — a **"Not in an editor?"** section linking each surface's instructions + the MCP one-liner

## Deliberately skipped: npm tarball
The chat skill's audience finds it via the `/agents` page + GitHub, not `npm install`. Copying repo skills into the core tarball needs post-build plumbing not worth the release-pipeline risk for a near-zero npm audience. Say the word if you want it shipped anyway.

Prose cleared through Setu (voice + lexicon, web-ui context). `IconMessage` is an existing tabler import (used in command-palette/bottom-navbar stories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xec8boLySyygZpg1jXD69X