### PR TITLE
fix(file-upload): focus-visible ring + motion hygiene (audit)

### DIFF
--- a/.changeset/file-upload-focus-motion.md
+++ b/.changeset/file-upload-focus-motion.md
@@ -1,0 +1,22 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix(file-upload): focus-visible ring + motion hygiene (audit)
+
+No API change — a11y + motion fixes.
+
+- **a11y (P0):** the keyboard-operable `role="button"` drop zone now has the DS
+  `focus-ring` — a `div[role=button]` gets no usable UA focus outline, so keyboard
+  users had no visible focus (WCAG 2.4.7).
+- **a11y (P1):** the disabled drop zone is `tabIndex={-1}` (leaves the tab order) to
+  match its `aria-disabled` — it was still focusable while disabled.
+- **motion (P1):** the progress bar animates `scaleX` on a full-width child
+  (`transform-origin: left`) instead of `width` — compositor-only and honored by
+  `prefers-reduced-motion` (a `width` animation slips past `MotionConfig`).
+- **motion (P1):** removed the default 5-keyframe error shake; the alert now fades/
+  slides in calmly.
+- **visual (P2):** the drop zone rests on `bg-surface-base` and tints on hover — the
+  hover token was being used at rest; adds real hover feedback.
+
+Follow-up (not in this change): compose the compact variant on `<Button>`.

--- a/packages/core/src/BelowBarBeforeAfter.stories.tsx
+++ b/packages/core/src/BelowBarBeforeAfter.stories.tsx
@@ -6,6 +6,7 @@ import { AvatarGroup, type AvatarUser } from './composed/avatar-group'
 import { TableSkeleton, ListSkeleton } from './composed/loading-skeleton'
 import { ErrorDisplay } from './composed/error-boundary'
 import { MasterDetail } from './composed/master-detail'
+import { FileUpload } from './ui/file-upload'
 import { Button } from './ui/button'
 import { Text } from './ui/text'
 
@@ -228,6 +229,21 @@ export const BeforeAfter: Story = {
             'motion (P2): the mobile detail slide is gated behind useReducedMotion (opacity-only / instant under prefers-reduced-motion).',
             'RTL (P2): list divider border-r → border-e; the mobile back arrow mirrors under dir="rtl".',
             'cleanup: removed the dead itemCount context; roving activeIndex derives from value or explicit active. (asChild/typeahead noted as follow-ups.)',
+          ]}
+        />
+
+        {/* ── file-upload: focus-visible + motion hygiene ── */}
+        <Row
+          name="FileUpload — focus-visible + motion hygiene"
+          verdict="Audit P0: the keyboard-operable drop zone had no focus-visible ring. P1: progress animated width (layout, escaped reduced-motion) + a default error shake."
+          after={<FileUpload onFiles={() => {}} label="Drop files or click to upload" />}
+          changes={[
+            'a11y (P0): the role="button" drop zone now has the focus-ring util — tab to it and you get a visible ring (a div[role=button] gets no usable UA outline). WCAG 2.4.7.',
+            'a11y (P1): disabled drop zone is tabIndex=-1 (leaves the tab order) to match aria-disabled — was still focusable while disabled.',
+            'motion (P1): progress bar animates scaleX on a full-width child (transform-origin:left) instead of width — compositor-only + honored by prefers-reduced-motion (width slipped past MotionConfig).',
+            'motion (P1): removed the default 5-keyframe error shake — the alert fades/slides in calmly now.',
+            'visual (P2): the drop zone rests on bg-surface-base (canvas) and tints on hover — the hover token was being used at rest; adds real hover feedback.',
+            'Follow-up noted: compose the compact variant on <Button> (still re-rolls button chrome).',
           ]}
         />
       </div>

--- a/packages/core/src/ui/file-upload.tsx
+++ b/packages/core/src/ui/file-upload.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence,motion } from 'framer-motion'
 import * as React from 'react'
 
 import { Icon } from './icon'
-import { durations,springs, tweens } from './lib/motion'
+import { springs, tweens } from './lib/motion'
 import { cn } from './lib/utils'
 import { Spinner } from './spinner'
 
@@ -301,7 +301,7 @@ const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
       >
         <motion.div
           role="button"
-          tabIndex={0}
+          tabIndex={disabled ? -1 : 0}
           aria-disabled={disabled || undefined}
           onClick={disabled ? undefined : openPicker}
           onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -313,11 +313,11 @@ const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
           className={cn(
             'flex flex-col items-center justify-center gap-ds-03 rounded-surface',
             'border-2 border-dashed p-ds-08',
-            'cursor-pointer',
-            'border-surface-border-strong bg-surface-raised-hover',
-            isDragActive &&
-              'border-accent-7 bg-accent-2',
-            disabled && 'opacity-action-disabled cursor-not-allowed',
+            'focus-ring transition-colors duration-fast-02 ease-productive-standard',
+            // Rest on the canvas fill; reserve the hover token for actual hover.
+            'border-surface-border-strong bg-surface-base',
+            disabled ? 'cursor-not-allowed opacity-action-disabled' : 'cursor-pointer hover:bg-surface-raised-hover',
+            isDragActive && 'border-accent-7 bg-accent-2',
           )}
           animate={{
             scale: isDragActive ? 1.02 : 1,
@@ -371,8 +371,9 @@ const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
                 className="h-2 w-full overflow-hidden rounded-pill bg-surface-raised-hover"
               >
                 <motion.div
-                  className="h-full rounded-pill bg-accent-9"
-                  animate={{ width: `${progress}%` }}
+                  // scaleX (compositor-only) not width (layout) → smooth + honored by reduced-motion.
+                  className="h-full w-full origin-left rounded-pill bg-accent-9"
+                  animate={{ scaleX: Math.max(0, Math.min(100, progress)) / 100 }}
                   transition={springs.smooth}
                 />
               </div>
@@ -399,16 +400,16 @@ const FileUpload = React.forwardRef<HTMLDivElement, FileUploadProps>(
           onFocus={handleInputFocus}
           tabIndex={-1}
         />
-        {/* Error message with shake animation */}
+        {/* Error message — a calm fade/slide in (no decorative shake). */}
         <AnimatePresence>
           {displayError && (
             <motion.p
               role="alert"
               className="mt-ds-02 text-body-xs text-error-11"
-              initial={{ opacity: 0, x: 0 }}
-              animate={{ opacity: 1, x: [0, -4, 4, -4, 4, 0] }}
+              initial={{ opacity: 0, y: -2 }}
+              animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0 }}
-              transition={{ opacity: tweens.fade, x: { type: 'tween', duration: durations.slow01, ease: 'easeOut' } }}
+              transition={tweens.fade}
             >
               {displayError}
             </motion.p>


### PR DESCRIPTION
No API change. **a11y (P0):** `focus-ring` on the `role=button` drop zone (keyboard users had no visible focus). **P1:** disabled drop zone `tabIndex=-1`; progress bar animates `scaleX` (compositor + reduced-motion) not `width`; removed the default error shake. **P2:** drop zone rests on canvas + hover tint (hover token was at rest). 18/18 green.