### PR TITLE
fix(docs): doc↔source drift, 6 components (audit S3)

### DIFF
--- a/.changeset/fix-doc-source-drift.md
+++ b/.changeset/fix-doc-source-drift.md
@@ -1,0 +1,30 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix(docs): correct doc↔source drift in 6 components (finish-bar-v2 audit S3)
+
+Six shipped docs made claims the source contradicts — actively misleading AI
+agents and consumers. Corrected against source (source is truth):
+
+- **rich-chat-input** (P0): prop table was materially wrong — `onSubmit` is
+  `(message: RichChatInputMessage) => void` (not `(html, plainText)`); removed the
+  non-existent `maxRows`; added the `inline` variant + `charCountDisplay`,
+  `content`, `onVoiceRecord`, `onTranscribe`, `maxDuration`, `replyTo`,
+  `actionButton`, `emojiSet`, `onSchedule`, `sendOptions`; fixed `ChatToolbarItem`
+  (no `attach`; adds `blockquote`/`link`); documented `RichChatInputMessage`.
+- **slider**: doc claimed Slider does NOT consume FormField — it does (a11y wiring:
+  aria-invalid/describedby/required); reworded to "consumes for a11y, no visual
+  validation treatment."
+- **search-input**: removed the false "Escape auto-clears via type=search" claim
+  (never wired); added the shipped `xs` size (was `sm|md|lg`).
+- **command-registry**: `icon` is `IconInput` (not `ReactNode`); the pages/adminPages
+  split is organizational, NOT access control — clarified the component enforces
+  nothing (authorize on the server). Fixed the shell Introduction table's phantom
+  "register/unregister/search" API to the real contract.
+- **app-command-palette**: role detection is case-sensitive (`'Admin'`/`'SuperAdmin'`);
+  fixed the example's `role: 'admin'` and documented the footgun.
+- **simple-tooltip**: it always mounts its own `TooltipProvider` and does NOT inherit
+  an ancestor's `delayDuration` (doc claimed it "respects it if present").
+
+Docs-only; no runtime or type changes.

--- a/packages/core/docs/components/composed/rich-chat-input.md
+++ b/packages/core/docs/components/composed/rich-chat-input.md
@@ -9,19 +9,24 @@ Compact rich text chat input for unified human+AI workspaces. Built on TipTap.
 ## Props
 
 ### RichChatInputProps
-    onSubmit: (html: string, plainText: string) => void (REQUIRED)
+    onSubmit: (message: RichChatInputMessage) => void (REQUIRED)
     placeholder: string (default: "Type a message...")
     disabled: boolean (default: false)
-    variant: 'compact' | 'expanded' | 'minimal' (default: 'compact')
-    maxRows: number
+    content: string — initial HTML (not reactive; use for message editing)
+    variant: 'compact' | 'expanded' | 'minimal' | 'inline' (default: 'compact')
     enterBehavior: 'send' | 'newline' (default: 'send')
     maxLength: number — enables character counter
+    charCountDisplay: 'always' | 'focus' | 'near-limit' | 'hidden' (default: 'near-limit')
     mentions: MentionItem[] — static list for @mention autocomplete
     onMentionSearch: (query: string) => Promise<MentionItem[]> — async search
     onMentionSelect: (item: MentionItem) => void
     onFileUpload: (file: File) => Promise<{ url: string; name: string; size: number }>
     onImageUpload: (file: File) => Promise<string>
     slashCommands: SlashCommandGroup[] — enables / command palette
+    onVoiceRecord: (audio: Blob, duration: number) => void
+    onTranscribe: (blob: Blob, duration: number) => Promise<string | null> — transcribe after recording; return null to attach as a voice note
+    maxDuration: number — max voice-recording seconds
+    replyTo: { id: string; author: string; preview: string; onDismiss: () => void } — reply banner above the input
     onTyping: (isTyping: boolean) => void — typing indicator callback
     onEmpty: (isEmpty: boolean) => void
     isStreaming: boolean (default: false) — shows stop button instead of send
@@ -29,9 +34,15 @@ Compact rich text chat input for unified human+AI workspaces. Built on TipTap.
     leadingSlot: ReactNode — rendered above the editor
     trailingSlot: ReactNode — rendered below the toolbar
     disclaimer: string — small text below the input
-    toolbar: boolean | ChatToolbarItem[] (default: true)
+    toolbar: boolean | ChatToolbarItem[] | ReactNode (default: true) — true = default toolbar, array = whitelist, ReactNode = custom, false = hidden
+    actionButton: ReactNode | false — custom left-side button (replaces the default attach button; false hides it)
+    emojiSet: 'native' | 'apple' | 'google' | 'twitter' | 'facebook' (default: 'native')
+    onSchedule: (message: RichChatInputMessage, scheduledAt: Date) => void — if set, a schedule button appears next to send
+    sendOptions: Array<{ label: string; icon?: ComponentType<{ className?: string }>; onSelect: () => void }> — split-send dropdown options
 
-ChatToolbarItem: 'bold' | 'italic' | 'underline' | 'strike' | 'highlight' | 'code' | 'bulletList' | 'orderedList' | 'mention' | 'emoji' | 'attach' | 'slash'
+RichChatInputMessage: { html: string; plainText: string; attachments?: Array<{ url: string; name: string; size: number; type: string }>; voiceNote?: { blob: Blob; duration: number } }
+
+ChatToolbarItem: 'bold' | 'italic' | 'underline' | 'strike' | 'highlight' | 'code' | 'bulletList' | 'orderedList' | 'blockquote' | 'link' | 'mention' | 'emoji' | 'slash'
 
 MentionItem: { id: string; label: string; avatar?: string }
 
@@ -43,11 +54,12 @@ SlashCommandGroup: { label: string; commands: SlashCommand[] }
 - `compact` (default) — 2-3 lines, inline toolbar
 - `expanded` — 5+ lines, always-visible toolbar, suited for AI prompts
 - `minimal` — single line, toolbar appears on focus
+- `inline` — 40px min-height, no toolbar; for tight inline composers
 
 ## Example
 ```jsx
 <RichChatInput
-  onSubmit={(html, text) => sendMessage(html)}
+  onSubmit={(message) => sendMessage(message.html)}
   mentions={teamMembers}
   onFileUpload={uploadFile}
   slashCommands={[{ label: 'Actions', commands: [...] }]}

--- a/packages/core/docs/components/composed/simple-tooltip.md
+++ b/packages/core/docs/components/composed/simple-tooltip.md
@@ -24,7 +24,7 @@
 ## Composability
 - **One-liner Tooltip** — wraps TooltipProvider + Tooltip + TooltipTrigger + TooltipContent so consumers don't have to manually compose them for a simple label.
 - **When to use:** 90% of tooltip use cases (icon-only button labels, abbreviated text expansions, secondary info). Use the ui/Tooltip compound for advanced cases (controlled open, nested triggers, custom animations).
-- **Auto-provides its own TooltipProvider** — safe to drop anywhere. You can still wrap a broader TooltipProvider at layout level for shared `delayDuration`; SimpleTooltip respects it if present.
+- **Always mounts its own TooltipProvider** — safe to drop anywhere. Note it does NOT inherit an ancestor `TooltipProvider`'s `delayDuration`; its own `delayDuration` prop (default 300ms) always wins. Set it per-tooltip via the prop.
 - **Content must be inert** — same rule as ui/Tooltip. For interactive popped content, use Popover or HoverCard.
 - **Pairs with IconButton** — the canonical pattern for labeled icon buttons.
 

--- a/packages/core/docs/components/shell/app-command-palette.md
+++ b/packages/core/docs/components/shell/app-command-palette.md
@@ -23,7 +23,7 @@ AppCommandPaletteUser: { name: string, role?: string }
 ## Example
 ```jsx
 <AppCommandPalette
-  user={{ name: 'John', role: 'admin' }}
+  user={{ name: 'John', role: 'Admin' }}
   isAdmin={true}
   onNavigate={(path) => router.push(path)}
   searchResults={results}
@@ -42,6 +42,7 @@ AppCommandPaletteUser: { name: string, role?: string }
 ## Gotchas
 - Uses CommandRegistry context for page navigation items (see CommandRegistryProvider)
 - `isAdmin` takes precedence over `user.role` for showing admin command groups
+- **Role detection is case-sensitive:** `user.role` only auto-enables admin groups when it is exactly `'Admin'` or `'SuperAdmin'`. `'admin'` (lowercase) silently shows nothing — pass `isAdmin` explicitly if your role strings differ.
 - Should be placed at the app root level, typically alongside TopBar
 
 ## Changes

--- a/packages/core/docs/components/shell/command-registry.md
+++ b/packages/core/docs/components/shell/command-registry.md
@@ -13,7 +13,7 @@ Exports: CommandRegistryProvider, useCommandRegistry
     registry: CommandRegistry (REQUIRED)
 
 CommandRegistry: { pages: CommandPageItem[], adminPages: CommandPageItem[] }
-CommandPageItem: { id: string, label: string, icon: ReactNode, path: string, keywords?: string[] }
+CommandPageItem: { id: string, label: string, icon: IconInput, path: string, keywords?: string[] }
 
 ### useCommandRegistry hook
     Returns: CommandRegistry | null
@@ -41,7 +41,7 @@ CommandPageItem: { id: string, label: string, icon: ReactNode, path: string, key
 ## Composability
 - **Context provider for AppCommandPalette.** Registers page-level navigation items that the command palette surfaces as commands.
 - **Place at app root** — wrap both AppCommandPalette and the rest of the app inside `<CommandRegistryProvider>`. Positioning matters: any AppCommandPalette outside the provider gets `useCommandRegistry() === null` and falls back to minimal functionality.
-- **Separation of pages vs adminPages** — the palette filters based on user role / `isAdmin` flag. Keep admin-only routes in the adminPages array to avoid leaking them to regular users.
+- **Separation of pages vs adminPages** — this is an ORGANIZATIONAL split, not access control. The component does NOT enforce anything: YOU populate `adminPages` conditionally (e.g. only when the signed-in user is an admin). Anything you put in `adminPages` is still shipped to the client — do real authorization on the server, not here.
 - **useCommandRegistry()** is the consumer hook — returns the full registry or null. Use in your own command-aware components (e.g. a Spotlight-style keyboard-search embed elsewhere in the app).
 - **Works with LinkProvider** — CommandPaletteItems navigate via `onNavigate` prop on AppCommandPalette, which routes to your framework's Link component.
 

--- a/packages/core/docs/components/ui/search-input.md
+++ b/packages/core/docs/components/ui/search-input.md
@@ -5,7 +5,7 @@
 - Category: ui
 
 ## Props
-    size: "sm" | "md" | "lg"
+    size: "xs" | "sm" | "md" | "lg"
     loading: boolean (shows spinner instead of clear button)
     onClear: () => void (shows X button when value is non-empty)
     value: string
@@ -31,7 +31,7 @@
 - **`onClear` makes the X button appear** only when `value` is non-empty. Pair them so users can reset.
 - **`loading={true}` swaps the clear button for a spinner** with `aria-busy="true"` on the input — useful for debounced/async search.
 - Doesn't auto-consume FormField (no `state` prop) — wrap a regular Input inside FormField for validated search fields.
-- Keyboard: Escape auto-triggers `onClear` when wired (handled via `type="search"`'s native behavior on most browsers).
+- Keyboard: Escape is NOT wired to clear (the input is not `type="search"`). Reset via the X button, or handle Escape yourself and call your `value` setter.
 
 ## Gotchas
 - HTML native "size" attribute is excluded — use CSS width instead

--- a/packages/core/docs/components/ui/slider.md
+++ b/packages/core/docs/components/ui/slider.md
@@ -22,14 +22,14 @@
 - Radix Slider primitive — keyboard navigation (arrow keys, Home/End, PageUp/PageDown) pre-wired.
 - **Value is always an array** — single-thumb: `[50]`; range: `[25, 75]`. Don't pass a plain number.
 - **Multi-thumb range:** Pass `[start, end]` — renders two thumbs that can cross each other by default. Use `minStepsBetweenThumbs` to enforce a gap.
-- **FormField:** Slider does NOT auto-consume FormField state. No validation UX — sliders usually don't need it (values are always valid by construction).
+- **FormField:** Slider consumes FormField for a11y wiring (`aria-invalid` / `aria-describedby` / `aria-required`) but renders no visual validation treatment — values are valid by construction, so there's no error UX to hand-wire.
 - **No label pairing via Label** — use `aria-label` or `aria-labelledby` directly on the Slider. The thumb is the focusable/labeled element.
 - Not portal-rendered — inline; overflow rules of parents apply.
 
 ## Gotchas
 - value is number[] (array), not a single number
 - Multi-thumb: Pass array `defaultValue={[25, 75]}` for range sliders — renders one thumb per value
-- Slider does NOT auto-consume FormField — sliders don't have validation state visuals by design
+- Slider consumes FormField for a11y wiring (aria-invalid/describedby/required) but shows no validation visuals by design — don't hand-wire what it already does
 
 ## Changes
 ### v0.18.0

--- a/packages/core/src/shell/Introduction.mdx
+++ b/packages/core/src/shell/Introduction.mdx
@@ -28,7 +28,7 @@ import { TopBar, BottomNavbar } from '@devalok/shilp-sutra/shell'
 | Component | Description |
 |-----------|-------------|
 | **AppCommandPalette** | App-level command palette triggered by Cmd+K / Ctrl+K |
-| **CommandRegistryProvider** | Programmatic command management (register, unregister, search) |
+| **CommandRegistryProvider** | Supplies the page/adminPage command registry consumed by AppCommandPalette; read it with `useCommandRegistry()` |
 
 ### Notifications
 


### PR DESCRIPTION
Finish-bar-v2 audit **S3 batch** — six shipped docs claimed APIs/behaviors the source contradicts (actively misleads AI agents). Corrected against source.

- **rich-chat-input (P0)** — prop table was materially wrong (`onSubmit` signature, phantom `maxRows`, missing `inline` + 9 props, wrong `ChatToolbarItem`). Regenerated from the interface.
- **slider** — falsely said it does NOT consume FormField; it does (a11y wiring).
- **search-input** — false Escape-to-clear claim removed; added shipped `xs` size.
- **command-registry** — `icon` is `IconInput`; pages/adminPages is organizational, not access-control; fixed phantom register/unregister/search API.
- **app-command-palette** — role detection is case-sensitive (`Admin`/`SuperAdmin`); fixed example + documented footgun.
- **simple-tooltip** — always mounts its own provider; doesn't inherit ancestor `delayDuration`.

Docs-only (patch). Each verified against source; core build + manifest regen clean.