### PR TITLE
fix(bulk-action-bar): ARIA toolbar keyboard model + a11y (audit)

### DIFF
--- a/.changeset/bulk-action-bar-toolbar.md
+++ b/.changeset/bulk-action-bar-toolbar.md
@@ -1,0 +1,24 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+fix(bulk-action-bar): ARIA toolbar keyboard model + a11y + composability (audit)
+
+Non-breaking (additive props). Fixes the P0 keyboard trap + P1/P2 gaps.
+
+- **a11y (P0):** roving `tabIndex` now sits on the real `<Button>`s, not a wrapper
+  `<div>`, so keyboard users can **activate** actions (Enter/Space), not just move
+  the ring past them. Single tab stop with Arrow/Home/End roving across ALL controls
+  (Select-all, actions, Clear) per the ARIA Toolbar model. Locked by a new
+  arrow-then-Enter regression test.
+- **a11y (P1):** inline confirmation is `role="group"` + `aria-live="assertive"`;
+  focus moves to Confirm on open and restores to the action on Cancel/Escape.
+- **RTL (P1):** logical positioning (`start-1/2`) + Arrow Left/Right mirrored under
+  `dir="rtl"`.
+- **api (P1):** `forwardRef` + spreads `HTMLAttributes`; action `color` widened to
+  the full Button union (`accent | error | success | warning | info | neutral`) —
+  was 2 of 6. New additive `loading` per-action pending spinner.
+- **motion (P2):** `springs.smooth` for the slide + `useReducedMotion` guard
+  (opacity-only under `prefers-reduced-motion`).
+- **docs:** prop table corrected to match source (`icon = IconInput`, full color
+  union, `totalCount`/`onSelectAll`/`loading`/confirm props).

--- a/packages/core/docs/components/composed/bulk-action-bar.md
+++ b/packages/core/docs/components/composed/bulk-action-bar.md
@@ -9,14 +9,20 @@
     count: number (number of selected items — displayed in badge)
     onClearSelection: () => void
     actions: BulkActionBarAction[]
+    totalCount: number (optional — total selectable items; enables "Select all")
+    onSelectAll: () => void (optional — called by the "Select all" control)
     className: string
+    ...div attributes (forwardRef to the toolbar div; HTMLAttributes spread)
 
 ### BulkActionBarAction
     label: string
-    icon: ComponentType<{ className?: string }> (optional icon component)
+    icon: IconInput (optional — any icon component or element)
     onClick: () => void
-    color: "default" | "error"
-    disabled: boolean
+    color: "accent" | "error" | "success" | "warning" | "info" | "neutral" (default: "accent")
+    disabled: boolean (optional)
+    loading: boolean (optional — pending spinner on the action)
+    requiresConfirmation: boolean (optional — inline confirm before executing)
+    confirmMessage: string (optional — default "Are you sure?")
 
 ## Defaults
     (no optional props with defaults)

--- a/packages/core/src/BelowBarBeforeAfter.stories.tsx
+++ b/packages/core/src/BelowBarBeforeAfter.stories.tsx
@@ -145,6 +145,25 @@ export const BeforeAfter: Story = {
             'P2: empty users renders nothing (was a focusable "0 team members"); max clamped ≥1; ring-offset follows borderColor (no seam on surface-base).',
           ]}
         />
+
+        {/* ── bulk-action-bar: ARIA toolbar keyboard model (P0) ── */}
+        <Row
+          name="BulkActionBar — ARIA toolbar keyboard model"
+          verdict="Audit P0: keyboard trap — roving tabindex sat on a wrapper div while the real Button was tabindex=-1, so actions were unreachable by keyboard. (Floating portal — see it live in the gallery; the win is behavioral.)"
+          after={
+            <Text variant="body-sm" className="text-surface-fg-muted">
+              Single tab stop → Arrow/Home/End rove across Select-all + actions + Clear, focus lands on the real buttons, Enter/Space activate. Locked by a new arrow-then-Enter test.
+            </Text>
+          }
+          changes={[
+            'P0 a11y: roving tabindex now on the actual <Button>s (was on wrapper divs) — arrow to an action, Enter activates it. Single tab stop across ALL controls (Select-all, actions, Clear), per the React-Aria Toolbar model.',
+            'P1 a11y: inline confirm is role="group" + aria-live="assertive"; focus moves to Confirm on open, restores to the action on Cancel/Escape.',
+            'P1 RTL: logical positioning (start-1/2) + Arrow Left/Right mirrored under dir="rtl".',
+            'P1 api: forwardRef + spreads HTMLAttributes; action color widened to the full Button union (was 2 of 6).',
+            'P2 state: per-action loading spinner; P2 motion: springs.smooth for the slide + reduced-motion guard (opacity-only under prefers-reduced-motion).',
+            'Docs corrected: prop table now matches source (icon = IconInput, full color union, +totalCount/onSelectAll/loading/confirm props).',
+          ]}
+        />
       </div>
     </div>
   ),

--- a/packages/core/src/composed/bulk-action-bar.test.tsx
+++ b/packages/core/src/composed/bulk-action-bar.test.tsx
@@ -53,6 +53,32 @@ describe('BulkActionBar', () => {
     expect(screen.queryByRole('toolbar')).not.toBeInTheDocument()
   })
 
+  it('roving focus + Enter activates the action (keyboard — P0 regression)', async () => {
+    const onArchive = vi.fn()
+    const onDelete = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <BulkActionBar
+        show
+        count={3}
+        onClearSelection={vi.fn()}
+        actions={[
+          { label: 'Archive', onClick: onArchive },
+          { label: 'Delete', onClick: onDelete, color: 'error' },
+        ]}
+      />,
+    )
+    // Single tab stop → focus lands on the first real button (not a wrapper div).
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'Archive' })).toHaveFocus()
+    // Roving with arrows, then activation with Enter.
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveFocus()
+    await user.keyboard('{Enter}')
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onArchive).not.toHaveBeenCalled()
+  })
+
   it('renders action buttons', () => {
     render(
       <BulkActionBar

--- a/packages/core/src/composed/bulk-action-bar.tsx
+++ b/packages/core/src/composed/bulk-action-bar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { IconX } from '@tabler/icons-react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 
@@ -12,216 +12,199 @@ import type { IconInput } from '../ui/lib/icon-input'
 import { springs } from '../ui/lib/motion'
 import { cn } from '../ui/lib/utils'
 
-// ============================================================
-// Types
-// ============================================================
+type ButtonColor = React.ComponentProps<typeof Button>['color']
 
 export interface BulkActionBarAction {
   label: string
   icon?: IconInput
   onClick: () => void
-  color?: 'accent' | 'error'
+  /** Any Button color. @default 'accent' (or 'error' for destructive). */
+  color?: ButtonColor
   disabled?: boolean
-  /** Show inline confirmation before executing the action */
+  /** Show a pending spinner on the action (e.g. slow bulk op in flight). */
+  loading?: boolean
+  /** Show inline confirmation before executing the action. */
   requiresConfirmation?: boolean
-  /** Custom confirmation message @default 'Are you sure?' */
+  /** Custom confirmation message. @default 'Are you sure?' */
   confirmMessage?: string
 }
 
-export interface BulkActionBarProps {
+export interface BulkActionBarProps
+  extends Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    // Keys whose types collide with framer-motion's HTMLMotionProps.
+    'children' | 'color' | 'onDrag' | 'onDragStart' | 'onDragEnd' | 'onAnimationStart' | 'onAnimationEnd' | 'onAnimationIteration' | 'style'
+  > {
   show: boolean
   count: number
   onClearSelection: () => void
   actions: BulkActionBarAction[]
-  /** Total number of items available for selection */
+  /** Total items available for selection (enables "Select all"). */
   totalCount?: number
-  /** Called when user clicks "Select all" */
+  /** Called when the user clicks "Select all". */
   onSelectAll?: () => void
-  className?: string
 }
 
-// ============================================================
-// ActionButton — handles inline confirmation
-// ============================================================
+/**
+ * BulkActionBar — floating selection toolbar. Follows the ARIA toolbar model:
+ * a single tab stop with roving focus (Arrow keys / Home / End) across ALL
+ * controls (Select-all, actions, Clear), focus landing on the real buttons so
+ * Enter/Space activate them. Arrow direction mirrors under `dir="rtl"`. Escape
+ * clears the selection (or cancels a pending confirmation).
+ */
+const BulkActionBar = React.forwardRef<HTMLDivElement, BulkActionBarProps>(
+  function BulkActionBar(
+    { show, count, onClearSelection, actions, totalCount, onSelectAll, className, ...props },
+    forwardedRef,
+  ) {
+    const reduced = useReducedMotion()
+    const [mounted, setMounted] = React.useState(false)
+    const [focusedIndex, setFocusedIndex] = React.useState(0)
+    const [confirming, setConfirming] = React.useState<number | null>(null)
+    const controlRefs = React.useRef<Array<HTMLButtonElement | null>>([])
+    const confirmRef = React.useRef<HTMLButtonElement | null>(null)
 
-const ActionButton = React.forwardRef<HTMLDivElement, { action: BulkActionBarAction; tabIndex?: number }>(function ActionButton({ action, tabIndex }, ref) {
-  const [confirming, setConfirming] = React.useState(false)
+    const hasSelectAll = totalCount != null && totalCount > count && !!onSelectAll
+    const selectAllOffset = hasSelectAll ? 1 : 0
+    const total = selectAllOffset + actions.length + 1 // + Clear
 
-  if (confirming) {
-    return (
-      <motion.div
-        ref={ref}
-        initial={{ opacity: 0, scale: 0.95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.95 }}
-        transition={springs.snappy}
-        className="flex items-center gap-ds-02"
-        tabIndex={tabIndex}
-      >
-        <span className="text-body-sm text-surface-fg-muted whitespace-nowrap">
-          {action.confirmMessage ?? 'Are you sure?'}
-        </span>
-        <Button
-          variant="solid"
-          size="sm"
-          color="error"
-          onClick={() => {
-            setConfirming(false)
-            action.onClick()
-          }}
-        >
-          Confirm
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setConfirming(false)}
-        >
-          Cancel
-        </Button>
-      </motion.div>
-    )
-  }
+    React.useEffect(() => { setMounted(true) }, [])
+    React.useEffect(() => { setFocusedIndex(0); setConfirming(null) }, [actions.length])
+    // Move focus to Confirm when a confirmation opens.
+    React.useEffect(() => {
+      if (confirming != null) confirmRef.current?.focus()
+    }, [confirming])
 
-  return (
-    <motion.div
-      ref={ref}
-      initial={{ opacity: 0, scale: 0.95 }}
-      animate={{ opacity: 1, scale: 1 }}
-      exit={{ opacity: 0, scale: 0.95 }}
-      transition={springs.snappy}
-      tabIndex={tabIndex}
-    >
-      <Button
-        variant="ghost"
-        size="sm"
-        color={action.color === 'error' ? 'error' : 'accent'}
-        disabled={action.disabled}
-        onClick={action.requiresConfirmation ? () => setConfirming(true) : action.onClick}
-        startIcon={action.icon ?? undefined}
-        tabIndex={-1}
-      >
-        {action.label}
-      </Button>
-    </motion.div>
-  )
-})
-
-// ============================================================
-// BulkActionBar
-// ============================================================
-
-function BulkActionBar({
-  show,
-  count,
-  onClearSelection,
-  actions,
-  totalCount,
-  onSelectAll,
-  className,
-}: BulkActionBarProps) {
-  const [mounted, setMounted] = React.useState(false)
-  const [focusedIndex, setFocusedIndex] = React.useState(0)
-  const actionRefs = React.useRef<(HTMLDivElement | null)[]>([])
-
-  // Reset focused index when actions change
-  React.useEffect(() => {
-    setFocusedIndex(0)
-  }, [actions.length])
-
-  React.useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Escape') {
-      e.preventDefault()
-      onClearSelection()
-      return
+    const focusAt = (i: number) => {
+      const clamped = (i + total) % total
+      setFocusedIndex(clamped)
+      controlRefs.current[clamped]?.focus()
     }
 
-    const count = actions.length
-    if (count === 0) return
-
-    if (e.key === 'ArrowRight') {
-      e.preventDefault()
-      const next = (focusedIndex + 1) % count
-      setFocusedIndex(next)
-      actionRefs.current[next]?.focus()
-    } else if (e.key === 'ArrowLeft') {
-      e.preventDefault()
-      const prev = (focusedIndex - 1 + count) % count
-      setFocusedIndex(prev)
-      actionRefs.current[prev]?.focus()
-    } else if (e.key === 'Home') {
-      e.preventDefault()
-      setFocusedIndex(0)
-      actionRefs.current[0]?.focus()
-    } else if (e.key === 'End') {
-      e.preventDefault()
-      const last = count - 1
-      setFocusedIndex(last)
-      actionRefs.current[last]?.focus()
+    function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        if (confirming != null) { setConfirming(null); focusAt(focusedIndex) }
+        else onClearSelection()
+        return
+      }
+      if (confirming != null) return // roving suspended during confirm
+      const rtl = e.currentTarget.dir === 'rtl' || document.dir === 'rtl'
+      const fwd = rtl ? 'ArrowLeft' : 'ArrowRight'
+      const back = rtl ? 'ArrowRight' : 'ArrowLeft'
+      if (e.key === fwd) { e.preventDefault(); focusAt(focusedIndex + 1) }
+      else if (e.key === back) { e.preventDefault(); focusAt(focusedIndex - 1) }
+      else if (e.key === 'Home') { e.preventDefault(); focusAt(0) }
+      else if (e.key === 'End') { e.preventDefault(); focusAt(total - 1) }
     }
-  }
 
-  if (!mounted) return null
+    if (!mounted) return null
 
-  return createPortal(
-    <AnimatePresence>
-      {show && (
-        <motion.div
-          initial={{ y: 100, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 100, opacity: 0 }}
-          transition={springs.snappy}
-          className={cn(
-            'fixed bottom-ds-06 left-1/2 z-sticky -translate-x-1/2',
-            'flex items-center gap-ds-04 rounded-surface bg-surface-overlay px-ds-05 py-ds-03 shadow-floating',
-            className,
-          )}
-          role="toolbar"
-          aria-label={`${count} items selected`}
-          onKeyDown={handleKeyDown}
-        >
-          <Badge variant="solid" size="sm">
-            {count} selected
-          </Badge>
+    const slideTransition = reduced ? { duration: 0 } : springs.smooth
 
-          {totalCount != null && totalCount > count && onSelectAll && (
-            <Button variant="link" size="xs" onClick={onSelectAll}>
-              Select all {totalCount}
-            </Button>
-          )}
-
-          <div className="flex items-center gap-ds-02">
-            <AnimatePresence mode="popLayout">
-              {actions.map((action, i) => (
-                <ActionButton
-                  key={action.label}
-                  ref={(el: HTMLDivElement | null) => { actionRefs.current[i] = el }}
-                  action={action}
-                  tabIndex={i === focusedIndex ? 0 : -1}
-                />
-              ))}
-            </AnimatePresence>
-          </div>
-
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={onClearSelection}
-            aria-label="Clear selection"
+    return createPortal(
+      <AnimatePresence>
+        {show && (
+          <motion.div
+            ref={forwardedRef}
+            initial={reduced ? { opacity: 0 } : { y: 100, opacity: 0 }}
+            animate={reduced ? { opacity: 1 } : { y: 0, opacity: 1 }}
+            exit={reduced ? { opacity: 0 } : { y: 100, opacity: 0 }}
+            transition={slideTransition}
+            className={cn(
+              'fixed bottom-ds-06 start-1/2 z-sticky -translate-x-1/2',
+              'flex items-center gap-ds-04 rounded-surface bg-surface-overlay px-ds-05 py-ds-03 shadow-floating',
+              className,
+            )}
+            role="toolbar"
+            aria-label={`${count} items selected`}
+            onKeyDown={handleKeyDown}
+            {...props}
           >
-            <Icon icon={IconX} size="sm" />
-          </Button>
-        </motion.div>
-      )}
-    </AnimatePresence>,
-    document.body,
-  )
-}
+            <Badge variant="solid" size="sm">{count} selected</Badge>
 
+            {hasSelectAll && (
+              <Button
+                ref={(el) => { controlRefs.current[0] = el }}
+                variant="link"
+                size="xs"
+                tabIndex={focusedIndex === 0 ? 0 : -1}
+                onClick={onSelectAll}
+              >
+                Select all {totalCount}
+              </Button>
+            )}
+
+            <div className="flex items-center gap-ds-02">
+              {actions.map((action, i) => {
+                const controlIndex = selectAllOffset + i
+                const isConfirming = confirming === i
+                if (isConfirming) {
+                  return (
+                    <div
+                      key={action.label}
+                      role="group"
+                      aria-live="assertive"
+                      className="flex items-center gap-ds-02"
+                    >
+                      <span className="whitespace-nowrap text-body-sm text-surface-fg-muted">
+                        {action.confirmMessage ?? 'Are you sure?'}
+                      </span>
+                      <Button
+                        ref={confirmRef}
+                        variant="solid"
+                        size="sm"
+                        color={action.color === 'error' ? 'error' : (action.color ?? 'accent')}
+                        onClick={() => { setConfirming(null); action.onClick() }}
+                      >
+                        Confirm
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => { setConfirming(null); focusAt(controlIndex) }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  )
+                }
+                return (
+                  <Button
+                    key={action.label}
+                    ref={(el) => { controlRefs.current[controlIndex] = el }}
+                    variant="ghost"
+                    size="sm"
+                    color={action.color ?? 'accent'}
+                    disabled={action.disabled}
+                    loading={action.loading}
+                    startIcon={action.icon ?? undefined}
+                    tabIndex={focusedIndex === controlIndex ? 0 : -1}
+                    onClick={action.requiresConfirmation ? () => setConfirming(i) : action.onClick}
+                  >
+                    {action.label}
+                  </Button>
+                )
+              })}
+            </div>
+
+            <Button
+              ref={(el) => { controlRefs.current[total - 1] = el }}
+              variant="ghost"
+              size="icon-sm"
+              tabIndex={focusedIndex === total - 1 ? 0 : -1}
+              onClick={onClearSelection}
+              aria-label="Clear selection"
+            >
+              <Icon icon={IconX} size="sm" />
+            </Button>
+          </motion.div>
+        )}
+      </AnimatePresence>,
+      document.body,
+    )
+  },
+)
 BulkActionBar.displayName = 'BulkActionBar'
 
 export { BulkActionBar }


### PR DESCRIPTION
P0 keyboard trap fixed: roving tabindex now on the real `<Button>`s (was on wrapper divs; Button was `tabindex=-1` → actions unreachable). Single tab stop, arrow/home/end roving across Select-all + actions + Clear, Enter/Space activates. New arrow-then-Enter regression test. P1: confirm `role=group`+`aria-live`+focus mgmt; RTL logical pos + mirrored arrows; forwardRef + HTMLAttributes; full Button color union. P2: per-action loading; smooth slide + reduced-motion. Docs corrected. 9/9 green.