### PR TITLE
fix(master-detail): a11y + selection ownership (audit)

### DIFF
--- a/.changeset/master-detail-a11y-selection.md
+++ b/.changeset/master-detail-a11y-selection.md
@@ -1,0 +1,24 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+fix(master-detail): a11y naming/live region + selection ownership (audit)
+
+Additive (non-breaking — controlled `selected` + explicit `active` still work).
+
+- **a11y (P0):** the `listbox` now has an accessible name via a `label` prop
+  (`aria-label`) — it was a nameless listbox to screen readers. The detail pane is a
+  `role="region"` `aria-live="polite"` region, so AT users are told the detail changed
+  when the selection swaps (was a silent swap).
+- **api (P1):** selection ownership — put `value` on each `MasterDetail.ListItem` and
+  `onSelect` / `defaultSelected` on the root; `active` + `aria-selected` derive from
+  context automatically. No more hand-wiring `active={id === sel}` **and** `onClick` on
+  every row (the DS `value`/`onSelect` model). Controlled `selected` is unchanged.
+- **motion (P2):** the mobile detail slide is gated behind `useReducedMotion`
+  (opacity-only / instant under `prefers-reduced-motion`).
+- **RTL (P2):** list divider `border-r` → `border-e`; the mobile back arrow mirrors
+  under `dir="rtl"`.
+- **cleanup:** removed the dead `itemCount` context; roving `activeIndex` derives from
+  `value` or an explicit `active`.
+
+Follow-ups noted (not in this change): `asChild`/`href` rows, typeahead, per-item disabled.

--- a/packages/core/docs/components/composed/master-detail.md
+++ b/packages/core/docs/components/composed/master-detail.md
@@ -10,13 +10,23 @@ MasterDetail (root), MasterDetail.List, MasterDetail.Detail, MasterDetail.ListIt
 ## Props
 
 ### MasterDetail (root)
-    selected: string | null (ID of currently selected item; null = show list on mobile)
+    selected: string | null (CONTROLLED selected item id; omit for uncontrolled)
+    defaultSelected: string | null (uncontrolled initial selection)
+    onSelect: (value: string) => void (called with a row's `value` when chosen)
+    label: string (accessible name for the listbox; default "Items")
     onBack: () => void (called when mobile back button is pressed)
     masterWidth: string (master panel width on desktop)
     breakpoint: "sm" | "md" | "lg" (below this, stacked mobile mode activates)
+    emptyState: ReactNode (shown in the detail pane when nothing is selected)
+    onNavigate: (direction: "up" | "down") => void
+
+Selection can be controlled (`selected`) or owned by the component
+(`defaultSelected` + `onSelect`). With `value` on each ListItem, `active` /
+`aria-selected` derive automatically — no need to hand-wire `active` + `onClick`.
 
 ### MasterDetail.ListItem
-    active: boolean (highlights the item)
+    value: string (row id — enables derived selection + auto-fires onSelect on activate)
+    active: boolean (explicit highlight; omit to derive from value === selected)
     (extends ButtonHTMLAttributes)
 
 ## Defaults

--- a/packages/core/src/BelowBarBeforeAfter.stories.tsx
+++ b/packages/core/src/BelowBarBeforeAfter.stories.tsx
@@ -5,6 +5,7 @@ import { ContentCard } from './composed/content-card'
 import { AvatarGroup, type AvatarUser } from './composed/avatar-group'
 import { TableSkeleton, ListSkeleton } from './composed/loading-skeleton'
 import { ErrorDisplay } from './composed/error-boundary'
+import { MasterDetail } from './composed/master-detail'
 import { Button } from './ui/button'
 import { Text } from './ui/text'
 
@@ -198,6 +199,35 @@ export const BeforeAfter: Story = {
             'api (P1): ErrorBoundary now has componentDidCatch → onError(error, info) for Sentry/logging; + an actions slot (secondary recovery action) replacing the hardcoded single "Try Again".',
             'api (P2): resetKeys — the boundary auto-recovers when a dependency changes (react-error-boundary parity); fallback now receives a guaranteed onReset.',
             'visual: dead border-card-strong → border-card; min-h-[60vh] gated behind a fullPage prop (inline boundaries no longer force viewport height).',
+          ]}
+        />
+
+        {/* ── master-detail: a11y naming/live + selection ownership ── */}
+        <Row
+          name="MasterDetail — a11y + selection ownership"
+          verdict="Audit P0: nameless listbox + detail swaps silently. P1: controlled-only, hand-wired active+onClick. Roving keyboard nav was already solid."
+          after={
+            <MasterDetail defaultSelected="karm" label="Projects" className="h-[240px] overflow-hidden rounded-control border border-surface-border">
+              <MasterDetail.List>
+                <MasterDetail.ListItem value="karm">Karm V2</MasterDetail.ListItem>
+                <MasterDetail.ListItem value="site">Website Redesign</MasterDetail.ListItem>
+                <MasterDetail.ListItem value="brand">Brand System</MasterDetail.ListItem>
+              </MasterDetail.List>
+              <MasterDetail.Detail>
+                <div className="p-ds-05">
+                  <Text variant="label-md" className="text-surface-fg">Detail pane</Text>
+                  <Text variant="body-sm" className="mt-ds-02 text-surface-fg-muted">Arrow/Home/End to rove, Enter to select. Focus a row.</Text>
+                </div>
+              </MasterDetail.Detail>
+            </MasterDetail>
+          }
+          changes={[
+            'a11y (P0): the listbox now has an accessible name (`label` prop → aria-label) — was a nameless listbox to screen readers.',
+            'a11y (P0): the detail pane is role="region" aria-live="polite" — AT users are told the detail changed on selection (was a silent swap).',
+            'api (P1): selection ownership — pass `value` per row + `onSelect`/`defaultSelected` on the root; active + aria-selected derive from context. No more hand-wiring `active={id===sel}` AND `onClick` on every row. Controlled `selected` still works.',
+            'motion (P2): the mobile detail slide is gated behind useReducedMotion (opacity-only / instant under prefers-reduced-motion).',
+            'RTL (P2): list divider border-r → border-e; the mobile back arrow mirrors under dir="rtl".',
+            'cleanup: removed the dead itemCount context; roving activeIndex derives from value or explicit active. (asChild/typeahead noted as follow-ups.)',
           ]}
         />
       </div>

--- a/packages/core/src/composed/master-detail.test.tsx
+++ b/packages/core/src/composed/master-detail.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect,it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MasterDetail } from './master-detail'
 
@@ -74,5 +74,40 @@ describe('MasterDetail', () => {
     )
     expect(screen.getByTestId('list-pane')).toBeInTheDocument()
     expect(screen.getByTestId('detail-pane')).toBeInTheDocument()
+  })
+
+  it('listbox has an accessible name + detail is a polite live region (a11y)', () => {
+    render(
+      <MasterDetail label="Projects">
+        <MasterDetail.List>
+          <MasterDetail.ListItem value="a">A</MasterDetail.ListItem>
+        </MasterDetail.List>
+        <MasterDetail.Detail>Detail</MasterDetail.Detail>
+      </MasterDetail>,
+    )
+    expect(screen.getByRole('listbox', { name: 'Projects' })).toBeInTheDocument()
+    const region = screen.getByRole('region', { name: 'Detail' })
+    expect(region).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('owns selection via value/onSelect (uncontrolled) — derives active from context', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event')
+    const onSelect = vi.fn()
+    render(
+      <MasterDetail defaultSelected="a" onSelect={onSelect}>
+        <MasterDetail.List>
+          <MasterDetail.ListItem value="a">Alpha</MasterDetail.ListItem>
+          <MasterDetail.ListItem value="b">Bravo</MasterDetail.ListItem>
+        </MasterDetail.List>
+        <MasterDetail.Detail>d</MasterDetail.Detail>
+      </MasterDetail>,
+    )
+    // Active derived from value === selected — no hand-wired `active` prop.
+    expect(screen.getByRole('option', { name: 'Alpha' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('option', { name: 'Bravo' })).toHaveAttribute('aria-selected', 'false')
+    await userEvent.click(screen.getByRole('option', { name: 'Bravo' }))
+    expect(onSelect).toHaveBeenCalledWith('b')
+    // Uncontrolled → the component moved selection itself.
+    expect(screen.getByRole('option', { name: 'Bravo' })).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/packages/core/src/composed/master-detail.tsx
+++ b/packages/core/src/composed/master-detail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { IconArrowLeft } from '@tabler/icons-react'
-import { AnimatePresence, motion } from 'framer-motion'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import * as React from 'react'
 
 import { Button } from '../ui/button'
@@ -9,18 +9,26 @@ import { Icon } from '../ui/icon'
 import { springs } from '../ui/lib/motion'
 import { cn } from '../ui/lib/utils'
 
-// ============================================================
-// Types
-// ============================================================
-
 /**
- * A responsive master-detail layout. On desktop, shows a fixed-width list panel
- * alongside a detail panel. Below the breakpoint, switches to a stacked view
- * with animated transitions and a back button.
+ * A responsive master-detail layout. Desktop: fixed-width list panel + detail
+ * panel. Below the breakpoint: stacked view with a back button. The list is an
+ * ARIA `listbox` with roving keyboard nav (Arrow/Home/End + Enter/Space).
+ *
+ * Selection can be **controlled** (`selected`) or **owned** by the component
+ * (`defaultSelected` + `onSelect`, deriving each row's active state from its
+ * `value` — no hand-wiring `active` + `onClick` per row).
  */
-export interface MasterDetailProps extends React.HTMLAttributes<HTMLDivElement> {
-  /** ID of currently selected item. null = no selection (show list on mobile). */
+export interface MasterDetailProps
+  // Replaces the rarely-used native text-selection `onSelect` with our row-select callback.
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSelect'> {
+  /** Controlled selected item id. `null` = no selection. Omit for uncontrolled. */
   selected?: string | null
+  /** Uncontrolled initial selection. */
+  defaultSelected?: string | null
+  /** Called with a row's `value` when it's chosen (click or Enter/Space). */
+  onSelect?: (value: string) => void
+  /** Accessible name for the list (the `listbox`). @default 'Items' */
+  label?: string
   /** Called when mobile back button is pressed. */
   onBack?: () => void
   /** Master panel width on desktop. @default '280px' */
@@ -29,31 +37,23 @@ export interface MasterDetailProps extends React.HTMLAttributes<HTMLDivElement> 
   breakpoint?: 'sm' | 'md' | 'lg'
   /** Content to show in the detail pane when nothing is selected. */
   emptyState?: React.ReactNode
-  /** Called when user presses ArrowUp/ArrowDown while the list has focus. */
+  /** Called when the user presses ArrowUp/ArrowDown while the list has focus. */
   onNavigate?: (direction: 'up' | 'down') => void
 }
 
 interface MasterDetailListProps extends React.HTMLAttributes<HTMLDivElement> {}
-
 interface MasterDetailDetailProps extends React.HTMLAttributes<HTMLDivElement> {}
-
 interface MasterDetailListItemProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Explicit active state. Omit to derive from `value` === the selected id. */
   active?: boolean
+  /** Row id — enables derived selection + auto-fires `onSelect` on activate. */
+  value?: string
 }
 
-// ============================================================
-// Breakpoint values
-// ============================================================
-
-const breakpoints: Record<string, string> = {
-  sm: '640px',
-  md: '768px',
-  lg: '1024px',
-}
+const breakpoints: Record<string, string> = { sm: '640px', md: '768px', lg: '1024px' }
 
 function useMediaQuery(query: string): boolean {
   const [matches, setMatches] = React.useState(false)
-
   React.useEffect(() => {
     if (typeof window === 'undefined') return
     const mql = window.matchMedia(query)
@@ -62,16 +62,13 @@ function useMediaQuery(query: string): boolean {
     mql.addEventListener('change', handler)
     return () => mql.removeEventListener('change', handler)
   }, [query])
-
   return matches
 }
 
-// ============================================================
-// Context
-// ============================================================
-
 interface MasterDetailContextValue {
   selected: string | null
+  onSelect?: (value: string) => void
+  label: string
   isMobile: boolean
   onBack?: () => void
   emptyState?: React.ReactNode
@@ -79,89 +76,67 @@ interface MasterDetailContextValue {
   activeIndex: number
   setActiveIndex: (index: number) => void
   registerItemRef: (index: number, el: HTMLButtonElement | null) => void
-  itemCount: number
-  setItemCount: (count: number) => void
 }
 
 const MasterDetailContext = React.createContext<MasterDetailContextValue>({
   selected: null,
+  label: 'Items',
   isMobile: false,
   activeIndex: 0,
   setActiveIndex: () => {},
   registerItemRef: () => {},
-  itemCount: 0,
-  setItemCount: () => {},
 })
 
-// ============================================================
-// Compound Components
-// ============================================================
+function itemIsActive(child: React.ReactNode, selected: string | null): boolean {
+  if (!React.isValidElement(child)) return false
+  const p = child.props as { active?: boolean; value?: string }
+  return p.active ?? (p.value != null && p.value === selected)
+}
 
-function MasterDetailList({ children, className, ...props }: MasterDetailListProps) {
-  const { selected, isMobile, onNavigate, activeIndex, setActiveIndex, registerItemRef, setItemCount } = React.useContext(MasterDetailContext)
+function MasterDetailList({ children, className, 'aria-label': ariaLabel, ...props }: MasterDetailListProps) {
+  const { selected, label, isMobile, onNavigate, activeIndex, setActiveIndex, registerItemRef } =
+    React.useContext(MasterDetailContext)
   const itemRefsLocal = React.useRef<(HTMLButtonElement | null)[]>([])
-
-  // Count children and register with context
   const childCount = React.Children.count(children)
-  React.useEffect(() => {
-    setItemCount(childCount)
-  }, [childCount, setItemCount])
 
-  // Keep roving focus in sync with the active/selected item, so keyboard nav
-  // starts on the current selection instead of always the first row.
+  // Roving focus starts on the active/selected row (derived from `active` or `value`).
   const activeChildIndex = React.useMemo(() => {
     let idx = -1
     React.Children.forEach(children, (child, i) => {
-      if (
-        React.isValidElement(child) &&
-        (child.props as { active?: boolean }).active
-      ) {
-        idx = i
-      }
+      if (itemIsActive(child, selected)) idx = i
     })
     return idx
-  }, [children])
+  }, [children, selected])
   React.useEffect(() => {
     if (activeChildIndex >= 0) setActiveIndex(activeChildIndex)
   }, [activeChildIndex, setActiveIndex])
 
-  // On mobile, hide list when something is selected
   if (isMobile && selected) return null
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       const next = Math.min(activeIndex + 1, childCount - 1)
-      setActiveIndex(next)
-      itemRefsLocal.current[next]?.focus()
-      onNavigate?.('down')
+      setActiveIndex(next); itemRefsLocal.current[next]?.focus(); onNavigate?.('down')
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
       const prev = Math.max(activeIndex - 1, 0)
-      setActiveIndex(prev)
-      itemRefsLocal.current[prev]?.focus()
-      onNavigate?.('up')
+      setActiveIndex(prev); itemRefsLocal.current[prev]?.focus(); onNavigate?.('up')
     } else if (e.key === 'Home') {
-      e.preventDefault()
-      setActiveIndex(0)
-      itemRefsLocal.current[0]?.focus()
+      e.preventDefault(); setActiveIndex(0); itemRefsLocal.current[0]?.focus()
     } else if (e.key === 'End') {
       e.preventDefault()
       const last = childCount - 1
-      setActiveIndex(last)
-      itemRefsLocal.current[last]?.focus()
+      setActiveIndex(last); itemRefsLocal.current[last]?.focus()
     }
   }
 
   return (
     <div
       role="listbox"
+      aria-label={ariaLabel ?? label}
       tabIndex={-1}
-      className={cn(
-        'overflow-y-auto focus-visible:outline-hidden',
-        !isMobile && 'border-r border-surface-border',
-        className,
-      )}
+      className={cn('overflow-y-auto focus-visible:outline-hidden', !isMobile && 'border-e border-surface-border', className)}
       onKeyDown={handleKeyDown}
       {...props}
     >
@@ -181,15 +156,15 @@ function MasterDetailList({ children, className, ...props }: MasterDetailListPro
 
 function MasterDetailDetail({ children, className, ...props }: MasterDetailDetailProps) {
   const { selected, isMobile, onBack, emptyState } = React.useContext(MasterDetailContext)
-
-  // On mobile, hide detail when nothing selected
+  const reduced = useReducedMotion()
   if (isMobile && !selected) return null
 
   return (
-    <div className={cn('flex-1 overflow-y-auto', className)} {...props}>
+    // aria-live so AT users are told the detail changed when the selection swaps.
+    <div role="region" aria-label="Detail" aria-live="polite" className={cn('flex-1 overflow-y-auto', className)} {...props}>
       {isMobile && onBack && (
         <div className="border-b border-surface-border px-ds-04 py-ds-03">
-          <Button variant="ghost" size="xs" onClick={onBack} startIcon={<Icon icon={IconArrowLeft} />}>
+          <Button variant="ghost" size="xs" onClick={onBack} startIcon={<Icon icon={IconArrowLeft} className="rtl:-scale-x-100" />}>
             Back
           </Button>
         </div>
@@ -197,10 +172,10 @@ function MasterDetailDetail({ children, className, ...props }: MasterDetailDetai
       <AnimatePresence mode="wait">
         <motion.div
           key={selected ?? 'empty'}
-          initial={isMobile ? { x: 20, opacity: 0 } : false}
+          initial={isMobile && !reduced ? { x: 20, opacity: 0 } : false}
           animate={{ x: 0, opacity: 1 }}
-          exit={isMobile ? { x: -20, opacity: 0 } : undefined}
-          transition={springs.snappy}
+          exit={isMobile && !reduced ? { x: -20, opacity: 0 } : undefined}
+          transition={reduced ? { duration: 0 } : springs.snappy}
         >
           {selected ? children : (emptyState ?? children)}
         </motion.div>
@@ -210,13 +185,20 @@ function MasterDetailDetail({ children, className, ...props }: MasterDetailDetai
 }
 
 const MasterDetailListItem = React.forwardRef<HTMLButtonElement, MasterDetailListItemProps>(
-  function MasterDetailListItem({ active = false, children, className, onKeyDown, ...props }, ref) {
+  function MasterDetailListItem({ active, value, children, className, onKeyDown, onClick, ...props }, ref) {
+    const { selected, onSelect } = React.useContext(MasterDetailContext)
+    const isActive = active ?? (value != null && value === selected)
+
     function handleKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
-        ;(e.target as HTMLButtonElement).click()
+        ;(e.currentTarget as HTMLButtonElement).click()
       }
       onKeyDown?.(e)
+    }
+    function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
+      if (value != null) onSelect?.(value)
+      onClick?.(e)
     }
 
     return (
@@ -224,15 +206,16 @@ const MasterDetailListItem = React.forwardRef<HTMLButtonElement, MasterDetailLis
         ref={ref}
         type="button"
         role="option"
-        aria-selected={active}
-        data-active={active || undefined}
+        aria-selected={isActive}
+        data-active={isActive || undefined}
         onKeyDown={handleKeyDown}
+        onClick={handleClick}
         className={cn(
           'flex w-full items-center px-ds-04 py-ds-03 text-left text-body-md font-sans text-surface-fg',
           'transition-colors duration-fast-01 ease-productive-standard',
           'hover:bg-surface-raised-hover',
           'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-7 focus-visible:ring-inset',
-          active && 'bg-accent-2 text-accent-11 font-medium',
+          isActive && 'bg-accent-2 text-accent-11 font-medium',
           className,
         )}
         {...props}
@@ -243,12 +226,11 @@ const MasterDetailListItem = React.forwardRef<HTMLButtonElement, MasterDetailLis
   },
 )
 
-// ============================================================
-// MasterDetail Root
-// ============================================================
-
 function MasterDetailRoot({
-  selected = null,
+  selected,
+  defaultSelected = null,
+  onSelect,
+  label = 'Items',
   onBack,
   masterWidth = '280px',
   breakpoint = 'md',
@@ -261,25 +243,32 @@ function MasterDetailRoot({
 }: MasterDetailProps) {
   const isMobile = useMediaQuery(`(max-width: ${breakpoints[breakpoint]})`)
   const [activeIndex, setActiveIndex] = React.useState(0)
-  const [itemCount, setItemCount] = React.useState(0)
   const itemRefs = React.useRef<(HTMLButtonElement | null)[]>([])
+
+  // Controlled when `selected` is provided; otherwise own the selection.
+  const isControlled = selected !== undefined
+  const [internalSelected, setInternalSelected] = React.useState<string | null>(defaultSelected)
+  const resolvedSelected = isControlled ? selected ?? null : internalSelected
+
+  const handleSelect = React.useCallback(
+    (value: string) => {
+      if (!isControlled) setInternalSelected(value)
+      onSelect?.(value)
+    },
+    [isControlled, onSelect],
+  )
 
   const registerItemRef = React.useCallback((index: number, el: HTMLButtonElement | null) => {
     itemRefs.current[index] = el
   }, [])
 
   return (
-    <MasterDetailContext.Provider value={{ selected, isMobile, onBack, emptyState, onNavigate, activeIndex, setActiveIndex, registerItemRef, itemCount, setItemCount }}>
+    <MasterDetailContext.Provider
+      value={{ selected: resolvedSelected, onSelect: handleSelect, label, isMobile, onBack, emptyState, onNavigate, activeIndex, setActiveIndex, registerItemRef }}
+    >
       <div
-        className={cn(
-          'flex h-full',
-          !isMobile && 'grid',
-          className,
-        )}
-        style={{
-          ...style,
-          ...(isMobile ? {} : { gridTemplateColumns: `${masterWidth} 1fr` }),
-        }}
+        className={cn('flex h-full', !isMobile && 'grid', className)}
+        style={{ ...style, ...(isMobile ? {} : { gridTemplateColumns: `${masterWidth} 1fr` }) }}
         {...props}
       >
         {children}


### PR DESCRIPTION
Additive (non-breaking). **a11y (P0):** listbox accessible name via `label` (was nameless to SR); detail pane `role=region aria-live=polite` (was silent swap). **api (P1):** selection ownership — `value` per row + `onSelect`/`defaultSelected` on root; active/aria-selected derive from context (no hand-wiring active+onClick). Controlled `selected` unchanged. **P2:** reduced-motion on mobile slide; RTL `border-e` + mirrored back arrow; removed dead itemCount context. 7/7 green.