### PR TITLE
fix(release): 0.54.0 hardening from Karm migration feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ transpilePackages: ['@devalok/shilp-sutra'],
 import { Button, Dialog, Input } from '@devalok/shilp-sutra/ui'
 import { PageHeader } from '@devalok/shilp-sutra/composed'
 import { DatePicker } from '@devalok/shilp-sutra/composed/date-picker'
-import { AppSidebar, TopBar } from '@devalok/shilp-sutra/shell'
+import { TopBar } from '@devalok/shilp-sutra/shell'
 ```
 
 > **Upgrading from 0.36 or earlier?** Read [MIGRATION.md](./MIGRATION.md#v0370--tailwind-4-css-first-migration).

--- a/apps/site/scripts/build-registry.mjs
+++ b/apps/site/scripts/build-registry.mjs
@@ -11,7 +11,14 @@
  * Hybrid model (validated with a real `shadcn add`): preset files import
  * primitives from the npm package @devalok/shilp-sutra, so registryDependencies
  * is empty and those imports pass through shadcn's @/-scoped rewrite untouched.
- * @devalok/shilp-sutra is pinned caret-to-minor (fixes flow, breaking major held).
+ *
+ * Dependency PIN (see pinFor):
+ *  - 0.x (beta): BARE specifier (no version). A caret is wrong here — `^0.53.0`
+ *    EXCLUDES 0.54.0 on 0.x, so it would fight a consumer upgrading to the version
+ *    that ships the preset; and the site deploys from `main`, which can lead npm,
+ *    so a version pin can demand an unpublished version → `shadcn add` hard-fails.
+ *    Bare installs latest / keeps the consumer's existing copy — always resolvable.
+ *  - >=1.x (stable): `^{major}.0.0` — patches + minors flow, breaking major held.
  */
 import { promises as fs } from 'node:fs'
 import { dirname, join } from 'node:path'
@@ -40,9 +47,15 @@ async function coreVersion() {
   return pkg.version
 }
 
-function caretMinor(version) {
-  const [maj, min] = version.split('.')
-  return `^${maj}.${min}.0`
+/**
+ * The version constraint to attach to @devalok/shilp-sutra in a preset's deps.
+ * Returns '' (bare, no constraint) on 0.x — see the file header for why a caret
+ * is broken there. On >=1.x, caret-major.
+ */
+function pinFor(version) {
+  const [maj] = version.split('.')
+  if (maj === '0') return '' // beta: bare specifier — always resolvable
+  return `^${maj}.0.0`
 }
 
 function packageOf(spec) {
@@ -95,7 +108,10 @@ async function main() {
     const { deps, core } = analyzeImports(content, `${slug}/preset.tsx`)
 
     const dependencies = []
-    if (core) dependencies.push(`@devalok/shilp-sutra@${caretMinor(version)}`)
+    if (core) {
+      const pin = pinFor(version)
+      dependencies.push(pin ? `@devalok/shilp-sutra@${pin}` : '@devalok/shilp-sutra')
+    }
     dependencies.push(...[...deps].sort())
 
     const item = {

--- a/docs/plans/2026-07-25-preset-library-registry.md
+++ b/docs/plans/2026-07-25-preset-library-registry.md
@@ -144,3 +144,22 @@ coordinated migration. MCP-delivered preset makes it AI-automatable.
 7. **`target` form**: `components/devalok/<slug>/…` vs `@components/…` alias-token (spike decides).
 8. **`shadcn build` oracle in CI?** (rec yes, drift job only.)
 9. Every preset = brand output → `setu_check` + `check_slop` gate in Phase-1 "done".
+
+---
+
+## Release order + pin (0.x) — learned from the Karm migration (2026-07-25)
+
+- **Registry dep pin is BARE on 0.x** (`build-registry.mjs` `pinFor`). A caret is
+  broken in beta: `^0.53.0` EXCLUDES 0.54.0, so it fights a consumer upgrading to
+  the version that ships the preset; and the site deploys from `main` (which can
+  lead npm), so a version pin can demand an unpublished version → `shadcn add`
+  hard-fails (Phase-0 spike recorded exactly this). Bare = latest/keep-existing,
+  always resolvable. Switch to `^{major}.0.0` only at 1.0.
+- **Release order:** publish npm FIRST, then redeploy `apps/site`. With the bare pin
+  this is no longer a hard-fail (bare always resolves), but redeploying after the
+  publish keeps `meta.shilpSutraVersion` in the registry matched to the published
+  version instead of leading it.
+- **Deprecation cycle collapsed to zero published releases** for AppSidebar
+  (0.53.0 undeprecated → 0.54.0 removed). Deliberate for a 0.x beta with one
+  coordinated consumer; recorded in BREAKING.json 0.54.0 notes. Post-1.0 removals
+  get a real deprecate→remove window.

--- a/packages/core/BREAKING.json
+++ b/packages/core/BREAKING.json
@@ -347,7 +347,8 @@
       ],
       "notes": [
         "The Sidebar PRIMITIVES (@devalok/shilp-sutra/ui/sidebar — Sidebar, SidebarProvider, SidebarMenu, SidebarMenuSub*, SidebarMenuBadge, SidebarGroupAction, etc.) are unchanged. Only the config-driven AppSidebar wrapper on top of them is removed.",
-        "Fastest migration: `npx shadcn@latest add @devalok/sidebar-app`, then replace <AppSidebar navGroups={…} user={…} currentPath={…} /> with the pasted <SidebarApp/>, wiring your router Link + active path."
+        "Fastest migration: `npx shadcn@latest add @devalok/sidebar-app`, then replace <AppSidebar navGroups={…} user={…} currentPath={…} /> with the pasted <SidebarApp/>, wiring your router Link + active path. Composing @devalok/shilp-sutra/ui/sidebar directly is equally valid and needs no registry.",
+        "Deprecation cycle: no PUBLISHED version carried an @deprecated AppSidebar — 0.53.0 shipped it undeprecated, 0.54.0 removes it. The deprecation marker existed only within the unreleased 0.54.0 line. This is a deliberate call for a 0.x beta with a single coordinated consumer (breaking changes ship in 0.x minors); a post-1.0 removal would get a real deprecate→remove window."
       ]
     }
   }


### PR DESCRIPTION
Pre-release fixes surfaced by the Karm AppSidebar migration agent.

- **Registry dep pin broken on 0.x (blocker):** `build-registry.mjs` emitted `@devalok/shilp-sutra@^{maj}.{min}.0`; on 0.x a caret excludes the next minor (`^0.53.0` ⊅ 0.54.0), so `shadcn add` installed a conflicting version, and since the site deploys from main (can lead npm) the pin could demand an unpublished version → hard-fail. Fix: `pinFor()` → **bare** on 0.x (always resolvable), `^{major}.0.0` at >=1.x. Registry regenerated → deps `["@devalok/shilp-sutra", "@tabler/icons-react"]`.
- **README.md** front-page sample dropped the removed `AppSidebar` import.
- **BREAKING.json 0.54.0:** recorded the zero-published-deprecation decision + that composing `ui/sidebar` directly needs no registry.
- **Plan doc:** release order (publish npm → redeploy site) + 0.x pin rationale.

MIGRATION merge-order trap: already resolved (#222 on main; stub is only-if-missing + idempotent).

**After merge:** apps/site needs a redeploy so the live registry serves the bare pin.