### PR TITLE
fix(combobox): FormField label association for the div trigger (release blocker)

### DIFF
--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -437,15 +437,17 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
             role="combobox"
             tabIndex={disabled ? -1 : 0}
             data-disabled={disabled || undefined}
-            // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor> resolves.
-            id={externalId ?? fieldCtx.inputId}
+            id={externalId}
             aria-expanded={open}
             aria-controls={listboxId}
             aria-haspopup="listbox"
             aria-disabled={disabled || undefined}
-            // Explicit accessibleLabel wins. Inside a FormField, let the visible <Label>
-            // provide the name (via htmlFor); only fall back to placeholder when standalone.
-            aria-label={accessibleLabel ?? (fieldCtx.inputId ? undefined : placeholder)}
+            // The trigger is a div[role=combobox] — non-labellable, so `<Label htmlFor>`
+            // can't target it. Inside a FormField, adopt the label's id via
+            // aria-labelledby; explicit accessibleLabel wins; placeholder is the
+            // standalone fallback.
+            aria-labelledby={accessibleLabel ? undefined : fieldCtx.labelId}
+            aria-label={accessibleLabel ?? (fieldCtx.labelId ? undefined : placeholder)}
             aria-invalid={isError || undefined}
             aria-describedby={ariaDescribedBy}
             aria-required={ariaRequired || undefined}

--- a/packages/core/src/ui/form.tsx
+++ b/packages/core/src/ui/form.tsx
@@ -13,6 +13,13 @@ interface FormFieldContextValue {
   helperTextId?: string
   /** Auto-generated id shared between Label (htmlFor) and the field input (id). */
   inputId?: string
+  /**
+   * Auto-generated id of the Label itself. Non-labellable controls (e.g. the
+   * Combobox trigger, a `div[role=combobox]`, which `<label htmlFor>` can't target)
+   * reference this via `aria-labelledby` to still adopt the visible label as their
+   * accessible name.
+   */
+  labelId?: string
   required?: boolean
 }
 const FormFieldContext = React.createContext<FormFieldContextValue>({})
@@ -55,9 +62,10 @@ const FormField = React.forwardRef<HTMLDivElement, FormFieldProps>(
     const autoId = React.useId()
     const resolvedHelperId = helperTextId || `${autoId}-helper`
     const resolvedInputId = inputId || `${autoId}-input`
+    const resolvedLabelId = `${resolvedInputId}-label`
     const contextValue = React.useMemo(
-      () => ({ state, helperTextId: resolvedHelperId, inputId: resolvedInputId, required }),
-      [state, resolvedHelperId, resolvedInputId, required],
+      () => ({ state, helperTextId: resolvedHelperId, inputId: resolvedInputId, labelId: resolvedLabelId, required }),
+      [state, resolvedHelperId, resolvedInputId, resolvedLabelId, required],
     )
 
     return (

--- a/packages/core/src/ui/label.tsx
+++ b/packages/core/src/ui/label.tsx
@@ -14,14 +14,18 @@ export interface LabelProps
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   LabelProps
->(({ className, required, children, htmlFor, ...props }, ref) => {
+>(({ className, required, children, htmlFor, id, ...props }, ref) => {
   const fieldCtx = useFormField()
   // Explicit htmlFor wins; otherwise fall back to FormField's inputId.
   const resolvedHtmlFor = htmlFor ?? fieldCtx.inputId
+  // Adopt the field's labelId so non-labellable controls (Combobox div) can point
+  // aria-labelledby at this label. Explicit id wins.
+  const resolvedId = id ?? fieldCtx.labelId
   const resolvedRequired = required ?? fieldCtx.required
   return (
     <LabelPrimitive.Root
       ref={ref}
+      id={resolvedId}
       htmlFor={resolvedHtmlFor}
       className={cn(
         'font-sans text-body-md font-medium text-surface-fg leading-none transition-opacity duration-fast-01 ease-productive-standard peer-disabled:opacity-action-disabled',


### PR DESCRIPTION
**Release blocker fix.** The 0.54.0 release failed at the Test gate (publish skipped → nothing published). One test failed: `form-field-label-association.test.tsx > Combobox` — the #217 nested-button fix made the trigger a `div[role=combobox]`, and `<label htmlFor>` can't target a non-labellable div, so FormField's label auto-association broke (getByLabelText threw 'non-labellable').

Fix: FormField exposes a `labelId`; Label adopts it as its id; the combobox references it via `aria-labelledby` and stops adopting `inputId` (which made the label's htmlFor hit the div). Labellable controls unchanged. 271 form-control tests green. Folds into unpublished 0.54.0 (no new changeset).