### PR TITLE
fix: P2 audit sweep — spinner/icon-button/separator

### DIFF
--- a/.changeset/p2-sweep-spinner-iconbutton-separator.md
+++ b/.changeset/p2-sweep-spinner-iconbutton-separator.md
@@ -1,0 +1,18 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix: P2 audit sweep — spinner reduced-motion contract, icon-button touch target, separator stories
+
+- **spinner (P1):** `onComplete` now fires under `prefers-reduced-motion`. The static
+  success/error paths render without an `onAnimationComplete`, so the documented
+  `onComplete` callback was silently dropped for reduced-motion users — a flow that
+  advances on the success tick would stall. It now fires from an effect when the final
+  state mounts, regardless of motion preference.
+- **icon-button (P1):** `sm` (32px) and `md` (40px) icon buttons now carry the
+  `touch-target` util — an invisible ≥44px press region (visual size unchanged) so
+  keyboard/touch targets meet WCAG 2.5.5. `lg` (48px) already cleared it. JSDoc
+  taxonomy corrected (adds `soft`; real color axis).
+- **separator:** dropped the dead `variant` radio control from Storybook (the prop is a
+  no-op since 0.45.0; the control advertised a feature that does nothing). The prop's
+  removal itself is a breaking change deferred to the next major.

--- a/packages/core/src/ui/icon-button.tsx
+++ b/packages/core/src/ui/icon-button.tsx
@@ -27,7 +27,8 @@ type IconButtonSize = 'sm' | 'md' | 'lg'
  *
  * **Size:** `'sm'` | `'md'` (default) | `'lg'` — maps to `icon-sm/md/lg` sizes internally.
  *
- * **All `Button` variants** are supported: `solid`, `outline`, `ghost`, `link` x `default`, `error`.
+ * **All `Button` axes** flow through: variants `solid` | `soft` | `outline` | `ghost` | `link`,
+ * colors `accent` | `error` | `success` | `warning` | `info` | `neutral` (see `Button`).
  *
  * @example
  * // Ghost toolbar icon button:
@@ -70,7 +71,13 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
       <Button
         ref={ref}
         size={sizeMap[size]}
-        className={cn(shape === 'circle' && 'rounded-pill', className)}
+        // sm (32px) / md (40px) are below the 44px touch target — expand the press
+        // region with an invisible ::before (visual size unchanged). lg is 48px.
+        className={cn(
+          shape === 'circle' && 'rounded-pill',
+          (size === 'sm' || size === 'md') && 'touch-target',
+          className,
+        )}
         loading={loading}
         loadingPosition="center"
         {...props}

--- a/packages/core/src/ui/separator.stories.tsx
+++ b/packages/core/src/ui/separator.stories.tsx
@@ -11,10 +11,6 @@ const meta = preview.meta({
       options: ['horizontal', 'vertical'],
     },
     decorative: { control: 'boolean' },
-    variant: {
-      control: 'radio',
-      options: ['default', 'gradient', 'gradient-left', 'gradient-right'],
-    },
   },
 })
 export default meta

--- a/packages/core/src/ui/spinner.test.tsx
+++ b/packages/core/src/ui/spinner.test.tsx
@@ -77,4 +77,9 @@ describe('Spinner', () => {
     // At least 2 circles: track + animated arc
     expect(circles.length).toBeGreaterThanOrEqual(2)
   })
+
+  // Note: the reduced-motion onComplete contract (fires from the static success/error
+  // path) can't be unit-tested here — framer-motion resolves reduced-motion via a
+  // module-level matchMedia singleton cached at import, so a runtime matchMedia swap
+  // doesn't flip it. Verified by code review (spinner.tsx: onComplete effect).
 })

--- a/packages/core/src/ui/spinner.tsx
+++ b/packages/core/src/ui/spinner.tsx
@@ -99,6 +99,16 @@ const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(
       return () => clearTimeout(timer)
     }, [delay])
 
+    // Under reduced-motion the success/error paths render statically (no
+    // onAnimationComplete), so fire the documented onComplete contract here.
+    const onCompleteRef = React.useRef(onComplete)
+    React.useEffect(() => { onCompleteRef.current = onComplete })
+    React.useEffect(() => {
+      if (prefersReduced && (state === 'success' || state === 'error')) {
+        onCompleteRef.current?.()
+      }
+    }, [prefersReduced, state])
+
     if (!visible) return null
 
     const arcSw = arcStrokeWidths[size]


### PR DESCRIPTION
**spinner (P1):** `onComplete` fires under reduced-motion (the static success/error path had no `onAnimationComplete` → the documented callback was silently dropped for RM users). **icon-button (P1):** `sm`/`md` get the `touch-target` util (invisible ≥44px press region, visual size unchanged) for WCAG 2.5.5; JSDoc taxonomy fixed. **separator:** dropped the dead `variant` radio from stories (no-op prop since 0.45; prop removal deferred to next major). 42 green.