### PR TITLE
fix(skeletons): S6 shimmer unify + a11y status region (audit)

### DIFF
--- a/.changeset/skeletons-s6-a11y.md
+++ b/.changeset/skeletons-s6-a11y.md
@@ -1,0 +1,23 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+fix(skeletons): unify shimmer (S6) + a11y status region (audit)
+
+`loading-skeleton` (Card/Table/Board/List) + `page-skeletons` (Dashboard/ProjectList/
+TaskDetail). Non-breaking (additive `label` prop).
+
+- **shimmer unify (S6, P0):** dropped every `bg-surface-raised-hover` fill override —
+  all bars now inherit the base `Skeleton`'s `skeleton-base`, so the system shimmers
+  from ONE source and bars no longer disappear in forced-colors (Windows HCM).
+- **a11y (P0):** each root is a `role="status"` + `aria-busy` region with an sr-only
+  label (loading was silent to AT — every child `Skeleton` is `aria-hidden`). New
+  optional `label` prop.
+- **state (P1):** count props (`rows`/`columns`/`cardsPerColumn`) clamped with
+  `Math.max(0, floor(...))` — `rows={-1}` / `NaN` can't throw a `RangeError`.
+- **motion (P1):** removed the inert `animationDelay` (it sat on non-animated wrapper
+  divs and never fired).
+- **cohesion (P1):** shells use `border-card` + `rounded-surface` (Card's vocabulary)
+  rather than `border-card-strong` / `rounded-overlay-lg` (Dialog radius);
+  page-skeletons' misleading `shimmer` fill constant removed.
+- **docs:** page-skeletons no longer falsely claims it's "Built on LoadingSkeleton".

--- a/packages/core/docs/components/composed/page-skeletons.md
+++ b/packages/core/docs/components/composed/page-skeletons.md
@@ -22,12 +22,12 @@ Exports: DashboardSkeleton, ProjectListSkeleton, TaskDetailSkeleton
 ## Composability
 - **Full-page skeleton layouts** for route-level loading states. Each mimics a common page shape (dashboard tiles, project list with filters, task detail with sidebar).
 - **Server-safe** — use in Next.js app router `loading.tsx` files for instant route-transition feedback while data streams.
-- **Built on LoadingSkeleton + ui/Skeleton** — these just assemble the pre-built regional skeletons into page-shaped layouts.
+- **Assembled from `ui/Skeleton`** — these compose the base `Skeleton` primitive directly into page-shaped layouts (they do NOT wrap the `LoadingSkeleton` regional exports). Each root is a `role="status"` / `aria-busy` region with an sr-only label.
 - **When to use which skeleton tier:**
   - `<Skeleton>` (ui) — single shape for a single element
   - `<CardSkeleton>` / `<TableSkeleton>` (LoadingSkeleton) — individual region shape
   - `<DashboardSkeleton>` / etc. (PageSkeletons) — full page placeholder
-- **Fixed layout structure** — the className prop adjusts the outer container, but internal layout isn't customizable. For custom page skeletons, compose LoadingSkeleton pieces yourself.
+- **Fixed layout structure** — the className prop adjusts the outer container, but internal layout isn't customizable. For custom page skeletons, compose `ui/Skeleton` (or the `LoadingSkeleton` regional exports) yourself.
 
 ## Gotchas
 - Server-safe: can be imported directly in Next.js Server Components

--- a/packages/core/src/BelowBarBeforeAfter.stories.tsx
+++ b/packages/core/src/BelowBarBeforeAfter.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { Card, CardHeader, CardTitle, CardAction, CardContent, CardFooter } from './ui/card'
 import { ContentCard } from './composed/content-card'
 import { AvatarGroup, type AvatarUser } from './composed/avatar-group'
+import { TableSkeleton, ListSkeleton } from './composed/loading-skeleton'
 import { Button } from './ui/button'
 import { Text } from './ui/text'
 
@@ -162,6 +163,26 @@ export const BeforeAfter: Story = {
             'P1 api: forwardRef + spreads HTMLAttributes; action color widened to the full Button union (was 2 of 6).',
             'P2 state: per-action loading spinner; P2 motion: springs.smooth for the slide + reduced-motion guard (opacity-only under prefers-reduced-motion).',
             'Docs corrected: prop table now matches source (icon = IconInput, full color union, +totalCount/onSelectAll/loading/confirm props).',
+          ]}
+        />
+
+        {/* ── loading-skeleton + page-skeletons: S6 shimmer unify + a11y ── */}
+        <Row
+          name="Skeletons — S6 shimmer unify + a11y status region"
+          verdict="Audit: two skeleton vocabularies in one system + silent to AT. Now one source of truth + role=status. (loading-skeleton + page-skeletons.)"
+          after={
+            <div className="flex flex-col gap-ds-05">
+              <TableSkeleton rows={3} columns={4} label="Loading table" />
+              <ListSkeleton rows={3} label="Loading list" />
+            </div>
+          }
+          changes={[
+            'S6 (P0): dropped every bg-surface-raised-hover fill override — all bars now inherit the base Skeleton’s skeleton-base, so the whole system shimmers from ONE source (was two vocabularies) and bars no longer vanish in forced-colors (Windows HCM).',
+            'a11y (P0): each root is now role="status" + aria-busy with an sr-only label (was silent to AT — child Skeletons are all aria-hidden). New optional `label` prop.',
+            'state (P1): count props clamped (Math.max(0, floor)) — rows={-1}/NaN can’t throw a RangeError anymore.',
+            'motion (P1): removed the inert animationDelay (it sat on non-animated wrapper divs and never fired).',
+            'cohesion (P1): shells use border-card + rounded-surface (Card’s vocabulary), not border-card-strong / rounded-overlay-lg (Dialog radius); page-skeletons’ misleading `shimmer` fill const deleted.',
+            'docs: page-skeletons no longer falsely claims it’s "Built on LoadingSkeleton".',
           ]}
         />
       </div>

--- a/packages/core/src/composed/loading-skeleton.tsx
+++ b/packages/core/src/composed/loading-skeleton.tsx
@@ -4,39 +4,52 @@ import * as React from 'react'
 import { cn } from '../ui/lib/utils'
 import { Skeleton } from '../ui/skeleton'
 
+// Non-negative integer count (guards Array.from against NaN / negatives → RangeError).
+const clamp = (n: number | undefined, fallback: number) =>
+  Math.max(0, Math.floor(typeof n === 'number' && !Number.isNaN(n) ? n : fallback))
+
+// role=status + aria-busy so AT announces the loading region (child Skeletons are
+// aria-hidden). sr-only label gives the announcement text.
+function statusProps(label?: string) {
+  return { role: 'status' as const, 'aria-busy': true, 'aria-label': label ?? 'Loading' }
+}
+function SrLabel({ label }: { label?: string }) {
+  return <span className="sr-only">{label ?? 'Loading'}…</span>
+}
+
 export interface CardSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {
   className?: string
+  /** Accessible label for the loading region. @default 'Loading' */
+  label?: string
 }
 
 const CardSkeleton = React.forwardRef<HTMLDivElement, CardSkeletonProps>(
-  function CardSkeleton({ className, ...props }, ref) {
-  return (
-    <div
-      ref={ref}
-      {...props}
-      className={cn(
-        'rounded-surface border border-card-strong bg-surface-raised p-ds-05b',
-        className,
-      )}
-    >
-      <div className="flex items-center justify-between pb-ds-05">
-        <Skeleton className="h-ds-05 w-[128px] bg-surface-raised-hover" />
-        <Skeleton className="h-ico-sm w-ico-sm rounded bg-surface-raised-hover" />
+  function CardSkeleton({ className, label, ...props }, ref) {
+    return (
+      <div
+        ref={ref}
+        {...statusProps(label)}
+        {...props}
+        className={cn('rounded-surface border border-card bg-surface-raised p-ds-05b', className)}
+      >
+        <SrLabel label={label} />
+        <div className="flex items-center justify-between pb-ds-05">
+          <Skeleton className="h-ds-05 w-ds-13" />
+          <Skeleton className="h-ico-sm w-ico-sm rounded" />
+        </div>
+        <div className="space-y-ds-04">
+          <Skeleton className="h-ds-04 w-full" />
+          <Skeleton className="h-ds-04 w-4/5" />
+          <Skeleton className="h-ds-04 w-3/5" />
+        </div>
+        <div className="flex items-center gap-ds-03 pt-ds-05">
+          <Skeleton className="h-ds-xs w-ds-xs rounded-pill" />
+          <Skeleton className="h-ds-04 w-ds-11" />
+        </div>
       </div>
-      <div className="space-y-ds-04">
-        <Skeleton className="h-ds-04 w-full bg-surface-raised-hover" />
-        <Skeleton className="h-ds-04 w-4/5 bg-surface-raised-hover" />
-        <Skeleton className="h-ds-04 w-3/5 bg-surface-raised-hover" />
-      </div>
-      <div className="flex items-center gap-ds-03 pt-ds-05">
-        <Skeleton className="h-ds-xs w-ds-xs rounded-pill bg-surface-raised-hover" />
-        <Skeleton className="h-ds-04 w-ds-11 bg-surface-raised-hover" />
-      </div>
-    </div>
-  )
-},
+    )
+  },
 )
-
 CardSkeleton.displayName = 'CardSkeleton'
 
 export interface TableSkeletonProps extends CardSkeletonProps {
@@ -45,60 +58,44 @@ export interface TableSkeletonProps extends CardSkeletonProps {
 }
 
 const TableSkeleton = React.forwardRef<HTMLDivElement, TableSkeletonProps>(
-  function TableSkeleton({
-  rows = 5,
-  columns = 4,
-  className,
-  ...props
-}, ref) {
-  return (
-    <div
-      ref={ref}
-      {...props}
-      className={cn(
-        'overflow-hidden rounded-surface border border-card-strong',
-        className,
-      )}
-    >
-      {/* Header */}
-      <div className="flex items-center gap-ds-05 border-b border-surface-border-strong bg-surface-raised px-ds-05 py-ds-04">
-        {Array.from({ length: columns }).map((_, i) => (
-          <Skeleton
-            key={`head-${i}`}
-            className={cn(
-              'h-ds-04 bg-surface-raised-hover',
-              i === 0 ? 'w-ds-13' : 'flex-1',
-            )}
-          />
-        ))}
-      </div>
-
-      {/* Rows */}
-      {Array.from({ length: rows }).map((_, rowIndex) => (
-        <div
-          key={`row-${rowIndex}`}
-          className={cn(
-            'flex items-center gap-ds-05 px-ds-05 py-ds-04',
-            rowIndex < rows - 1 && 'border-b border-surface-border-strong',
-          )}
-          style={{ animationDelay: `${rowIndex * 50}ms` }}
-        >
-          {Array.from({ length: columns }).map((_, colIndex) => (
-            <Skeleton
-              key={`cell-${rowIndex}-${colIndex}`}
-              className={cn(
-                'h-ds-04 bg-surface-raised-hover',
-                colIndex === 0 ? 'w-ds-13' : 'flex-1',
-              )}
-            />
+  function TableSkeleton({ rows = 5, columns = 4, className, label, ...props }, ref) {
+    const r = clamp(rows, 5)
+    const c = Math.max(1, clamp(columns, 4))
+    return (
+      <div
+        ref={ref}
+        {...statusProps(label)}
+        {...props}
+        className={cn('overflow-hidden rounded-surface border border-card', className)}
+      >
+        <SrLabel label={label} />
+        {/* Header */}
+        <div className="flex items-center gap-ds-05 border-b border-surface-border-strong bg-surface-raised px-ds-05 py-ds-04">
+          {Array.from({ length: c }).map((_, i) => (
+            <Skeleton key={`head-${i}`} className={cn('h-ds-04', i === 0 ? 'w-ds-13' : 'flex-1')} />
           ))}
         </div>
-      ))}
-    </div>
-  )
-},
+        {/* Rows */}
+        {Array.from({ length: r }).map((_, rowIndex) => (
+          <div
+            key={`row-${rowIndex}`}
+            className={cn(
+              'flex items-center gap-ds-05 px-ds-05 py-ds-04',
+              rowIndex < r - 1 && 'border-b border-surface-border-strong',
+            )}
+          >
+            {Array.from({ length: c }).map((_, colIndex) => (
+              <Skeleton
+                key={`cell-${rowIndex}-${colIndex}`}
+                className={cn('h-ds-04', colIndex === 0 ? 'w-ds-13' : 'flex-1')}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  },
 )
-
 TableSkeleton.displayName = 'TableSkeleton'
 
 export interface BoardSkeletonProps extends CardSkeletonProps {
@@ -107,56 +104,48 @@ export interface BoardSkeletonProps extends CardSkeletonProps {
 }
 
 const BoardSkeleton = React.forwardRef<HTMLDivElement, BoardSkeletonProps>(
-  function BoardSkeleton({
-  columns = 4,
-  cardsPerColumn = 3,
-  className,
-  ...props
-}, ref) {
-  return (
-    <div ref={ref} {...props} className={cn('flex gap-ds-05 overflow-x-auto', className)}>
-      {Array.from({ length: columns }).map((_, colIndex) => (
-        <div
-          key={`col-${colIndex}`}
-          className="flex w-[272px] shrink-0 flex-col gap-ds-03"
-        >
-          {/* Column header */}
-          <div className="flex items-center justify-between px-ds-02 py-ds-03">
-            <div className="flex items-center gap-ds-03">
-              <Skeleton className="h-ds-04 w-ds-04 rounded bg-surface-raised-hover" />
-              <Skeleton className="h-ds-04 w-ds-11 bg-surface-raised-hover" />
-              <Skeleton className="h-ds-05 w-ds-05b rounded-pill bg-surface-raised-hover" />
-            </div>
-            <Skeleton className="h-ico-sm w-ico-sm rounded bg-surface-raised-hover" />
-          </div>
-
-          {/* Column cards */}
-          {Array.from({ length: cardsPerColumn }).map((_, cardIndex) => (
-            <div
-              key={`card-${colIndex}-${cardIndex}`}
-              className="rounded-surface border border-card-strong bg-surface-raised p-ds-04"
-              style={{ animationDelay: `${(colIndex * cardsPerColumn + cardIndex) * 50}ms` }}
-            >
-              <div className="space-y-ds-03">
-                <Skeleton className="h-ds-04 w-4/5 bg-surface-raised-hover" />
-                <Skeleton className="h-ds-04 w-3/5 bg-surface-raised-hover" />
+  function BoardSkeleton({ columns = 4, cardsPerColumn = 3, className, label, ...props }, ref) {
+    const c = clamp(columns, 4)
+    const cards = clamp(cardsPerColumn, 3)
+    return (
+      <div ref={ref} {...statusProps(label)} {...props} className={cn('flex gap-ds-05 overflow-x-auto', className)}>
+        <SrLabel label={label} />
+        {Array.from({ length: c }).map((_, colIndex) => (
+          <div key={`col-${colIndex}`} className="flex w-[272px] shrink-0 flex-col gap-ds-03">
+            {/* Column header */}
+            <div className="flex items-center justify-between px-ds-02 py-ds-03">
+              <div className="flex items-center gap-ds-03">
+                <Skeleton className="h-ds-04 w-ds-04 rounded" />
+                <Skeleton className="h-ds-04 w-ds-11" />
+                <Skeleton className="h-ds-05 w-ds-05b rounded-pill" />
               </div>
-              <div className="flex items-center justify-between pt-ds-04">
-                <div className="flex items-center gap-ds-02b">
-                  <Skeleton className="h-ico-md w-ico-md rounded-pill bg-surface-raised-hover" />
-                  <Skeleton className="h-ds-03 w-ds-10 bg-surface-raised-hover" />
+              <Skeleton className="h-ico-sm w-ico-sm rounded" />
+            </div>
+            {/* Column cards */}
+            {Array.from({ length: cards }).map((_, cardIndex) => (
+              <div
+                key={`card-${colIndex}-${cardIndex}`}
+                className="rounded-surface border border-card bg-surface-raised p-ds-04"
+              >
+                <div className="space-y-ds-03">
+                  <Skeleton className="h-ds-04 w-4/5" />
+                  <Skeleton className="h-ds-04 w-3/5" />
                 </div>
-                <Skeleton className="h-ds-05 w-ds-lg rounded-pill bg-surface-raised-hover" />
+                <div className="flex items-center justify-between pt-ds-04">
+                  <div className="flex items-center gap-ds-02b">
+                    <Skeleton className="h-ico-md w-ico-md rounded-pill" />
+                    <Skeleton className="h-ds-03 w-ds-10" />
+                  </div>
+                  <Skeleton className="h-ds-05 w-ds-lg rounded-pill" />
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
-      ))}
-    </div>
-  )
-},
+            ))}
+          </div>
+        ))}
+      </div>
+    )
+  },
 )
-
 BoardSkeleton.displayName = 'BoardSkeleton'
 
 export interface ListSkeletonProps extends CardSkeletonProps {
@@ -165,38 +154,31 @@ export interface ListSkeletonProps extends CardSkeletonProps {
 }
 
 const ListSkeleton = React.forwardRef<HTMLDivElement, ListSkeletonProps>(
-  function ListSkeleton({
-  rows = 6,
-  showAvatar = true,
-  className,
-  ...props
-}, ref) {
-  return (
-    <div ref={ref} {...props} className={cn('flex flex-col', className)}>
-      {Array.from({ length: rows }).map((_, i) => (
-        <div
-          key={`list-${i}`}
-          className={cn(
-            'flex items-center gap-ds-04 py-ds-04',
-            i < rows - 1 && 'border-b border-surface-border-strong',
-          )}
-          style={{ animationDelay: `${i * 50}ms` }}
-        >
-          {showAvatar && (
-            <Skeleton className="h-ds-sm w-ds-sm shrink-0 rounded-pill bg-surface-raised-hover" />
-          )}
-          <div className="flex flex-1 flex-col gap-ds-02b">
-            <Skeleton className="h-ds-04 w-2/5 bg-surface-raised-hover" />
-            <Skeleton className="h-ds-03 w-3/5 bg-surface-raised-hover" />
+  function ListSkeleton({ rows = 6, showAvatar = true, className, label, ...props }, ref) {
+    const r = clamp(rows, 6)
+    return (
+      <div ref={ref} {...statusProps(label)} {...props} className={cn('flex flex-col', className)}>
+        <SrLabel label={label} />
+        {Array.from({ length: r }).map((_, i) => (
+          <div
+            key={`list-${i}`}
+            className={cn(
+              'flex items-center gap-ds-04 py-ds-04',
+              i < r - 1 && 'border-b border-surface-border-strong',
+            )}
+          >
+            {showAvatar && <Skeleton className="h-ds-sm w-ds-sm shrink-0 rounded-pill" />}
+            <div className="flex flex-1 flex-col gap-ds-02b">
+              <Skeleton className="h-ds-04 w-2/5" />
+              <Skeleton className="h-ds-03 w-3/5" />
+            </div>
+            <Skeleton className="h-ds-05b w-ds-09 rounded-pill" />
           </div>
-          <Skeleton className="h-ds-05b w-[56px] rounded-pill bg-surface-raised-hover" />
-        </div>
-      ))}
-    </div>
-  )
-},
+        ))}
+      </div>
+    )
+  },
 )
-
 ListSkeleton.displayName = 'ListSkeleton'
 
-export { BoardSkeleton, CardSkeleton, ListSkeleton,TableSkeleton }
+export { BoardSkeleton, CardSkeleton, ListSkeleton, TableSkeleton }

--- a/packages/core/src/composed/page-skeletons.tsx
+++ b/packages/core/src/composed/page-skeletons.tsx
@@ -4,47 +4,58 @@ import * as React from 'react'
 import { cn } from '../ui/lib/utils'
 import { Skeleton } from '../ui/skeleton'
 
-const shimmer = 'bg-surface-raised-hover'
+// role=status + aria-busy so AT announces the loading region (child Skeletons are
+// aria-hidden). The sr-only label carries the announcement text.
+function statusProps(label?: string) {
+  return { role: 'status' as const, 'aria-busy': true, 'aria-label': label ?? 'Loading' }
+}
+function SrLabel({ label }: { label?: string }) {
+  return <span className="sr-only">{label ?? 'Loading'}…</span>
+}
 
 // --- Dashboard Skeleton ---
 
-export interface DashboardSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {}
+export interface DashboardSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {
+  /** Accessible label for the loading region. @default 'Loading' */
+  label?: string
+}
 
 const DashboardSkeleton = React.forwardRef<HTMLDivElement, DashboardSkeletonProps>(
-  function DashboardSkeleton({ className, ...props }, ref) {
+  function DashboardSkeleton({ className, label, ...props }, ref) {
   return (
-    <div ref={ref} {...props} className={cn("flex flex-col gap-ds-06", className)}>
+    <div ref={ref} {...statusProps(label)} {...props} className={cn("flex flex-col gap-ds-06", className)}>
+      <SrLabel label={label} />
       {/* Stat cards grid */}
       <div className="grid grid-cols-1 gap-ds-05 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={`stat-${i}`}
-            className="flex flex-col gap-ds-04 rounded-overlay-lg border border-card-strong bg-surface-raised p-ds-05b"
+            className="flex flex-col gap-ds-04 rounded-surface border border-card bg-surface-raised p-ds-05b"
           >
             <div className="flex items-center justify-between">
-              <Skeleton className={cn('h-ds-04 w-ds-11', shimmer)} />
-              <Skeleton className={cn('h-ds-sm w-ds-sm rounded-surface', shimmer)} />
+              <Skeleton className={'h-ds-04 w-ds-11'} />
+              <Skeleton className={'h-ds-sm w-ds-sm rounded-surface'} />
             </div>
-            <Skeleton className={cn('h-ds-xs-plus w-ds-10', shimmer)} />
-            <Skeleton className={cn('h-ds-03 w-[112px]', shimmer)} />
+            <Skeleton className={'h-ds-xs-plus w-ds-10'} />
+            <Skeleton className={'h-ds-03 w-[112px]'} />
           </div>
         ))}
       </div>
 
       {/* Attendance calendar placeholder */}
-      <div className="rounded-overlay-lg border border-card-strong bg-surface-raised p-ds-06">
+      <div className="rounded-surface border border-card bg-surface-raised p-ds-06">
         <div className="mb-ds-06 flex items-center justify-between">
-          <Skeleton className={cn('h-ds-05b w-[128px]', shimmer)} />
+          <Skeleton className={'h-ds-05b w-[128px]'} />
           <div className="flex items-center gap-ds-03">
-            <Skeleton className={cn('h-ds-sm w-ds-sm rounded-surface', shimmer)} />
-            <Skeleton className={cn('h-ds-05 w-[112px]', shimmer)} />
-            <Skeleton className={cn('h-ds-sm w-ds-sm rounded-surface', shimmer)} />
+            <Skeleton className={'h-ds-sm w-ds-sm rounded-surface'} />
+            <Skeleton className={'h-ds-05 w-[112px]'} />
+            <Skeleton className={'h-ds-sm w-ds-sm rounded-surface'} />
           </div>
         </div>
         {/* Weekday headers */}
         <div className="mb-ds-03 grid grid-cols-7 gap-ds-03">
           {Array.from({ length: 7 }).map((_, i) => (
-            <Skeleton key={`wh-${i}`} className={cn('mx-auto h-ds-04 w-ds-07', shimmer)} />
+            <Skeleton key={`wh-${i}`} className={'mx-auto h-ds-04 w-ds-07'} />
           ))}
         </div>
         {/* Calendar grid */}
@@ -52,7 +63,7 @@ const DashboardSkeleton = React.forwardRef<HTMLDivElement, DashboardSkeletonProp
           {Array.from({ length: 35 }).map((_, i) => (
             <Skeleton
               key={`cal-${i}`}
-              className={cn('mx-auto h-ds-md w-ds-md rounded-pill', shimmer)}
+              className={'mx-auto h-ds-md w-ds-md rounded-pill'}
             />
           ))}
         </div>
@@ -66,27 +77,31 @@ DashboardSkeleton.displayName = 'DashboardSkeleton'
 
 // --- Project List Skeleton ---
 
-export interface ProjectListSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {}
+export interface ProjectListSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {
+  /** Accessible label for the loading region. @default 'Loading' */
+  label?: string
+}
 
 const ProjectListSkeleton = React.forwardRef<HTMLDivElement, ProjectListSkeletonProps>(
-  function ProjectListSkeleton({ className, ...props }, ref) {
+  function ProjectListSkeleton({ className, label, ...props }, ref) {
   return (
-    <div ref={ref} {...props} className={cn("flex flex-col gap-ds-06", className)}>
+    <div ref={ref} {...statusProps(label)} {...props} className={cn("flex flex-col gap-ds-06", className)}>
+      <SrLabel label={label} />
       {/* Header */}
       <div className="flex flex-col gap-ds-05 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-ds-03">
-          <Skeleton className={cn('h-ds-06 w-[112px]', shimmer)} />
-          <Skeleton className={cn('h-ds-04 w-ds-13', shimmer)} />
+          <Skeleton className={'h-ds-06 w-[112px]'} />
+          <Skeleton className={'h-ds-04 w-ds-13'} />
         </div>
-        <Skeleton className={cn('h-ds-sm-plus w-[128px] rounded-surface', shimmer)} />
+        <Skeleton className={'h-ds-sm-plus w-[128px] rounded-surface'} />
       </div>
 
       {/* Filters */}
       <div className="flex flex-col gap-ds-04 sm:flex-row sm:items-center">
-        <Skeleton className={cn('h-ds-sm-plus flex-1 rounded-surface', shimmer)} />
+        <Skeleton className={'h-ds-sm-plus flex-1 rounded-surface'} />
         <div className="flex gap-ds-02b">
           {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={`f-${i}`} className={cn('h-ds-sm w-ds-10 rounded-surface', shimmer)} />
+            <Skeleton key={`f-${i}`} className={'h-ds-sm w-ds-10 rounded-surface'} />
           ))}
         </div>
       </div>
@@ -96,18 +111,18 @@ const ProjectListSkeleton = React.forwardRef<HTMLDivElement, ProjectListSkeleton
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={`proj-${i}`}
-            className="flex flex-col gap-ds-05 rounded-overlay-lg border border-card-strong bg-surface-raised p-ds-05b"
+            className="flex flex-col gap-ds-05 rounded-surface border border-card bg-surface-raised p-ds-05b"
           >
             {/* Top row: status + org */}
             <div className="flex items-center justify-between">
-              <Skeleton className={cn('h-ds-05b w-ds-10 rounded-pill', shimmer)} />
-              <Skeleton className={cn('h-ds-05 w-ds-11 rounded-control', shimmer)} />
+              <Skeleton className={'h-ds-05b w-ds-10 rounded-pill'} />
+              <Skeleton className={'h-ds-05 w-ds-11 rounded-control'} />
             </div>
             {/* Title + description */}
             <div className="flex flex-col gap-ds-03">
-              <Skeleton className={cn('h-ds-05 w-3/4', shimmer)} />
-              <Skeleton className={cn('h-ds-04 w-full', shimmer)} />
-              <Skeleton className={cn('h-ds-04 w-2/3', shimmer)} />
+              <Skeleton className={'h-ds-05 w-3/4'} />
+              <Skeleton className={'h-ds-04 w-full'} />
+              <Skeleton className={'h-ds-04 w-2/3'} />
             </div>
             {/* Bottom row: members + count */}
             <div className="flex items-center justify-between pt-ds-02">
@@ -115,11 +130,11 @@ const ProjectListSkeleton = React.forwardRef<HTMLDivElement, ProjectListSkeleton
                 {Array.from({ length: 3 }).map((_, j) => (
                   <Skeleton
                     key={`av-${i}-${j}`}
-                    className={cn('h-ds-xs-plus w-ds-xs-plus rounded-pill', shimmer)}
+                    className={'h-ds-xs-plus w-ds-xs-plus rounded-pill'}
                   />
                 ))}
               </div>
-              <Skeleton className={cn('h-ds-04 w-ds-md', shimmer)} />
+              <Skeleton className={'h-ds-04 w-ds-md'} />
             </div>
           </div>
         ))}
@@ -133,18 +148,22 @@ ProjectListSkeleton.displayName = 'ProjectListSkeleton'
 
 // --- Task Detail Skeleton ---
 
-export interface TaskDetailSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {}
+export interface TaskDetailSkeletonProps extends React.ComponentPropsWithoutRef<'div'> {
+  /** Accessible label for the loading region. @default 'Loading' */
+  label?: string
+}
 
 const TaskDetailSkeleton = React.forwardRef<HTMLDivElement, TaskDetailSkeletonProps>(
-  function TaskDetailSkeleton({ className, ...props }, ref) {
+  function TaskDetailSkeleton({ className, label, ...props }, ref) {
   return (
-    <div ref={ref} {...props} className={cn("flex h-full flex-col gap-0 rounded-overlay-lg border border-card-strong bg-surface-raised", className)}>
+    <div ref={ref} {...statusProps(label)} {...props} className={cn("flex h-full flex-col gap-0 rounded-surface border border-card bg-surface-raised", className)}>
+      <SrLabel label={label} />
       {/* Header */}
       <div className="flex items-center justify-between border-b border-surface-border-strong px-ds-05b py-ds-05">
-        <Skeleton className={cn('h-ds-05b w-[192px]', shimmer)} />
+        <Skeleton className={'h-ds-05b w-[192px]'} />
         <div className="flex items-center gap-ds-03">
-          <Skeleton className={cn('h-ds-xs-plus w-ds-xs-plus rounded-surface', shimmer)} />
-          <Skeleton className={cn('h-ds-xs-plus w-ds-xs-plus rounded-surface', shimmer)} />
+          <Skeleton className={'h-ds-xs-plus w-ds-xs-plus rounded-surface'} />
+          <Skeleton className={'h-ds-xs-plus w-ds-xs-plus rounded-surface'} />
         </div>
       </div>
 
@@ -155,8 +174,8 @@ const TaskDetailSkeleton = React.forwardRef<HTMLDivElement, TaskDetailSkeletonPr
             key={`prop-${i}`}
             className="flex items-center gap-ds-05 py-ds-03"
           >
-            <Skeleton className={cn('h-ds-04 w-ds-12 shrink-0', shimmer)} />
-            <Skeleton className={cn('h-ds-06 w-[128px] rounded-control', shimmer)} />
+            <Skeleton className={'h-ds-04 w-ds-12 shrink-0'} />
+            <Skeleton className={'h-ds-06 w-[128px] rounded-control'} />
           </div>
         ))}
       </div>
@@ -165,18 +184,18 @@ const TaskDetailSkeleton = React.forwardRef<HTMLDivElement, TaskDetailSkeletonPr
       <div className="border-b border-surface-border-strong px-ds-05b">
         <div className="flex gap-ds-05 py-ds-04">
           {Array.from({ length: 3 }).map((_, i) => (
-            <Skeleton key={`tab-${i}`} className={cn('h-ds-05 w-ds-10', shimmer)} />
+            <Skeleton key={`tab-${i}`} className={'h-ds-05 w-ds-10'} />
           ))}
         </div>
       </div>
 
       {/* Tab content */}
       <div className="flex flex-1 flex-col gap-ds-04 px-ds-05b py-ds-05">
-        <Skeleton className={cn('h-ds-04 w-full', shimmer)} />
-        <Skeleton className={cn('h-ds-04 w-4/5', shimmer)} />
-        <Skeleton className={cn('h-ds-04 w-3/5', shimmer)} />
-        <Skeleton className={cn('mt-ds-03 h-ds-04 w-full', shimmer)} />
-        <Skeleton className={cn('h-ds-04 w-2/3', shimmer)} />
+        <Skeleton className={'h-ds-04 w-full'} />
+        <Skeleton className={'h-ds-04 w-4/5'} />
+        <Skeleton className={'h-ds-04 w-3/5'} />
+        <Skeleton className={'mt-ds-03 h-ds-04 w-full'} />
+        <Skeleton className={'h-ds-04 w-2/3'} />
       </div>
     </div>
   )


### PR DESCRIPTION
loading-skeleton + page-skeletons. Non-breaking (additive `label`). **S6 (P0):** dropped every `bg-surface-raised-hover` fill override so all bars inherit the base Skeleton's `skeleton-base` — one shimmer source; fixes forced-colors invisibility. **a11y (P0):** each root is `role=status`+`aria-busy` with an sr-only label (was silent to AT). **P1:** clamp counts (no RangeError); removed inert animationDelay; `border-card`+`rounded-surface` cohesion; deleted misleading shimmer const; corrected the false 'Built on LoadingSkeleton' doc. 49/49 green.