### PR TITLE
fix: P2 audit sweep — switch RTL/reduced-motion, table forced-colors

### DIFF
--- a/.changeset/p2-sweep-switch-table.md
+++ b/.changeset/p2-sweep-switch-table.md
@@ -1,0 +1,13 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix: P2 audit sweep — switch RTL + reduced-motion, table forced-colors selection
+
+- **switch (P1):** the thumb now travels toward the inline-end — mirrored under
+  `dir="rtl"` (it previously slid the wrong way in RTL). The thumb spring +
+  press-scale are gated behind `useReducedMotion` (instant, no scale under
+  `prefers-reduced-motion`).
+- **table (P1):** the selected-row tint (`accent-3`) gets a `forced-colors:outline`
+  fallback so selection survives Windows High-Contrast Mode (the tint collapses to
+  Canvas with no cue otherwise).

--- a/packages/core/src/ui/switch.tsx
+++ b/packages/core/src/ui/switch.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as SwitchPrimitives from "@primitives/react-switch"
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import * as React from "react"
 
 import { useFormField } from './form'
@@ -48,6 +48,11 @@ const Switch = React.forwardRef<
   // Track checked state internally to drive Framer Motion animation
   const [internalChecked, setInternalChecked] = React.useState(defaultChecked ?? false)
   const isChecked = checked !== undefined ? checked : internalChecked
+  const reduced = useReducedMotion()
+  // Thumb travels toward the inline-end — mirror it under RTL.
+  const isRtl =
+    typeof document !== 'undefined' &&
+    (document.dir === 'rtl' || document.documentElement.dir === 'rtl')
   const { track, thumb, travel } = sizeConfig[size]
 
   const handleCheckedChange = React.useCallback(
@@ -84,9 +89,9 @@ const Switch = React.forwardRef<
             "pointer-events-none flex items-center justify-center rounded-pill bg-accent-fg shadow-raised-hover ring-0",
             thumb
           )}
-          animate={{ x: isChecked ? travel : 0 }}
-          whileTap={{ scale: 0.85 }}
-          transition={springs.snappy}
+          animate={{ x: (isChecked ? travel : 0) * (isRtl ? -1 : 1) }}
+          whileTap={reduced ? undefined : { scale: 0.85 }}
+          transition={reduced ? { duration: 0 } : springs.snappy}
         >
           {thumbIcon}
         </motion.span>

--- a/packages/core/src/ui/table.tsx
+++ b/packages/core/src/ui/table.tsx
@@ -108,7 +108,7 @@ const TableRow = React.forwardRef<
       // `group/row` lets TableRowActions reveal on row hover/focus; the has-[]
       // rule draws a row-level focus ring when a TableRowLink inside is
       // keyboard-focused (the anchor itself suppresses its own ring).
-      "group/row border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3 data-[state=selected]:hover:bg-accent-4",
+      "group/row border-b border-surface-border-subtle transition-colors hover:bg-surface-raised-hover data-[state=selected]:bg-accent-3 data-[state=selected]:hover:bg-accent-4 data-[state=selected]:forced-colors:outline data-[state=selected]:forced-colors:outline-1",
       "has-[[data-slot=row-link]:focus-visible]:outline-2 has-[[data-slot=row-link]:focus-visible]:outline-accent-9 has-[[data-slot=row-link]:focus-visible]:-outline-offset-2",
       className,
     )}


### PR DESCRIPTION
**switch (P1):** thumb travel mirrored under `dir=rtl` (slid the wrong way in RTL); spring + press-scale gated behind `useReducedMotion`. **table (P1):** selected-row tint gets a `forced-colors:outline` fallback (collapsed to Canvas in Windows HCM with no cue). 34 green.