### PR TITLE
fix: P2 sweep — notification-preferences a11y + split-button doc

### DIFF
--- a/.changeset/p2-sweep-notifprefs-splitbutton.md
+++ b/.changeset/p2-sweep-notifprefs-splitbutton.md
@@ -1,0 +1,18 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix: P2 audit sweep — notification-preferences a11y names + split-button doc accuracy
+
+- **notification-preferences (P1 a11y):** the per-row mute `Switch` and min-tier
+  `Select` now have accessible names (`aria-label`) — every row's inline controls
+  announced their value with no "what" (WCAG 4.1.2). Names include the channel +
+  project (e.g. "Mute In-App for Karm V2").
+- **split-button (docs):** corrected the Composability section — it falsely claimed
+  SplitButton *inherits* Button's variant/color/size vocabulary and `ButtonGroup`
+  context (it re-implements styling locally and ignores group context). Dropped the
+  stale "arrow-key nav planned for 0.45.0" changelog line.
+
+Deferred (bigger/riskier, noted for a future pass): derive split-button's half styling
+from `buttonVariants` (layout-sensitive), and de-duplicate the context-menu/menubar
+Radix-twin plumbing.

--- a/packages/core/docs/components/ui/split-button.md
+++ b/packages/core/docs/components/ui/split-button.md
@@ -37,9 +37,9 @@ import { SplitButton } from '@devalok/shilp-sutra'
 
 ## Composability
 - **Two-in-one button:** visually unified `[Action | ▼]` with the left half being the primary click and the right half opening a dropdown. Use for actions that have a most-common choice plus alternatives (Save vs. Save-As-Draft, Send vs. Schedule).
-- **Built on Button + Popover internally** — inherits Button's variant/color/size vocabulary and Popover's placement prop (`top-end` default works for most top-of-page toolbars).
+- **Composes the DS Popover internally** and shares the `color` type + a `variant`/`size` subset with Button (currently `solid`/`soft`/`outline` × the Button colors; no `ghost`/`link`/`lg`). Note: the half styling is implemented locally, not inherited from `Button` — a few Button niceties (e.g. `solid`'s `hover:shadow-brand`) don't apply. Popover placement via `top-end` default suits most top-of-page toolbars.
 - **Dropdown content is consumer-provided** — pass any JSX via `dropdownContent` (typically a DropdownMenu, list of actions, a custom panel, or a small form). Don't try to shove a full-featured menu into the chevron; keep it focused on 2–5 alternatives.
-- **ButtonGroup compatibility:** Put SplitButton inside a `<ButtonGroup>` — it inherits variant/color/size from the group context just like Button does. Position-aware corners work too.
+- **ButtonGroup:** SplitButton does NOT consume `ButtonGroup` context — set its `variant`/`color`/`size` explicitly to match a surrounding group.
 - **Controlled dropdown:** Pass `open` + `onOpenChange` for controlled state; omit for uncontrolled. Useful when the dropdown must close programmatically after a selection.
 
 ## Gotchas
@@ -49,7 +49,7 @@ import { SplitButton } from '@devalok/shilp-sutra'
 ## Changes
 
 ### v0.44.2
-- **Fixed** The dropdown is now keyboard-accessible. It previously used a hand-rolled floating panel (`role="menu"`) with no focus management, arrow keys, or Escape — keyboard users couldn't reach or dismiss it. It now composes the DS **Popover** primitive: focus moves in on open, Escape and outside-click close, focus returns to the trigger, and on mobile it opens as a bottom sheet. (Full menu semantics with arrow-key item navigation via DropdownMenu are planned for 0.45.0.)
+- **Fixed** The dropdown is now keyboard-accessible. It previously used a hand-rolled floating panel (`role="menu"`) with no focus management, arrow keys, or Escape — keyboard users couldn't reach or dismiss it. It now composes the DS **Popover** primitive: focus moves in on open, Escape and outside-click close, focus returns to the trigger, and on mobile it opens as a bottom sheet.
 
 ### v0.33.0
 - **Added** Initial release

--- a/packages/core/src/shell/notification-preferences.tsx
+++ b/packages/core/src/shell/notification-preferences.tsx
@@ -213,7 +213,10 @@ const NotificationPreferences = React.forwardRef<HTMLDivElement, NotificationPre
                       value={pref.minTier}
                       onValueChange={(v) => onUpdateTier?.(pref, v)}
                     >
-                      <SelectTrigger className="h-ds-xs-plus w-[130px] text-body-sm">
+                      <SelectTrigger
+                        aria-label={`Minimum notification tier for ${channelInfo.label} on ${getProjectName(pref.projectId)}`}
+                        className="h-ds-xs-plus w-[130px] text-body-sm"
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -231,6 +234,7 @@ const NotificationPreferences = React.forwardRef<HTMLDivElement, NotificationPre
                         {pref.muted ? 'Muted' : 'Active'}
                       </span>
                       <Switch
+                        aria-label={`${pref.muted ? 'Unmute' : 'Mute'} ${channelInfo.label} for ${getProjectName(pref.projectId)}`}
                         checked={!pref.muted}
                         onCheckedChange={() => onToggleMute?.(pref)}
                       />


### PR DESCRIPTION
**notification-preferences (P1 a11y):** per-row mute Switch + min-tier Select get `aria-label` (channel + project) — inline controls were unnamed (WCAG 4.1.2). **split-button (docs):** corrected the false Composability claims (it does NOT inherit Button vocab / ButtonGroup context — re-rolls styling locally); dropped the stale 'planned for 0.45.0' line. Deferred (noted): split-button `buttonVariants` derivation (layout-risky) + context-menu/menubar Radix-twin de-dup.