### PR TITLE
fix(ci): fetch base ref with ancestry so change-scope merge-base resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Detect change scope
         id: scope
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
+          # Fetch the base ref WITH ancestry (no --depth=1). The three-dot diff
+          # below needs a merge-base; a shallow depth-1 fetch only has the base
+          # tip, so when a branch's fork-point is not the current base tip (base
+          # advanced after branching), merge-base fails: "no merge base", exit
+          # 128. Checkout already uses fetch-depth: 0, so full history is cheap.
+          git fetch origin ${{ github.base_ref }}
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           echo "$CHANGED"
           # mcp_only: EVERY changed file is under packages/mcp-server/ → skip the


### PR DESCRIPTION
## Problem
The `ci.yml` "Detect change scope" step fetched the base ref with `--depth=1`, then ran `git diff origin/<base>...HEAD` (three-dot, needs a merge-base). A depth-1 fetch has only the base tip and no ancestry, so when a branch's fork-point is not the current base tip (base advanced after branching), merge-base fails:

```
fatal: origin/main...HEAD: no merge base
##[error]Process completed with exit code 128
```

The job dies in **pre-flight, before any typecheck/test** — so the red check says nothing about the code. This bit PR #210 (a branch created off an older main tip); the fix there was a manual rebase, which shouldn't be necessary.

## Fix
Drop `--depth=1`. Checkout already uses `fetch-depth: 0`, so fetching the base ref with full ancestry is cheap and makes the merge-base resolve in every case. Three-dot semantics (changes introduced by THIS branch, not base-ahead changes) are preserved.

This PR's own CI exercises the fixed step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xec8boLySyygZpg1jXD69X