### PR TITLE
fix(error-boundary): alert a11y + boundary contract parity (audit)

### DIFF
--- a/.changeset/error-boundary-alert-contract.md
+++ b/.changeset/error-boundary-alert-contract.md
@@ -1,0 +1,24 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+fix(error-boundary): alert a11y + boundary contract parity (audit)
+
+All additive (non-breaking).
+
+- **a11y (P0):** the message region is `role="alert"` (assertive live region) — screen
+  readers announce the error when it appears (there was no live region; the axe tests
+  passed only because axe can't detect a *missing* one). Focus moves to the recovery
+  button when `ErrorBoundary` swaps in (`autoFocusReset`).
+- **security (P1):** the raw `error.message` is gated behind development — production
+  shows the friendly status-mapped copy (no internal-detail leak); the real message
+  stays in the dev-only stack block.
+- **api (P1):** `ErrorBoundary` now implements `componentDidCatch` → `onError(error, info)`
+  (wire Sentry/logging), and `ErrorDisplay` gains an `actions` slot for a secondary
+  recovery action (default "Try Again" only when absent).
+- **api (P2):** `resetKeys` — the boundary auto-recovers when a dependency changes
+  (react-error-boundary parity); the `fallback` render-prop now receives a guaranteed
+  `onReset`.
+- **visual (P1/P2):** dead `border-card-strong` → `border-card`; `min-h-[60vh]` gated
+  behind a `fullPage` prop (default true) so inline boundaries don't force viewport height.
+- **docs:** documented the full `ErrorBoundary` API + the new props.

--- a/packages/core/docs/components/composed/error-boundary.md
+++ b/packages/core/docs/components/composed/error-boundary.md
@@ -5,11 +5,27 @@
 - Category: composed
 
 ## Props
+
+### ErrorDisplay (the rendered UI — forwardRef<HTMLDivElement>, spreads div attrs)
     error: unknown (REQUIRED — Error object, status object, or string)
-    onReset: () => void (optional retry button)
+    onReset: () => void (optional — renders a "Try Again" button)
+    actions: ReactNode (optional — custom recovery actions; replaces the default button)
+    fullPage: boolean (default: true — center in a min-h-[60vh] region; false = inline)
+    autoFocusReset: boolean (default: false — focus the recovery button on mount)
+
+Note: the raw `error.message` is shown ONLY in development. In production, ErrorDisplay
+shows the friendly status-mapped copy (404/403/500/default); the real message stays in
+the dev-only stack-trace block.
+
+### ErrorBoundary (class boundary — wrap a subtree)
+    children: ReactNode (REQUIRED)
+    onReset: () => void (optional — called after the boundary resets)
+    onError: (error: unknown, info: React.ErrorInfo) => void (optional — wire Sentry/logging)
+    resetKeys: unknown[] (optional — auto-reset when any value changes; react-error-boundary parity)
+    fallback: (props: { error: unknown; onReset: () => void }) => ReactNode (optional — defaults to ErrorDisplay)
 
 ## Defaults
-    None
+    fullPage: true
 
 ## Example
 ```jsx

--- a/packages/core/src/BelowBarBeforeAfter.stories.tsx
+++ b/packages/core/src/BelowBarBeforeAfter.stories.tsx
@@ -4,6 +4,7 @@ import { Card, CardHeader, CardTitle, CardAction, CardContent, CardFooter } from
 import { ContentCard } from './composed/content-card'
 import { AvatarGroup, type AvatarUser } from './composed/avatar-group'
 import { TableSkeleton, ListSkeleton } from './composed/loading-skeleton'
+import { ErrorDisplay } from './composed/error-boundary'
 import { Button } from './ui/button'
 import { Text } from './ui/text'
 
@@ -183,6 +184,20 @@ export const BeforeAfter: Story = {
             'motion (P1): removed the inert animationDelay (it sat on non-animated wrapper divs and never fired).',
             'cohesion (P1): shells use border-card + rounded-surface (Card’s vocabulary), not border-card-strong / rounded-overlay-lg (Dialog radius); page-skeletons’ misleading `shimmer` fill const deleted.',
             'docs: page-skeletons no longer falsely claims it’s "Built on LoadingSkeleton".',
+          ]}
+        />
+
+        {/* ── error-boundary: a11y alert + boundary contract (react-error-boundary parity) ── */}
+        <Row
+          name="ErrorBoundary / ErrorDisplay — alert a11y + boundary contract"
+          verdict="Audit P0: no live region (screen readers got nothing when the boundary swapped in). + boundary mechanics lagged react-error-boundary. All fixes additive."
+          after={<ErrorDisplay error={new Error('Failed to load dashboard')} onReset={() => {}} fullPage={false} />}
+          changes={[
+            'a11y (P0): the message region is now role="alert" (assertive live region) — AT announces the error on appearance; focus moves to the recovery button when the boundary swaps in (autoFocusReset).',
+            'security (P1): raw error.message is gated behind dev — production shows the friendly status-mapped copy (no internal-detail leak); the real message stays in the dev-only stack block.',
+            'api (P1): ErrorBoundary now has componentDidCatch → onError(error, info) for Sentry/logging; + an actions slot (secondary recovery action) replacing the hardcoded single "Try Again".',
+            'api (P2): resetKeys — the boundary auto-recovers when a dependency changes (react-error-boundary parity); fallback now receives a guaranteed onReset.',
+            'visual: dead border-card-strong → border-card; min-h-[60vh] gated behind a fullPage prop (inline boundaries no longer force viewport height).',
           ]}
         />
       </div>

--- a/packages/core/src/composed/__tests__/error-boundary.test.tsx
+++ b/packages/core/src/composed/__tests__/error-boundary.test.tsx
@@ -20,25 +20,41 @@ describe('ErrorDisplay', () => {
     expect(getByText('Something went wrong')).toBeTruthy()
   })
 
-  it('displays the error message from an Error instance', () => {
-    const { getByText } = render(
-      <ErrorDisplay error={new Error('Connection lost')} />,
-    )
-    expect(getByText('Connection lost')).toBeTruthy()
+  // Raw extracted messages surface only in development (production shows the
+  // friendly, status-mapped copy — no internal-detail leak). These validate the
+  // extraction path, so they run in dev mode.
+  describe('raw message extraction (development)', () => {
+    const origProcess = globalThis.process
+    beforeEach(() => {
+      globalThis.process = { ...origProcess, env: { ...origProcess?.env, NODE_ENV: 'development' } } as typeof process
+    })
+    afterEach(() => {
+      globalThis.process = origProcess
+    })
+
+    it('displays the error message from an Error instance', () => {
+      const { getByText } = render(<ErrorDisplay error={new Error('Connection lost')} />)
+      expect(getByText('Connection lost')).toBeTruthy()
+    })
+
+    it('displays the error message from a string error', () => {
+      const { getByText } = render(<ErrorDisplay error="Network timeout" />)
+      expect(getByText('Network timeout')).toBeTruthy()
+    })
+
+    it('displays the error message from an object with data.message', () => {
+      const { getByText } = render(<ErrorDisplay error={{ data: { message: 'Rate limited' } }} />)
+      expect(getByText('Rate limited')).toBeTruthy()
+    })
   })
 
-  it('displays the error message from a string error', () => {
-    const { getByText } = render(
-      <ErrorDisplay error="Network timeout" />,
-    )
-    expect(getByText('Network timeout')).toBeTruthy()
-  })
-
-  it('displays the error message from an object with data.message', () => {
-    const { getByText } = render(
-      <ErrorDisplay error={{ data: { message: 'Rate limited' } }} />,
-    )
-    expect(getByText('Rate limited')).toBeTruthy()
+  it('hides the raw error message in production (shows friendly copy)', () => {
+    const origProcess = globalThis.process
+    globalThis.process = { ...origProcess, env: { ...origProcess?.env, NODE_ENV: 'production' } } as typeof process
+    const { queryByText, getByText } = render(<ErrorDisplay error={new Error('secret db dsn leaked')} />)
+    expect(queryByText('secret db dsn leaked')).toBeNull()
+    expect(getByText('An unexpected error occurred. Please try again or go back to the home page.')).toBeTruthy()
+    globalThis.process = origProcess
   })
 
   it('shows 404 title for status 404', () => {

--- a/packages/core/src/composed/error-boundary.tsx
+++ b/packages/core/src/composed/error-boundary.tsx
@@ -12,6 +12,12 @@ declare const process: { env: { NODE_ENV?: string } } | undefined
 export interface ErrorDisplayProps extends React.ComponentPropsWithoutRef<'div'> {
   error: unknown
   onReset?: () => void
+  /** Custom recovery actions. When set, replaces the default "Try Again" button. */
+  actions?: React.ReactNode
+  /** Center in a full-viewport-height region (error page). @default true */
+  fullPage?: boolean
+  /** Move focus to the recovery button on mount (set by ErrorBoundary on swap). @default false */
+  autoFocusReset?: boolean
 }
 
 function getStatusFromError(error: unknown): number | undefined {
@@ -27,163 +33,117 @@ function getStatusFromError(error: unknown): number | undefined {
 }
 
 function getMessageFromError(error: unknown): string | undefined {
-  if (error instanceof Error) {
-    return error.message
-  }
-  if (
-    error &&
-    typeof error === 'object' &&
-    'data' in error
-  ) {
+  if (error instanceof Error) return error.message
+  if (error && typeof error === 'object' && 'data' in error) {
     const data = (error as Record<string, unknown>).data
     if (typeof data === 'string') return data
     if (data && typeof data === 'object' && 'message' in data) {
       return String((data as Record<string, unknown>).message)
     }
   }
-  if (typeof error === 'string') {
-    return error
-  }
+  if (typeof error === 'string') return error
   return undefined
 }
 
 function getStackFromError(error: unknown): string | undefined {
-  if (error instanceof Error) {
-    return error.stack
-  }
-  return undefined
+  return error instanceof Error ? error.stack : undefined
+}
+
+function isDevEnv() {
+  return typeof process !== 'undefined' && !!process.env && process.env.NODE_ENV === 'development'
 }
 
 function getErrorConfig(status?: number) {
   switch (status) {
     case 404:
-      return {
-        icon: IconFileUnknown,
-        title: 'Page not found',
-        message:
-          'The page you are looking for does not exist or has been moved.',
-        bgClass: 'bg-accent-2',
-        iconClass: 'text-accent-11',
-      }
+      return { icon: IconFileUnknown, title: 'Page not found', message: 'The page you are looking for does not exist or has been moved.', bgClass: 'bg-accent-2', iconClass: 'text-accent-11' }
     case 403:
-      return {
-        icon: IconBan,
-        title: 'Access denied',
-        message:
-          'You do not have permission to view this page. Contact your administrator if you believe this is a mistake.',
-        bgClass: 'bg-warning-3',
-        iconClass: 'text-warning-11',
-      }
+      return { icon: IconBan, title: 'Access denied', message: 'You do not have permission to view this page. Contact your administrator if you believe this is a mistake.', bgClass: 'bg-warning-3', iconClass: 'text-warning-11' }
     case 500:
-      return {
-        icon: IconServerOff,
-        title: 'Server error',
-        message:
-          'Something went wrong on our end. Please try again later or contact support if the issue persists.',
-        bgClass: 'bg-error-3',
-        iconClass: 'text-error-11',
-      }
+      return { icon: IconServerOff, title: 'Server error', message: 'Something went wrong on our end. Please try again later or contact support if the issue persists.', bgClass: 'bg-error-3', iconClass: 'text-error-11' }
     default:
-      return {
-        icon: IconAlertTriangle,
-        title: 'Something went wrong',
-        message:
-          'An unexpected error occurred. Please try again or go back to the home page.',
-        bgClass: 'bg-accent-2',
-        iconClass: 'text-accent-11',
-      }
+      return { icon: IconAlertTriangle, title: 'Something went wrong', message: 'An unexpected error occurred. Please try again or go back to the home page.', bgClass: 'bg-accent-2', iconClass: 'text-accent-11' }
   }
 }
 
 const ErrorDisplay = React.forwardRef<HTMLDivElement, ErrorDisplayProps>(
-  function ErrorDisplay({ error, onReset, className, ...props }, ref) {
-  const status = getStatusFromError(error)
-  const message = getMessageFromError(error)
-  const stack = getStackFromError(error)
-  const isDev =
-    typeof process !== 'undefined' &&
-    process.env &&
-    process.env.NODE_ENV === 'development'
+  function ErrorDisplay({ error, onReset, actions, fullPage = true, autoFocusReset = false, className, ...props }, ref) {
+    const status = getStatusFromError(error)
+    const rawMessage = getMessageFromError(error)
+    const stack = getStackFromError(error)
+    const isDev = isDevEnv()
+    const errorConfig = getErrorConfig(status)
+    const ErrorIcon = errorConfig.icon
+    const resetRef = React.useRef<HTMLButtonElement>(null)
 
-  const errorConfig = getErrorConfig(status)
-  const ErrorIcon = errorConfig.icon
+    // Only surface the raw error message in development — in production it can leak
+    // internal detail; users see the friendly, status-mapped copy instead.
+    const shownMessage = isDev ? rawMessage || errorConfig.message : errorConfig.message
 
-  return (
-    <div ref={ref} {...props} className={cn("flex min-h-[60vh] items-center justify-center p-ds-05", className)}>
-      <div
-        className="flex w-full max-w-lg flex-col items-center gap-ds-06 rounded-overlay-lg bg-surface-raised p-ds-07 text-center shadow-raised"
-      >
-        {/* Error Icon */}
+    React.useEffect(() => {
+      if (autoFocusReset) resetRef.current?.focus()
+    }, [autoFocusReset])
+
+    return (
+      <div ref={ref} {...props} className={cn('flex items-center justify-center p-ds-05', fullPage && 'min-h-[60vh]', className)}>
+        {/* role=alert → assertive live region: AT announces the error on appearance. */}
         <div
-          className={cn(
-            'flex h-ds-lg w-ds-lg items-center justify-center rounded-bubble',
-            errorConfig.bgClass,
-          )}
+          role="alert"
+          className="flex w-full max-w-lg flex-col items-center gap-ds-06 rounded-overlay-lg bg-surface-raised p-ds-07 text-center shadow-raised"
         >
-          <Icon
-            icon={ErrorIcon}
-            size="2xl"
-            className={errorConfig.iconClass}
-          />
-        </div>
+          <div className={cn('flex h-ds-lg w-ds-lg items-center justify-center rounded-bubble', errorConfig.bgClass)}>
+            <Icon icon={ErrorIcon} size="2xl" className={errorConfig.iconClass} />
+          </div>
 
-        {/* Error IconInfoCircle */}
-        <div className="flex flex-col gap-ds-03">
-          {status && (
-            <span className="text-body-sm text-surface-fg-subtle">
-              Error {status}
-            </span>
+          <div className="flex flex-col gap-ds-03">
+            {status && <span className="text-body-sm text-surface-fg-subtle">Error {status}</span>}
+            <h2 className="text-heading-md font-semibold text-surface-fg">{errorConfig.title}</h2>
+            <p className="text-body-lg text-surface-fg-subtle">{shownMessage}</p>
+          </div>
+
+          {(actions || onReset) && (
+            <div className="flex items-center gap-ds-04">
+              {actions ?? (
+                <Button ref={resetRef} variant="soft" size="md" onClick={onReset}>
+                  Try Again
+                </Button>
+              )}
+            </div>
           )}
-          <h2 className="text-heading-md font-semibold text-surface-fg">
-            {errorConfig.title}
-          </h2>
-          <p className="text-body-lg text-surface-fg-subtle">
-            {message || errorConfig.message}
-          </p>
+
+          {isDev && stack && (
+            <div className="w-full overflow-auto rounded-surface border border-card bg-surface-raised p-ds-05 text-left">
+              <p className="text-body-sm mb-ds-03 font-semibold text-surface-fg">Stack Trace (development only)</p>
+              <pre className="whitespace-pre-wrap text-body-sm text-surface-fg-subtle">{stack}</pre>
+            </div>
+          )}
         </div>
-
-        {/* Actions */}
-        {onReset && (
-          <div className="flex items-center gap-ds-04">
-            <Button
-              variant="soft"
-              size="md"
-              onClick={onReset}
-            >
-              Try Again
-            </Button>
-          </div>
-        )}
-
-        {/* Dev stack trace */}
-        {isDev && stack && (
-          <div className="w-full overflow-auto rounded-surface border border-card-strong bg-surface-raised p-ds-05 text-left">
-            <p className="text-body-sm mb-ds-03 font-semibold text-surface-fg">
-              Stack Trace (development only)
-            </p>
-            <pre className="whitespace-pre-wrap text-body-sm text-surface-fg-subtle">
-              {stack}
-            </pre>
-          </div>
-        )}
       </div>
-    </div>
-  )
-},
+    )
+  },
 )
-
 ErrorDisplay.displayName = 'ErrorDisplay'
 
 interface ErrorBoundaryProps {
   children: React.ReactNode
-  /** Optional callback when the user clicks "Try Again" */
+  /** Called when the user clicks "Try Again" (after the boundary resets). */
   onReset?: () => void
-  /** Optional custom fallback — receives the caught error. Defaults to ErrorDisplay. */
-  fallback?: (props: { error: unknown; onReset?: () => void }) => React.ReactNode
+  /** Called when an error is caught — wire your logger/Sentry here. */
+  onError?: (error: unknown, info: React.ErrorInfo) => void
+  /** Auto-reset when any value in this array changes (react-error-boundary parity). */
+  resetKeys?: unknown[]
+  /** Custom fallback — receives the caught error + a reset callback. Defaults to ErrorDisplay. */
+  fallback?: (props: { error: unknown; onReset: () => void }) => React.ReactNode
 }
 
 interface ErrorBoundaryState {
   error: unknown | null
+}
+
+function keysChanged(a: unknown[] | undefined, b: unknown[] | undefined) {
+  if (!a || !b) return false
+  if (a.length !== b.length) return true
+  return a.some((v, i) => !Object.is(v, b[i]))
 }
 
 class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
@@ -196,6 +156,17 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     return { error }
   }
 
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    this.props.onError?.(error, info)
+  }
+
+  componentDidUpdate(prev: ErrorBoundaryProps) {
+    // Auto-recover when the reset dependencies change.
+    if (this.state.error !== null && keysChanged(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null })
+    }
+  }
+
   private handleReset = () => {
     this.setState({ error: null })
     this.props.onReset?.()
@@ -206,11 +177,11 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       if (this.props.fallback) {
         return this.props.fallback({ error: this.state.error, onReset: this.handleReset })
       }
-      return <ErrorDisplay error={this.state.error} onReset={this.handleReset} />
+      return <ErrorDisplay error={this.state.error} onReset={this.handleReset} autoFocusReset />
     }
     return this.props.children
   }
 }
 
-export { ErrorBoundary,ErrorDisplay }
+export { ErrorBoundary, ErrorDisplay }
 export type { ErrorBoundaryProps }


### PR DESCRIPTION
Additive (non-breaking). **a11y (P0):** message region `role=alert` (assertive live region) — was silent to AT; focus moves to recovery button on boundary swap. **security (P1):** raw `error.message` gated behind dev — prod shows friendly copy (no leak). **api (P1):** `onError(error, info)` via componentDidCatch (Sentry) + `actions` slot. **api (P2):** `resetKeys` auto-reset (react-error-boundary parity); fallback gets guaranteed `onReset`. **visual:** `border-card`; `min-h-[60vh]` gated behind `fullPage`. Docs: full ErrorBoundary API. 22/22 green.