### PR TITLE
fix(types): make published .d.ts usable with declaration checking on

### DIFF
--- a/.changeset/dts-consumer-correctness.md
+++ b/.changeset/dts-consumer-correctness.md
@@ -19,13 +19,19 @@ All three faults were invisible on the most common consumer config (`moduleResol
 
 **Three dependencies removed — no consumer action required.** `diff`, `frimousse` and `@emoji-mart/data` were declared as runtime dependencies while already being fully bundled into `dist`, so every consumer installed packages they also received a copy of. Nothing resolves them at runtime and nothing references them in the types. Dependencies drop from seven to four; the remaining four are all genuinely required — `class-variance-authority` and `clsx` appear in our published types, `tw-animate-css` is resolved by your CSS build, and `use-sync-external-store` is an externalized TipTap transitive.
 
-**Four gates added, so this class cannot ship again.** The 45 existing gates all passed on the broken release because our own consumer smoke test set `skipLibCheck: true` — the exact setting that hides it.
+**Two more faults, found only under pnpm.** All of the above was verified with npm, which hoists dependencies flat and auto-installs peers — so an undeclared package still resolves and a forgotten peer still appears. Re-running the same verification under pnpm's isolated layout surfaced two further problems, both of which ship in 0.54.0 today:
 
-- `scripts/audit-dts.mjs` — asserts no directive prologue, no undeclared bare specifier, no extensionless relative specifier.
-- `attw` in the pre-publish audit, ignoring only the two by-design rules (ESM-only, and node10's inability to read `exports`).
+- **`@tiptap/pm` was missing from the peer set.** TipTap's own declarations import `@tiptap/pm/state` and TipTap declares `@tiptap/pm` as *its* peer, so `pnpm add -D @tiptap/react` still left six `TS2307` errors from inside TipTap. This is not derivable from our imports — the requirement lives in the peer's types — so `derive-peer-map.mjs` gains an explicit companion map.
+- **Two 0-byte emitted modules** (`dist/ui/toast-types.js`, `dist/ai/types.js`). A types-only entry has no runtime content, so the bundler emits an empty file while `exports` still advertises a runtime path. An empty file gives Node's module-type detection nothing to read, and under pnpm's symlinks that ambiguity throws `ERR_REQUIRE_CYCLE_MODULE` on import. A new `fix-empty-modules.mjs` gives them an `export {}` body.
+
+**Five gates added, so this class cannot ship again.** The 45 existing gates all passed on the broken release because our own consumer smoke test set `skipLibCheck: true` — the exact setting that hides it — and installed npm-style.
+
+- `scripts/audit-dts.mjs` — no directive prologue, no undeclared bare specifier, no extensionless relative specifier, no 0-byte emitted module.
+- `scripts/consumer-strict-install.mjs` — pnpm with hoisting disabled and auto-install-peers off, importing all 150 subpath exports and checking both types and runtime. This is the gate that found the two faults above.
+- `attw` (pinned, not `npx @latest`) in the pre-publish audit, ignoring only the two by-design rules — ESM-only, and node10's inability to read `exports`.
 - The smoke consumer now runs with `skipLibCheck: false`.
 - The smoke consumer type-checks across `bundler` × `nodenext` × `skipLibCheck` on/off.
 
-Verified against a packed tarball in a clean consumer: all four configurations report zero errors, and `attw`'s `InternalResolutionError` count goes from 301 to 0.
+Verified against a packed tarball: 150/150 subpaths type-check clean under pnpm at `skipLibCheck: false` and 150/150 import cleanly at runtime; all four tsconfig combinations report zero errors; `attw`'s `InternalResolutionError` count goes from 301 to 0. Also verified React 18, `require(esm)` on Node 22.12+, a real Tailwind 4 build emitting every DS utility, and an end-to-end Vite app that builds, server-renders, and passes 13 browser interaction checks with no console errors.
 
 Two behaviours are documented rather than changed, in `docs/recipes/troubleshoot.md`: legacy `moduleResolution: "node"` cannot resolve our subpaths (it predates `exports`), and the package is ESM-only, so CommonJS callers need a dynamic import.

--- a/.changeset/dts-consumer-correctness.md
+++ b/.changeset/dts-consumer-correctness.md
@@ -1,0 +1,31 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+Fix three faults that made the published type declarations unusable for anyone type-checking them, and drop three dependencies that were never needed.
+
+Reported by a consumer who installed 0.54.0 and hit "a ton of TS errors from your package's `.d.ts` file". Reproduced exactly: one `import { Button } from '@devalok/shilp-sutra/ui'` produced **78 errors**.
+
+All three faults were invisible on the most common consumer config (`moduleResolution: "bundler"` + `skipLibCheck: true`), which is why they shipped. They appear the moment a consumer turns on declaration checking.
+
+**`"use client"` no longer emitted into `.d.ts`** — 209 of 284 published declaration files began with a `"use client"` prologue. A `.d.ts` is an ambient context, so that is a statement, and every one was `error TS1036: Statements are not allowed in ambient contexts`. The directive is a bundler/RSC runtime concern, read off the `.js` module graph; declarations are erased before anything runs. `inject-use-client.mjs` now skips `.d.ts` and strips any stale directive.
+
+**No more undeclared type imports** — `split-button.d.ts` referenced `@floating-ui/dom` and seven files referenced `@tiptap/core` / `@tiptap/react` / `@tiptap/suggestion`, none of them declared anywhere: `error TS2307: Cannot find module`. The cause was a rule that only held for runtime — a module is a consumer peer *iff* the build externalizes it. Rollup bundles TipTap's JavaScript, but TypeScript's declaration emitter does not bundle third-party types, so the bare specifier survived into our `.d.ts` with nothing declaring it.
+
+- `@floating-ui/dom`'s `Placement` is now inlined as `SplitButtonPlacement` (same twelve members, also exported) — no install, no leak.
+- `@tiptap/core`, `@tiptap/react` and `@tiptap/suggestion` are now **optional, types-only peers**. The runtime stays bundled; install them as devDependencies only if you import `RichTextEditor` / `RichChatInput` and want the editor object typed. `derive-peer-map.mjs` understands this category, so `preflight` and the recipe tables say "types only" rather than implying a runtime need.
+
+**Relative imports in `.d.ts` now carry explicit `.js` extensions** — 234 extensionless specifiers broke `moduleResolution: "node16" | "nodenext"` (TS2834/TS2835). Directory specifiers resolve to `/index.js`. A new `fix-dts-extensions.mjs` post-build step handles this.
+
+**Three dependencies removed — no consumer action required.** `diff`, `frimousse` and `@emoji-mart/data` were declared as runtime dependencies while already being fully bundled into `dist`, so every consumer installed packages they also received a copy of. Nothing resolves them at runtime and nothing references them in the types. Dependencies drop from seven to four; the remaining four are all genuinely required — `class-variance-authority` and `clsx` appear in our published types, `tw-animate-css` is resolved by your CSS build, and `use-sync-external-store` is an externalized TipTap transitive.
+
+**Four gates added, so this class cannot ship again.** The 45 existing gates all passed on the broken release because our own consumer smoke test set `skipLibCheck: true` — the exact setting that hides it.
+
+- `scripts/audit-dts.mjs` — asserts no directive prologue, no undeclared bare specifier, no extensionless relative specifier.
+- `attw` in the pre-publish audit, ignoring only the two by-design rules (ESM-only, and node10's inability to read `exports`).
+- The smoke consumer now runs with `skipLibCheck: false`.
+- The smoke consumer type-checks across `bundler` × `nodenext` × `skipLibCheck` on/off.
+
+Verified against a packed tarball in a clean consumer: all four configurations report zero errors, and `attw`'s `InternalResolutionError` count goes from 301 to 0.
+
+Two behaviours are documented rather than changed, in `docs/recipes/troubleshoot.md`: legacy `moduleResolution: "node"` cannot resolve our subpaths (it predates `exports`), and the package is ESM-only, so CommonJS callers need a dynamic import.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -99,6 +99,13 @@ jobs:
         if: steps.affected.outputs.core == 'true'
         run: node scripts/consumer-smoke-test.mjs
 
+      # pnpm isolated layout + every subpath. The smoke consumer above
+      # installs npm-style (hoisted, peers auto-installed), which hides
+      # undeclared deps and forgotten peers. This one cannot.
+      - name: Consumer strict install (pnpm isolated, all subpaths)
+        if: steps.affected.outputs.core == 'true'
+        run: node scripts/consumer-strict-install.mjs --no-build
+
       - name: Compiled-CSS coverage (Turbopack)
         if: steps.affected.outputs.core == 'true'
         run: node scripts/audit-compiled-css.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,18 @@ jobs:
         if: steps.affected.outputs.core == 'true'
         run: node scripts/consumer-smoke-test.mjs
 
+      # Strict-install consumer — pnpm with hoisting disabled and
+      # auto-install-peers off, importing EVERY subpath export. The smoke
+      # consumer above installs npm-style: deps get hoisted flat and peers
+      # are auto-installed, so an undeclared package still resolves and a
+      # forgotten peer still appears. pnpm's isolated layout does neither.
+      # Found two faults that every npm-based gate passed — a missing
+      # @tiptap/pm peer, and 0-byte emitted modules throwing
+      # ERR_REQUIRE_CYCLE_MODULE on import (both shipped in 0.54.0).
+      - name: Consumer strict install (pnpm isolated, all subpaths)
+        if: steps.affected.outputs.core == 'true'
+        run: node scripts/consumer-strict-install.mjs --no-build
+
       # Compiled-CSS coverage audit — verifies every DS utility class
       # referenced in source actually emits a rule in the consumer's
       # compiled CSS. Catches the exact failure mode that shipped

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ playgrounds-review-*/
 
 # Turborepo
 .turbo/
+tests/.strict-consumer/

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "release": "pnpm build:fresh && changeset publish"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.18.0",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.1",
     "@storybook/addon-a11y": "^10.5.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vitest/browser": "4.1.10",
     "@vitest/browser-playwright": "4.1.10",
     "autoprefixer": "^10.5.4",
+    "axe-core": "^4",
     "chromatic": "^18.1.0",
     "eslint": "^10.7.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://devalok-design.github.io/shilp-sutra/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/devalok-design/shilp-sutra",
+    "url": "git+https://github.com/devalok-design/shilp-sutra.git",
     "directory": "packages/brand"
   },
   "bugs": {

--- a/packages/core/docs/recipes/install-astro.md
+++ b/packages/core/docs/recipes/install-astro.md
@@ -38,8 +38,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
-| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
-| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-astro.md
+++ b/packages/core/docs/recipes/install-astro.md
@@ -38,6 +38,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-next-app-router.md
+++ b/packages/core/docs/recipes/install-next-app-router.md
@@ -51,6 +51,8 @@ Some components depend on third-party libraries that ship as optional peers. **I
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-next-app-router.md
+++ b/packages/core/docs/recipes/install-next-app-router.md
@@ -51,8 +51,8 @@ Some components depend on third-party libraries that ship as optional peers. **I
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
-| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
-| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-remix.md
+++ b/packages/core/docs/recipes/install-remix.md
@@ -34,6 +34,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-remix.md
+++ b/packages/core/docs/recipes/install-remix.md
@@ -34,8 +34,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
-| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
-| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-tanstack-start.md
+++ b/packages/core/docs/recipes/install-tanstack-start.md
@@ -43,6 +43,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-tanstack-start.md
+++ b/packages/core/docs/recipes/install-tanstack-start.md
@@ -43,8 +43,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
-| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
-| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-vite.md
+++ b/packages/core/docs/recipes/install-vite.md
@@ -49,8 +49,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
-| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
-| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/install-vite.md
+++ b/packages/core/docs/recipes/install-vite.md
@@ -49,6 +49,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/packages/core/docs/recipes/troubleshoot.md
+++ b/packages/core/docs/recipes/troubleshoot.md
@@ -206,6 +206,28 @@ pnpm add use-sync-external-store
 
 And open an issue at <https://github.com/devalok-design/shilp-sutra/issues> with the resolution graph (`pnpm why use-sync-external-store`) so we can fix the root cause.
 
+## Symptom: `error TS2305: Module '"react"' has no exported member 'ReactSVG'`
+
+**This is an upstream `@tabler/icons-react` bug, not a shilp-sutra one** — but you will hit it following our install instructions, so it is documented here.
+
+`@tabler/icons-react` (through 3.45.0, the current release) opens its type declarations with:
+
+```ts
+import { ReactSVG, … } from 'react'
+```
+
+React 18's types exported `ReactSVG`; React 19's removed it, keeping only `ReactSVGElement`. So on React 19 the icon package's own `.d.ts` fails to compile.
+
+You only see it with **all three**: React 19, `skipLibCheck: false`, and a direct `@tabler/icons-react` import in your own code. React 18 is unaffected, and the default `skipLibCheck: true` suppresses it.
+
+Workarounds, in order of preference:
+
+1. Leave `skipLibCheck: true` (the default in every framework scaffold). It suppresses errors inside dependency declarations — including this one.
+2. Import icons through our re-export instead of directly, so the broken declaration is never loaded into your program.
+3. Pin `@types/react` to 18 if your app is still on React 18.
+
+There is nothing to fix on our side: we neither wrap nor re-declare Tabler's types. Track it upstream at <https://github.com/tabler/tabler-icons/issues>.
+
 ## Symptom: `error TS2307: Cannot find module '@devalok/shilp-sutra/ui/button'` under `"moduleResolution": "node"`
 
 **Diagnosis:** You are on TypeScript's legacy resolution mode, which predates and ignores the `exports` field in `package.json`. Our files live under `dist/`, and every public path is mapped through `exports` — legacy resolution looks for a literal `node_modules/@devalok/shilp-sutra/ui/button.js` and finds nothing.

--- a/packages/core/docs/recipes/troubleshoot.md
+++ b/packages/core/docs/recipes/troubleshoot.md
@@ -196,6 +196,8 @@ In dev mode, calling `toast()` without a mounted `<Toaster />` logs a one-time c
 
 **Diagnosis:** Should not happen since v0.37.0 — `use-sync-external-store` was moved to runtime dependencies and is auto-installed transitively.
 
+**Why this dependency exists at all** (it is a hook built into React 18+, so it looks redundant): we do not use the shim ourselves. It is a TipTap transitive. TipTap's code is bundled into our `dist`, and that bundled chunk imports `use-sync-external-store/shim`. We externalize the shim rather than bundling it, because bundling forced a `createRequire` bridge into our Rollup runtime chunk that broke every Turbopack consumer. Externalized code must be resolvable from the consumer's tree, hence the declaration.
+
 If it still happens, install it explicitly:
 
 ```bash
@@ -203,6 +205,36 @@ pnpm add use-sync-external-store
 ```
 
 And open an issue at <https://github.com/devalok-design/shilp-sutra/issues> with the resolution graph (`pnpm why use-sync-external-store`) so we can fix the root cause.
+
+## Symptom: `error TS2307: Cannot find module '@devalok/shilp-sutra/ui/button'` under `"moduleResolution": "node"`
+
+**Diagnosis:** You are on TypeScript's legacy resolution mode, which predates and ignores the `exports` field in `package.json`. Our files live under `dist/`, and every public path is mapped through `exports` — legacy resolution looks for a literal `node_modules/@devalok/shilp-sutra/ui/button.js` and finds nothing.
+
+**Supported resolution modes:**
+
+| `moduleResolution` | Supported | Notes |
+|---|---|---|
+| `bundler` | ✅ | Recommended. Vite, Next.js, and most modern setups default to this. |
+| `node16` / `nodenext` | ✅ | Fully supported since 0.55.0. |
+| `node` (legacy) | ❌ | Cannot read `exports`. No subpath resolves. |
+
+Fix — in your `tsconfig.json`:
+
+```jsonc
+{ "compilerOptions": { "moduleResolution": "bundler" } }
+```
+
+## Symptom: `require('@devalok/shilp-sutra')` fails in a CommonJS file
+
+**Diagnosis:** The package is ESM-only — we ship no CommonJS build. `require()` of an ES module throws `ERR_REQUIRE_ESM` on older Node, and bundlers report the entry as ESM-only.
+
+Use a dynamic import from CommonJS:
+
+```js
+const { Button } = await import('@devalok/shilp-sutra/ui/button')
+```
+
+Or move the consuming file to ESM (`"type": "module"`, or a `.mjs` extension). Every supported framework target — Next.js, Vite, Remix, Astro, TanStack Start — handles the ESM entry natively; this only affects hand-written CJS scripts.
 
 ## Symptom: Storybook MCP server `localhost:6006/mcp` returns 404
 

--- a/packages/core/docs/recipes/troubleshoot.md
+++ b/packages/core/docs/recipes/troubleshoot.md
@@ -206,6 +206,27 @@ pnpm add use-sync-external-store
 
 And open an issue at <https://github.com/devalok-design/shilp-sutra/issues> with the resolution graph (`pnpm why use-sync-external-store`) so we can fix the root cause.
 
+## Symptom: `Cannot find package 'sonner'` when you only imported a hook (or `'react-markdown'` from the AI barrel)
+
+**Diagnosis:** you imported a *barrel* rather than the component itself, and the barrel re-exports something with an optional peer.
+
+- `@devalok/shilp-sutra/hooks` re-exports `toast`, which needs `sonner`.
+- `@devalok/shilp-sutra/ai` re-exports the block renderer, which needs `react-markdown`.
+
+A bundler tree-shakes the unused branch away, so this is invisible in a client build. It bites at **runtime in Node** — SSR, a route handler, a test — where the import is evaluated for real.
+
+Fix — import the specific module instead of the barrel:
+
+```ts
+// needs sonner installed, because the barrel also exports toast
+import { useIsMobile } from '@devalok/shilp-sutra/hooks'
+
+// no optional peers at all
+import { useIsMobile } from '@devalok/shilp-sutra/hooks/use-mobile'
+```
+
+Every hook has its own subpath: `use-mobile`, `use-color-mode`, `use-touch-device`, `use-viewport-height`. Same rule applies across the library — a deep import never costs you more than that component needs.
+
 ## Symptom: `error TS2305: Module '"react"' has no exported member 'ReactSVG'`
 
 **This is an upstream `@tabler/icons-react` bug, not a shilp-sutra one** — but you will hit it following our install instructions, so it is documented here.

--- a/packages/core/docs/recipes/troubleshoot.md
+++ b/packages/core/docs/recipes/troubleshoot.md
@@ -224,11 +224,16 @@ Fix — in your `tsconfig.json`:
 { "compilerOptions": { "moduleResolution": "bundler" } }
 ```
 
-## Symptom: `require('@devalok/shilp-sutra')` fails in a CommonJS file
+## Symptom: `require('@devalok/shilp-sutra')` throws `ERR_REQUIRE_ESM`
 
-**Diagnosis:** The package is ESM-only — we ship no CommonJS build. `require()` of an ES module throws `ERR_REQUIRE_ESM` on older Node, and bundlers report the entry as ESM-only.
+**Diagnosis:** The package is ESM-only — we ship no CommonJS build. Whether `require()` works depends on your Node version:
 
-Use a dynamic import from CommonJS:
+| Node | `require('@devalok/shilp-sutra/ui/button')` |
+|---|---|
+| 22.12+ / 23+ | ✅ Works — `require(esm)` is supported and unflagged. Verified against every entry point, including the full `./ui` barrel. |
+| < 22.12 | ❌ `ERR_REQUIRE_ESM` |
+
+On older Node, use a dynamic import:
 
 ```js
 const { Button } = await import('@devalok/shilp-sutra/ui/button')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://shilp-sutra.devalok.in",
   "repository": {
     "type": "git",
-    "url": "https://github.com/devalok-design/shilp-sutra",
+    "url": "git+https://github.com/devalok-design/shilp-sutra.git",
     "directory": "packages/core"
   },
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -732,6 +732,16 @@
       "import": "./dist/hooks/use-mobile.js",
       "default": "./dist/hooks/use-mobile.js"
     },
+    "./hooks/use-touch-device": {
+      "types": "./dist/hooks/use-touch-device.d.ts",
+      "import": "./dist/hooks/use-touch-device.js",
+      "default": "./dist/hooks/use-touch-device.js"
+    },
+    "./hooks/use-viewport-height": {
+      "types": "./dist/hooks/use-viewport-height.d.ts",
+      "import": "./dist/hooks/use-viewport-height.js",
+      "default": "./dist/hooks/use-viewport-height.js"
+    },
     "./utils": {
       "types": "./dist/ui/lib/utils.d.ts",
       "import": "./dist/ui/lib/utils.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,11 +52,8 @@
     "provenance": true
   },
   "dependencies": {
-    "@emoji-mart/data": "^1.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "diff": "^9.0.0",
-    "frimousse": "^0.3.0",
     "tw-animate-css": "^1.4.0",
     "use-sync-external-store": "^1.6.0"
   },
@@ -865,6 +862,9 @@
     "@tabler/icons-react": "^3.0.0",
     "@tanstack/react-table": "^8.0.0",
     "@tanstack/react-virtual": "^3.0.0",
+    "@tiptap/core": "^3.28.0",
+    "@tiptap/react": "^3.28.0",
+    "@tiptap/suggestion": "^3.28.0",
     "d3-array": "^3.0.0",
     "d3-axis": "^3.0.0",
     "d3-format": "^3.0.0",
@@ -892,6 +892,15 @@
       "optional": true
     },
     "@tanstack/react-virtual": {
+      "optional": true
+    },
+    "@tiptap/core": {
+      "optional": true
+    },
+    "@tiptap/react": {
+      "optional": true
+    },
+    "@tiptap/suggestion": {
       "optional": true
     },
     "d3-array": {
@@ -982,8 +991,10 @@
     "d3-time-format": "^4.1.0",
     "d3-transition": "^3.0.1",
     "date-fns": "^4.4.0",
+    "diff": "^9.0.0",
     "esbuild": "^0.28.1",
     "framer-motion": "^12.42.2",
+    "frimousse": "^0.3.0",
     "input-otp": "^1.4.2",
     "prosemirror-state": "^1.4.4",
     "react-colorful": "^5.8.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -863,6 +863,7 @@
     "@tanstack/react-table": "^8.0.0",
     "@tanstack/react-virtual": "^3.0.0",
     "@tiptap/core": "^3.28.0",
+    "@tiptap/pm": "^3.28.0",
     "@tiptap/react": "^3.28.0",
     "@tiptap/suggestion": "^3.28.0",
     "d3-array": "^3.0.0",
@@ -895,6 +896,9 @@
       "optional": true
     },
     "@tiptap/core": {
+      "optional": true
+    },
+    "@tiptap/pm": {
       "optional": true
     },
     "@tiptap/react": {

--- a/packages/core/scripts/derive-peer-map.mjs
+++ b/packages/core/scripts/derive-peer-map.mjs
@@ -87,7 +87,29 @@ const TYPES_ONLY_PEERS = new Set([
   '@tiptap/suggestion',
 ])
 
-export { TYPES_ONLY_PEERS }
+/**
+ * Type-peers OF a types-only peer — packages we never import, but which the
+ * peer's own declarations require in order to type-check.
+ *
+ * `@tiptap/core`'s .d.ts opens with `import … from '@tiptap/pm/state'`, and
+ * TipTap declares `@tiptap/pm` as its own peer rather than depending on it. So
+ * a consumer told to `pnpm add -D @tiptap/react` still gets six TS2307 errors
+ * from inside TipTap's declarations until `@tiptap/pm` is present too.
+ *
+ * This is invisible under npm — hoisting plus auto-install-peers pulls it in
+ * silently — and only shows up under pnpm's strict layout. Caught by the
+ * pnpm-strict harness, not by any npm-based test.
+ *
+ * Cannot be derived: the requirement lives in the peer's declarations, not in
+ * our imports, so it has to be stated.
+ */
+const TYPES_ONLY_COMPANIONS = {
+  '@tiptap/core': ['@tiptap/pm'],
+  '@tiptap/react': ['@tiptap/pm'],
+  '@tiptap/suggestion': ['@tiptap/pm'],
+}
+
+export { TYPES_ONLY_PEERS, TYPES_ONLY_COMPANIONS }
 
 /** Bare-module root: '@scope/pkg/sub' → '@scope/pkg', 'pkg/sub' → 'pkg'. */
 function moduleRoot(spec) {
@@ -250,6 +272,14 @@ export function derivePeerMap({ categories = MANIFEST_CATEGORIES, exportedOnly =
           }
         }
       }
+      // Pull in the type-peers of any types-only peer (see TYPES_ONLY_COMPANIONS).
+      for (const p of [...peers]) {
+        for (const companion of TYPES_ONLY_COMPANIONS[p] || []) {
+          peers.add(companion)
+          gatedUniverse.add(companion)
+        }
+      }
+
       const key = kebab(name)
       if (peers.size && (!exported || exported.has(key))) map[key] = [...peers].sort()
     }

--- a/packages/core/scripts/derive-peer-map.mjs
+++ b/packages/core/scripts/derive-peer-map.mjs
@@ -64,6 +64,31 @@ const BASE_EXTERNALS = new Set([
   '@tabler/icons-react',
 ])
 
+// ── Types-only peers ────────────────────────────────────────────────────────
+//
+// Modules we BUNDLE at runtime but still reference from our published `.d.ts`.
+// The externalization rule above cannot see these: rollup inlines their JS into
+// dist, so they are not external — but TypeScript's declaration emitter does
+// NOT bundle third-party types, it leaves `import { Editor } from '@tiptap/react'`
+// as a bare specifier. Undeclared, that is `error TS2307: Cannot find module`
+// for any consumer type-checking declarations (0.54.0 shipped 7 such files).
+//
+// They are declared as OPTIONAL peers so the specifier resolves, and listed
+// here so every downstream surface (MCP manifest, preflight, recipe tables)
+// can say "install as a devDependency, for types only" rather than implying the
+// package is needed at runtime — the "phantom install instruction" the
+// 2026-07-10 dogfood rightly objected to.
+//
+// Keep the declared peer range in package.json pinned to the major we bundle,
+// or a consumer's types describe a different API than the code that runs.
+const TYPES_ONLY_PEERS = new Set([
+  '@tiptap/core',
+  '@tiptap/react',
+  '@tiptap/suggestion',
+])
+
+export { TYPES_ONLY_PEERS }
+
 /** Bare-module root: '@scope/pkg/sub' → '@scope/pkg', 'pkg/sub' → 'pkg'. */
 function moduleRoot(spec) {
   const parts = spec.split('/')
@@ -193,7 +218,10 @@ function bareImportsOf(file) {
 export function derivePeerMap({ categories = MANIFEST_CATEGORIES, exportedOnly = true } = {}) {
   const externals = loadExternalMatchers()
   const isExternal = (root) => externals.some((re) => re.test(root))
-  const isGated = (root) => isExternal(root) && !BASE_EXTERNALS.has(root)
+  // A gated peer is either externalized (consumer must provide the runtime) or
+  // types-only (we bundle the runtime, but our .d.ts still names the package).
+  const isGated = (root) =>
+    (isExternal(root) || TYPES_ONLY_PEERS.has(root)) && !BASE_EXTERNALS.has(root)
   const exported = exportedOnly ? loadExportedComponents() : null
 
   const map = {}
@@ -226,7 +254,7 @@ export function derivePeerMap({ categories = MANIFEST_CATEGORIES, exportedOnly =
       if (peers.size && (!exported || exported.has(key))) map[key] = [...peers].sort()
     }
   }
-  return { map, gatedUniverse, externals }
+  return { map, gatedUniverse, externals, typesOnly: TYPES_ONLY_PEERS }
 }
 
 // ── Gate: diff derived map against the recipe §2a tables ──────────────────────

--- a/packages/core/scripts/fix-dts-extensions.mjs
+++ b/packages/core/scripts/fix-dts-extensions.mjs
@@ -1,0 +1,118 @@
+/**
+ * fix-dts-extensions.mjs
+ *
+ * Post-build script that rewrites relative import specifiers in dist/**\/*.d.ts
+ * to carry an explicit `.js` extension:
+ *
+ *   export { Button } from './button'        →  from './button.js'
+ *   export * from './chat'                   →  from './chat/index.js'
+ *   import type { X } from '../primitives/y' →  from '../primitives/y.js'
+ *
+ * WHY
+ * ---
+ * Under `"moduleResolution": "node16" | "nodenext"`, ECMAScript imports require
+ * explicit file extensions. Extensionless relative specifiers in a declaration
+ * file are a hard error for those consumers:
+ *
+ *   error TS2835: Relative import paths need explicit file extensions in
+ *     ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'.
+ *   error TS2834: Relative import paths need explicit file extensions …
+ *
+ * 0.54.0 published 234 such specifiers, so a single barrel import under
+ * nodenext + `skipLibCheck: false` produced 79 errors. `moduleResolution:
+ * "bundler"` (Vite/Next default) tolerates extensionless paths, which is why
+ * this went unnoticed — the failure is invisible on the most common config.
+ *
+ * The extension is `.js`, NOT `.d.ts`: a declaration file describes the runtime
+ * module graph, and TypeScript maps `./button.js` to `./button.d.ts` itself.
+ * Writing `.d.ts` here would be wrong and would not resolve.
+ *
+ * Directory specifiers must become explicit `/index.js` — node16 resolution
+ * performs no directory-index lookup. That is why this script resolves every
+ * specifier against the real emitted files rather than blindly appending.
+ *
+ * Run from packages/core/ AFTER fix-dts-primitives (which rewrites the
+ * `@primitives/*` alias into relative paths that also need extensions):
+ *   node scripts/fix-dts-extensions.mjs
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const distRoot = join(__dirname, '..', 'dist')
+
+/** Extensions that are already explicit — never touch these. */
+const HAS_EXTENSION = /\.(js|mjs|cjs|json|css|d\.ts)$/
+
+/**
+ * Matches the specifier of any module reference a .d.ts can contain:
+ *   import … from '…' / export … from '…' / import('…') / import '…'
+ * Capture groups: 1 = leading syntax up to the quote, 2 = quote, 3 = specifier.
+ */
+const SPECIFIER_RE =
+  /((?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(['"]))([^'"]+)\2/g
+
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, acc)
+    else if (full.endsWith('.d.ts')) acc.push(full)
+  }
+  return acc
+}
+
+/**
+ * Resolve an extensionless relative specifier against the emitted files.
+ * @returns the rewritten specifier, or null when nothing on disk matches.
+ */
+function resolveSpecifier(fromFile, spec) {
+  const base = join(dirname(fromFile), spec)
+  if (existsSync(`${base}.d.ts`)) return `${spec}.js`
+  if (existsSync(join(base, 'index.d.ts'))) return `${spec.replace(/\/$/, '')}/index.js`
+  return null
+}
+
+const files = walk(distRoot)
+let rewritten = 0
+let filesTouched = 0
+const unresolved = []
+
+for (const file of files) {
+  const src = readFileSync(file, 'utf8')
+  let changed = false
+
+  const out = src.replace(SPECIFIER_RE, (match, lead, quote, spec) => {
+    if (!spec.startsWith('.')) return match // bare / package specifier
+    if (HAS_EXTENSION.test(spec)) return match // already explicit
+
+    const next = resolveSpecifier(file, spec)
+    if (!next) {
+      unresolved.push(`${file.slice(distRoot.length + 1)} → ${spec}`)
+      return match
+    }
+    changed = true
+    rewritten++
+    return `${lead}${next}${quote}`
+  })
+
+  if (changed) {
+    writeFileSync(file, out)
+    filesTouched++
+  }
+}
+
+if (unresolved.length) {
+  // Not fatal on its own — an unresolvable relative specifier is already broken
+  // regardless of extension — but it always means the emit is wrong somewhere.
+  console.warn(
+    `fix-dts-extensions: WARNING — ${unresolved.length} relative specifier(s) matched no emitted file:`
+  )
+  for (const u of unresolved.slice(0, 20)) console.warn(`  ${u}`)
+  if (unresolved.length > 20) console.warn(`  … and ${unresolved.length - 20} more`)
+}
+
+console.log(
+  `fix-dts-extensions: ${rewritten} specifier(s) given explicit extensions across ${filesTouched}/${files.length} .d.ts files`
+)

--- a/packages/core/scripts/fix-dts-extensions.mjs
+++ b/packages/core/scripts/fix-dts-extensions.mjs
@@ -79,11 +79,27 @@ let rewritten = 0
 let filesTouched = 0
 const unresolved = []
 
+/**
+ * Byte offsets of every comment, so import-looking text inside a JSDoc
+ * `@example` is left alone. Without this the script tries to resolve
+ * documentation (`* import { normalizeIcon } from './lib/normalize-icon'`)
+ * against the emit and warns about it on every build.
+ */
+function commentRanges(src) {
+  const ranges = []
+  for (const m of src.matchAll(/\/\*[\s\S]*?\*\//g)) ranges.push([m.index, m.index + m[0].length])
+  for (const m of src.matchAll(/(^|[^:])\/\/.*$/gm)) ranges.push([m.index, m.index + m[0].length])
+  return ranges
+}
+
 for (const file of files) {
   const src = readFileSync(file, 'utf8')
   let changed = false
+  const comments = commentRanges(src)
+  const inComment = (i) => comments.some(([a, b]) => i >= a && i < b)
 
-  const out = src.replace(SPECIFIER_RE, (match, lead, quote, spec) => {
+  const out = src.replace(SPECIFIER_RE, (match, lead, quote, spec, offset) => {
+    if (inComment(offset)) return match // documentation, not an import
     if (!spec.startsWith('.')) return match // bare / package specifier
     if (HAS_EXTENSION.test(spec)) return match // already explicit
 

--- a/packages/core/scripts/fix-empty-modules.mjs
+++ b/packages/core/scripts/fix-empty-modules.mjs
@@ -1,0 +1,56 @@
+/**
+ * fix-empty-modules.mjs
+ *
+ * Post-build script that gives every 0-byte emitted `.js` module an explicit
+ * `export {}` body.
+ *
+ * WHY
+ * ---
+ * A types-only entry point (`ui/toast-types`, `ai/types`) has no runtime
+ * content, so the bundler emits an empty file — while `package.json#exports`
+ * still advertises a runtime `import` condition for it. An empty file contains
+ * no syntax for Node's module-type detection to look at, so it is ambiguous
+ * between ESM and CJS. Under pnpm's symlinked `node_modules`, resolving that
+ * ambiguity through the realpath makes Node believe it is being `require()`d
+ * from inside its own graph:
+ *
+ *   ERR_REQUIRE_CYCLE_MODULE: Cannot require() ES Module … in a cycle.
+ *
+ * So `import '@devalok/shilp-sutra/ui/toast-types'` throws for pnpm consumers
+ * while working fine under npm, whose flat layout avoids the symlink hop. The
+ * fault predates this script — published 0.54.0 fails the same way — and is
+ * invisible to any npm-based test.
+ *
+ * `export {}` is the minimum body that makes the file unambiguously an ES
+ * module. It adds no runtime behaviour and no exports.
+ *
+ * Run from packages/core/ after the bundle is emitted:
+ *   node scripts/fix-empty-modules.mjs
+ */
+
+import { readdirSync, statSync, writeFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const distRoot = join(__dirname, '..', 'dist')
+
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) walk(full, acc)
+    else if (full.endsWith('.js') && st.size === 0) acc.push(full)
+  }
+  return acc
+}
+
+const empties = walk(distRoot)
+for (const file of empties) {
+  writeFileSync(file, 'export {};\n')
+}
+
+console.log(
+  `fix-empty-modules: ${empties.length} empty module(s) given an explicit ESM body` +
+    (empties.length ? ` — ${empties.map((f) => f.slice(distRoot.length + 1)).join(', ')}` : '')
+)

--- a/packages/core/scripts/inject-use-client.mjs
+++ b/packages/core/scripts/inject-use-client.mjs
@@ -1,9 +1,22 @@
 /**
  * inject-use-client.mjs
  *
- * Post-build script that prepends `"use client";\n` to every .js and .d.ts
- * file in dist/, EXCEPT for files that are server-safe (pure markup / no hooks)
- * and files that already contain the directive.
+ * Post-build script that prepends `"use client";\n` to every .js file in dist/,
+ * EXCEPT for files that are server-safe (pure markup / no hooks) and files that
+ * already contain the directive.
+ *
+ * `.d.ts` files are deliberately NOT injected — and any pre-existing directive
+ * in one is stripped. A declaration file is an ambient context, so a directive
+ * prologue there is a statement and TypeScript rejects it outright:
+ *
+ *   dist/ui/button.d.ts(1,1): error TS1036:
+ *     Statements are not allowed in ambient contexts.
+ *
+ * Consumers only see this with `skipLibCheck: false`, which is why it survived
+ * to 0.54.0 (209 of 284 published .d.ts carried the directive; a single barrel
+ * import produced 78 errors). The directive is a bundler/RSC runtime concern —
+ * it is read off the .js module graph, and declarations are erased before
+ * anything runs, so putting it in a .d.ts buys nothing and only breaks people.
  *
  * Server-safe components are detected automatically from a `// @server-safe`
  * comment on the first line of their source file. Build artifacts that are
@@ -128,12 +141,23 @@ for (const key of SERVER_SAFE) {
 
 let injected = 0
 let skipped = 0
+let stripped = 0
+
+const DIRECTIVE_RE = /^\s*(["'])use client\1;?[ \t]*\r?\n/
 
 for (const filePath of allFiles) {
-  // Only process .js and .d.ts files
-  const isJS = filePath.endsWith('.js')
-  const isDTS = filePath.endsWith('.d.ts')
-  if (!isJS && !isDTS) {
+  // `.d.ts` is an ambient context — a directive prologue there is a statement
+  // (TS1036). Never inject, and strip one if a previous build left it behind.
+  if (filePath.endsWith('.d.ts')) {
+    const dtsContent = readFileSync(filePath, 'utf8')
+    if (DIRECTIVE_RE.test(dtsContent)) {
+      writeFileSync(filePath, dtsContent.replace(DIRECTIVE_RE, ''))
+      stripped++
+    }
+    continue
+  }
+
+  if (!filePath.endsWith('.js')) {
     continue
   }
 
@@ -252,5 +276,5 @@ try {
 // externalizing the offending dep over re-adding a CJS bridge.
 
 console.log(
-  `inject-use-client: ${injected} files updated, ${skipped} skipped`
+  `inject-use-client: ${injected} files updated, ${skipped} skipped, ${stripped} .d.ts directives stripped`
 )

--- a/packages/core/scripts/post-build.mjs
+++ b/packages/core/scripts/post-build.mjs
@@ -9,8 +9,9 @@
  * 2. copy-root-docs     — Copy CHANGELOG/MIGRATION/README to dist/
  * 3. copy-skill         — Copy skills/shilp-sutra/ to packages/core/skill/
  * 4. fix-dts-primitives — Rewrite @primitives/ import paths in .d.ts files
- * 5. inject-use-client  — Add "use client" directives + SSR safety patches
- * 6. build-docs         — Generate per-component documentation
+ * 5. fix-dts-extensions — Give .d.ts relative imports explicit .js extensions
+ * 6. inject-use-client  — Add "use client" directives + SSR safety patches
+ * 7. build-docs         — Generate per-component documentation
  */
 
 import { execFileSync } from 'child_process'
@@ -25,6 +26,7 @@ const steps = [
   { name: 'copy-root-docs', script: 'copy-root-docs.mjs' },
   { name: 'copy-skill', script: 'copy-skill.mjs' },
   { name: 'fix-dts-primitives', script: 'fix-dts-primitives.mjs' },
+  { name: 'fix-dts-extensions', script: 'fix-dts-extensions.mjs' },
   { name: 'inject-use-client', script: 'inject-use-client.mjs' },
   { name: 'build-docs', script: 'build-component-docs.mjs' },
   { name: 'build-mcp-manifest', script: 'build-mcp-manifest.mjs' },

--- a/packages/core/scripts/post-build.mjs
+++ b/packages/core/scripts/post-build.mjs
@@ -10,8 +10,9 @@
  * 3. copy-skill         — Copy skills/shilp-sutra/ to packages/core/skill/
  * 4. fix-dts-primitives — Rewrite @primitives/ import paths in .d.ts files
  * 5. fix-dts-extensions — Give .d.ts relative imports explicit .js extensions
- * 6. inject-use-client  — Add "use client" directives + SSR safety patches
- * 7. build-docs         — Generate per-component documentation
+ * 6. fix-empty-modules  — Give 0-byte emitted modules an explicit ESM body
+ * 7. inject-use-client  — Add "use client" directives + SSR safety patches
+ * 8. build-docs         — Generate per-component documentation
  */
 
 import { execFileSync } from 'child_process'
@@ -27,6 +28,7 @@ const steps = [
   { name: 'copy-skill', script: 'copy-skill.mjs' },
   { name: 'fix-dts-primitives', script: 'fix-dts-primitives.mjs' },
   { name: 'fix-dts-extensions', script: 'fix-dts-extensions.mjs' },
+  { name: 'fix-empty-modules', script: 'fix-empty-modules.mjs' },
   { name: 'inject-use-client', script: 'inject-use-client.mjs' },
   { name: 'build-docs', script: 'build-component-docs.mjs' },
   { name: 'build-mcp-manifest', script: 'build-mcp-manifest.mjs' },

--- a/packages/core/src/__tests__/derive-peer-map.test.ts
+++ b/packages/core/src/__tests__/derive-peer-map.test.ts
@@ -29,11 +29,40 @@ describe('derivePeerMap', () => {
     )
   })
 
-  it('does NOT list bundled deps as peers (@tiptap, frimousse, @emoji-mart/data are in dist, not external)', () => {
-    // emoji-picker bundles frimousse + @emoji-mart/data (lazy chunk) → no gated peer.
+  it('does NOT list a bundled dep as a peer when it stays out of our types (frimousse, @emoji-mart/data)', () => {
+    // emoji-picker bundles frimousse + @emoji-mart/data (lazy chunk), and
+    // neither is named in any emitted .d.ts → nothing for a consumer to
+    // install, so no gated peer. This is the 2026-07-10 dogfood invariant:
+    // a phantom install instruction for a dep we already ship.
     expect(map['emoji-picker']).toBeUndefined()
     const rte = map['rich-text-editor'] ?? []
-    expect(rte.some((p) => p.startsWith('@tiptap/') || p.startsWith('@emoji-mart/') || p === 'frimousse')).toBe(false)
+    expect(rte.some((p) => p.startsWith('@emoji-mart/') || p === 'frimousse')).toBe(false)
+  })
+
+  it('DOES list a bundled dep as a peer when our published types name it (@tiptap)', () => {
+    // Refines the rule above (0.55.0). "Bundled" settles the RUNTIME question
+    // only. Rollup inlines TipTap's JS, but TypeScript's declaration emitter
+    // does not inline third-party types — `import { Editor } from
+    // '@tiptap/react'` survives into rich-text-editor.d.ts as a bare
+    // specifier. Undeclared, that is TS2307 for every consumer who
+    // type-checks declarations; 0.54.0 shipped 7 such files.
+    //
+    // So these are declared as OPTIONAL, TYPES-ONLY peers. Asserting the
+    // positive here stops a future "it's bundled, drop the peer" cleanup from
+    // silently reintroducing the unresolvable import.
+    const rte = map['rich-text-editor'] ?? []
+    expect(rte).toContain('@tiptap/react')
+  })
+
+  it('pulls in the type-peers OF a types-only peer (@tiptap/react → @tiptap/pm)', () => {
+    // @tiptap/pm is never imported by us. TipTap's own .d.ts imports
+    // '@tiptap/pm/state' and declares @tiptap/pm as ITS peer, so a consumer
+    // told only to install @tiptap/react still gets six TS2307 errors from
+    // inside TipTap. Not derivable from our imports — it lives in the peer's
+    // declarations — hence TYPES_ONLY_COMPANIONS. Found by the pnpm
+    // strict-install harness; npm's hoisting hid it completely.
+    const rte = map['rich-text-editor'] ?? []
+    expect(rte).toContain('@tiptap/pm')
   })
 
   it('scans _internal/ subdirs (charts/_internal/axes.tsx → d3-axis)', () => {

--- a/packages/core/src/ui/index.ts
+++ b/packages/core/src/ui/index.ts
@@ -32,7 +32,7 @@ export { Input, type InputProps, type InputState, inputWrapperVariants } from '.
 export { Label, type LabelProps } from './label'
 export { type FieldState } from './lib/field-state'
 export { Separator, type SeparatorProps } from './separator'
-export { SplitButton, type SplitButtonProps } from './split-button'
+export { SplitButton, type SplitButtonPlacement,type SplitButtonProps } from './split-button'
 export { VisuallyHidden, type VisuallyHiddenProps } from './visually-hidden'
 
 // Autocomplete

--- a/packages/core/src/ui/split-button.tsx
+++ b/packages/core/src/ui/split-button.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { type Placement } from '@floating-ui/dom'
 import { type VariantProps } from 'class-variance-authority'
 import * as React from 'react'
 
@@ -9,6 +8,24 @@ import { cn } from './lib/utils'
 import { Popover, PopoverContent, PopoverTrigger } from './popover'
 
 // ── Types ───────────────────────────────────────────────────────
+
+/**
+ * Placement of the dropdown panel, in floating-ui's vocabulary.
+ *
+ * Declared here rather than imported from `@floating-ui/dom`: that package is
+ * bundled into dist at runtime but is NOT a consumer dependency, so a type
+ * import leaks an unresolvable specifier into the published .d.ts —
+ * `error TS2307: Cannot find module '@floating-ui/dom'` for anyone type-checking
+ * declarations. The union is stable and two lines; borrowing it is not worth an
+ * install. (This component no longer calls floating-ui at all — see the Radix
+ * Popover mapping below.)
+ */
+export type SplitButtonPlacement =
+  | 'top' | 'right' | 'bottom' | 'left'
+  | 'top-start' | 'top-end'
+  | 'right-start' | 'right-end'
+  | 'bottom-start' | 'bottom-end'
+  | 'left-start' | 'left-end'
 
 type SplitButtonVariant = 'solid' | 'soft' | 'outline'
 type SplitButtonColor = NonNullable<VariantProps<typeof buttonVariants>['color']>
@@ -42,7 +59,7 @@ export interface SplitButtonProps {
   /** Which side the dropdown trigger sits on. @default 'right' */
   triggerSide?: 'left' | 'right'
   /** Preferred placement for the dropdown panel. @default 'top-end' */
-  placement?: Placement
+  placement?: SplitButtonPlacement
   /** Width of the trigger (chevron) half. @default 'auto' */
   triggerWidth?: number | string
   className?: string

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -196,7 +196,35 @@ export default defineConfig({
             )
               return 'vendor-utils'
           }
-          if (id.includes('primitives/')) return 'primitives'
+          // Vendored Radix primitives: one chunk PER primitive, with the
+          // shared internals kept together in a single chunk.
+          //
+          // History, because both extremes are wrong and the middle is not
+          // obvious:
+          //
+          //   `return 'primitives'` (before 0.55.0) put all 25 primitives in
+          //   one 231 KB chunk. A consumer importing only <Button> — which
+          //   needs nothing but `Slot`/`Slottable` from react-slot (~3 KB) —
+          //   still shipped Select, Dialog, Menu, Tooltip and Slider. Measured:
+          //   209 KB of our code for the FIRST component, ~43 KB for the next
+          //   eleven. A fixed floor everyone paid.
+          //
+          //   Removing the rule entirely (letting Rollup chunk freely) fixed
+          //   the floor — Button fell to 56 KB — but Rollup then DUPLICATED
+          //   the shared internals into every primitive chunk, and a realistic
+          //   12-component app went 252 KB → 586 KB. Strictly worse for the
+          //   common case.
+          //
+          // Splitting per primitive while pinning `_internal/` to one shared
+          // chunk gets both: a primitive is only pulled in by components that
+          // reference it, and the internals every primitive depends on
+          // (compose-refs, context, presence, portal, dismissable-layer, …)
+          // exist exactly once.
+          if (id.includes('primitives/')) {
+            if (id.includes('primitives/_internal/')) return 'primitives-internal'
+            const m = id.replace(/\\/g, '/').match(/primitives\/([^/]+?)\.[jt]sx?$/)
+            return m ? `primitives/${m[1]}` : 'primitives'
+          }
         },
       },
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.4
         version: 10.5.4(postcss@8.5.22)
+      axe-core:
+        specifier: ^4
+        version: 4.12.1
       chromatic:
         specifier: ^18.1.0
         version: 18.1.0
@@ -297,6 +300,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@tiptap/pm':
+        specifier: ^3.28.0
+        version: 3.28.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.0
+        version: 0.18.5
       '@changesets/changelog-github':
         specifier: ^0.6.0
         version: 0.6.0
@@ -504,6 +507,18 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@andrewbranch/untar.js@1.0.3':
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@arethetypeswrong/cli@0.18.5':
+    resolution: {integrity: sha512-gM+8vRsQOD/Uc7EnBedUhkG5OCsDWE4uoak5QvomGpMpaky0Eh41p04nIMgrWb8EOmqZUJGc6zz9hsP6E56R7g==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@arethetypeswrong/core@0.18.5':
+    resolution: {integrity: sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ==}
+    engines: {node: '>=20'}
+
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -626,6 +641,9 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
+  '@braidai/lang@1.1.2':
+    resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -690,6 +708,10 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@csstools/color-helpers@6.1.0':
     resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
@@ -1179,6 +1201,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@loaderkit/resolve@1.0.6':
+    resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1861,6 +1886,10 @@ packages:
 
   '@rushstack/ts-command-line@5.3.12':
     resolution: {integrity: sha512-Vg2n24arSf7JvUNga2DMHYTbxnVq9L5OtVCp4Gfr8YC/kmL/bmdR8FQhGcpMzMYNY9Vdw3+TaimG11Sf+z1Tpw==}
+
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2724,8 +2753,20 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
@@ -2915,9 +2956,17 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -2966,18 +3015,44 @@ packages:
       '@chromatic-com/vitest':
         optional: true
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3247,8 +3322,14 @@ packages:
   emoji-mart@5.6.0:
     resolution: {integrity: sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -3269,6 +3350,10 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -3474,6 +3559,9 @@ packages:
   fflate@0.4.9:
     resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3585,6 +3673,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -3816,6 +3908,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
@@ -4223,9 +4319,20 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
   marked@17.0.6:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
     engines: {node: '>= 20'}
+    hasBin: true
+
+  marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -4481,6 +4588,10 @@ packages:
       sass:
         optional: true
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -4595,6 +4706,15 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -4995,6 +5115,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -5134,6 +5258,10 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -5206,6 +5334,10 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -5265,9 +5397,17 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -5455,6 +5595,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript@5.6.1-rc:
+    resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -5478,6 +5623,10 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -5590,6 +5739,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  validate-npm-package-name@5.0.1:
+    resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5811,6 +5964,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5837,12 +5994,24 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5873,6 +6042,29 @@ snapshots:
   '@adobe/css-tools@4.5.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@andrewbranch/untar.js@1.0.3': {}
+
+  '@arethetypeswrong/cli@0.18.5':
+    dependencies:
+      '@arethetypeswrong/core': 0.18.5
+      chalk: 4.1.2
+      cli-table3: 0.6.5
+      commander: 10.0.1
+      marked: 9.1.6
+      marked-terminal: 7.3.0(marked@9.1.6)
+      semver: 7.8.5
+
+  '@arethetypeswrong/core@0.18.5':
+    dependencies:
+      '@andrewbranch/untar.js': 1.0.3
+      '@loaderkit/resolve': 1.0.6
+      cjs-module-lexer: 1.4.3
+      fflate: 0.8.3
+      lru-cache: 11.5.2
+      semver: 7.8.5
+      typescript: 5.6.1-rc
+      validate-npm-package-name: 5.0.1
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -6022,6 +6214,8 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.4
 
   '@blazediff/core@1.9.1': {}
+
+  '@braidai/lang@1.1.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -6184,6 +6378,9 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.2.0
       prettier: 2.8.8
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@csstools/color-helpers@6.1.0': {}
 
@@ -6549,6 +6746,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@loaderkit/resolve@1.0.6':
+    dependencies:
+      '@braidai/lang': 1.1.2
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7074,6 +7275,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
     optional: true
+
+  '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -8031,7 +8234,17 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
 
@@ -8233,7 +8446,14 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -8269,15 +8489,46 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  cjs-module-lexer@1.4.3: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
   client-only@0.0.1: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@4.1.1: {}
 
@@ -8499,7 +8750,11 @@ snapshots:
 
   emoji-mart@5.6.0: {}
 
+  emoji-regex@8.0.0: {}
+
   emoji-regex@9.2.2: {}
+
+  emojilib@2.4.0: {}
 
   empathic@2.0.1: {}
 
@@ -8516,6 +8771,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   entities@8.0.0: {}
+
+  environment@1.1.0: {}
 
   es-abstract-get@1.0.0:
     dependencies:
@@ -8849,6 +9106,8 @@ snapshots:
 
   fflate@0.4.9: {}
 
+  fflate@0.8.3: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -8963,6 +9222,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9025,8 +9286,7 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
-  has-flag@4.0.0:
-    optional: true
+  has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -9212,6 +9472,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.2:
     dependencies:
@@ -9561,7 +9823,20 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked-terminal@7.3.0(marked@9.1.6):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 9.1.6
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
   marked@17.0.6: {}
+
+  marked@9.1.6: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -10014,6 +10289,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -10174,6 +10456,14 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@8.0.1:
     dependencies:
@@ -10646,6 +10936,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
@@ -10888,6 +11180,10 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   slash@3.0.0: {}
 
   sonner@2.0.7(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
@@ -10962,6 +11258,12 @@ snapshots:
   string-argv@0.3.2:
     optional: true
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.9
@@ -11034,10 +11336,19 @@ snapshots:
       tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
     optional: true
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -11264,6 +11575,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript@5.6.1-rc: {}
+
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
@@ -11280,6 +11593,8 @@ snapshots:
   undici-types@8.3.0: {}
 
   undici@7.28.0: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -11384,6 +11699,8 @@ snapshots:
   valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
+
+  validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
 
@@ -11566,6 +11883,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
@@ -11578,9 +11901,23 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,21 +294,12 @@ importers:
 
   packages/core:
     dependencies:
-      '@emoji-mart/data':
-        specifier: ^1.2.1
-        version: 1.2.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      diff:
-        specifier: ^9.0.0
-        version: 9.0.0
-      frimousse:
-        specifier: ^0.3.0
-        version: 0.3.0(react@19.2.8)(typescript@6.0.3)
       react:
         specifier: ^18 || ^19
         version: 19.2.8
@@ -325,6 +316,9 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(react@19.2.8)
     devDependencies:
+      '@emoji-mart/data':
+        specifier: ^1.2.1
+        version: 1.2.1
       '@emoji-mart/react':
         specifier: ^1.1.1
         version: 1.1.1(emoji-mart@5.6.0)(react@19.2.8)
@@ -412,12 +406,18 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
       framer-motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      frimousse:
+        specifier: ^0.3.0
+        version: 0.3.0(react@19.2.8)(typescript@6.0.3)
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/scripts/audit-dts.mjs
+++ b/scripts/audit-dts.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * audit-dts.mjs
+ *
+ * Publish gate for the CONSUMER-FACING correctness of our emitted declaration
+ * files. Three assertions over packages/core/dist/**\/*.d.ts:
+ *
+ *   1. NO DIRECTIVE PROLOGUE — a `.d.ts` is an ambient context, so a leading
+ *      `"use client"` is a statement and every consumer with
+ *      `skipLibCheck: false` gets `error TS1036: Statements are not allowed in
+ *      ambient contexts`.
+ *
+ *   2. NO UNDECLARED BARE SPECIFIER — every package named in a .d.ts must be a
+ *      declared dependency or peerDependency. A module can be BUNDLED at
+ *      runtime and still be named in our types (rollup inlines the JS; the
+ *      TypeScript declaration emitter does not inline third-party types), so
+ *      "it's bundled" is not evidence it can be left undeclared. Undeclared
+ *      means `error TS2307: Cannot find module` for the consumer.
+ *
+ *   3. NO EXTENSIONLESS RELATIVE SPECIFIER — under `moduleResolution:
+ *      "node16" | "nodenext"` an ECMAScript import needs an explicit
+ *      extension, or the consumer gets TS2834/TS2835.
+ *
+ * WHY THIS GATE EXISTS
+ * --------------------
+ * 0.54.0 shipped all three faults at once — 209 .d.ts with a directive
+ * prologue, 8 with undeclared type imports (@tiptap/*, @floating-ui/dom), and
+ * 234 extensionless specifiers. A single barrel import produced 78 errors.
+ * None of the 45 existing gates saw it, because our own consumer smoke test
+ * had `skipLibCheck: true` — the setting that suppresses exactly this class.
+ *
+ * All three are invisible on the most common consumer config (`bundler` +
+ * `skipLibCheck: true`), which is why they must be asserted mechanically
+ * rather than noticed.
+ *
+ * Usage:
+ *   node scripts/audit-dts.mjs                 # exit 1 on any violation
+ *   node scripts/audit-dts.mjs --json          # machine-readable findings
+ *   node scripts/audit-dts.mjs --root <dir>    # audit an installed/extracted
+ *                                              # package instead of our dist
+ *
+ * `--root` exists so the gate itself is testable: point it at a published
+ * tarball to confirm it still detects a known-bad release.
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const asJson = process.argv.includes('--json')
+const rootFlag = process.argv.indexOf('--root')
+const coreRoot =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(__dirname, '..', 'packages', 'core')
+const distRoot = join(coreRoot, 'dist')
+
+if (!existsSync(distRoot)) {
+  console.error(`audit-dts: ${distRoot} not found — run the build first.`)
+  process.exit(1)
+}
+
+const pkg = JSON.parse(readFileSync(join(coreRoot, 'package.json'), 'utf8'))
+const declared = new Set([
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+  // Always resolvable in any React consumer; react-dom is a required peer.
+  'react',
+  'react-dom',
+])
+
+/**
+ * Strip comments before scanning. Without this the audit trips over prose and
+ * `@example` blocks — a JSDoc line reading `import { X } from '@scope/pkg'` is
+ * documentation, not a dependency, and `@module @devalok/shilp-sutra/ui` is a
+ * tag. Both produced false positives in the ad-hoc version of this scan.
+ */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+const HAS_EXTENSION = /\.(js|mjs|cjs|json|css|d\.ts)$/
+const SPECIFIER_RE = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)['"]([^'"]+)['"]/g
+
+function moduleRoot(spec) {
+  const parts = spec.split('/')
+  return spec.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+function walk(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, acc)
+    else if (full.endsWith('.d.ts')) acc.push(full)
+  }
+  return acc
+}
+
+const files = walk(distRoot)
+const findings = { directive: [], undeclared: [], extensionless: [] }
+
+for (const file of files) {
+  const rel = file.slice(distRoot.length + 1).split('\\').join('/')
+  const raw = readFileSync(file, 'utf8')
+
+  if (/^\s*["']use (client|server)["']/.test(raw)) findings.directive.push(rel)
+
+  const code = stripComments(raw)
+  for (const m of code.matchAll(SPECIFIER_RE)) {
+    const spec = m[1]
+    if (spec.startsWith('.')) {
+      if (!HAS_EXTENSION.test(spec)) findings.extensionless.push(`${rel} → ${spec}`)
+      continue
+    }
+    if (spec.startsWith('node:')) continue
+    const root = moduleRoot(spec)
+    if (!declared.has(root)) findings.undeclared.push(`${rel} → ${root}`)
+  }
+}
+
+const total =
+  findings.directive.length + findings.undeclared.length + findings.extensionless.length
+
+if (asJson) {
+  console.log(JSON.stringify({ scanned: files.length, total, findings }, null, 2))
+  process.exit(total ? 1 : 0)
+}
+
+console.log(`# audit-dts\n\nScanned ${files.length} declaration files in ${distRoot}.\n`)
+
+const report = (label, items, hint) => {
+  if (!items.length) {
+    console.log(`✓ ${label}`)
+    return
+  }
+  console.log(`\n✗ ${label} — ${items.length} violation(s):`)
+  for (const i of items.slice(0, 25)) console.log(`    ${i}`)
+  if (items.length > 25) console.log(`    … and ${items.length - 25} more`)
+  console.log(`  ${hint}`)
+}
+
+report(
+  'No directive prologue in .d.ts',
+  findings.directive,
+  'Fix: inject-use-client.mjs must skip .d.ts (TS1036 for skipLibCheck:false consumers).'
+)
+report(
+  'Every bare specifier is a declared dep/peer',
+  [...new Set(findings.undeclared)],
+  'Fix: declare it (optional peer if types-only), or stop exposing the type. TS2307 otherwise.'
+)
+report(
+  'No extensionless relative specifiers',
+  findings.extensionless,
+  'Fix: fix-dts-extensions.mjs must run in post-build (TS2834/TS2835 under node16/nodenext).'
+)
+
+if (total) {
+  console.log(`\naudit-dts: FAILED — ${total} violation(s).`)
+  process.exit(1)
+}
+console.log('\naudit-dts: PASSED.')

--- a/scripts/audit-dts.mjs
+++ b/scripts/audit-dts.mjs
@@ -2,8 +2,8 @@
 /**
  * audit-dts.mjs
  *
- * Publish gate for the CONSUMER-FACING correctness of our emitted declaration
- * files. Three assertions over packages/core/dist/**\/*.d.ts:
+ * Publish gate for the CONSUMER-FACING correctness of what we emit. Four
+ * assertions over packages/core/dist:
  *
  *   1. NO DIRECTIVE PROLOGUE — a `.d.ts` is an ambient context, so a leading
  *      `"use client"` is a statement and every consumer with
@@ -21,15 +21,21 @@
  *      "node16" | "nodenext"` an ECMAScript import needs an explicit
  *      extension, or the consumer gets TS2834/TS2835.
  *
+ *   4. NO 0-BYTE EMITTED MODULE — an empty .js has no syntax for Node's
+ *      module-type detection, and under pnpm's symlinked node_modules that
+ *      ambiguity throws ERR_REQUIRE_CYCLE_MODULE on import. Works under npm's
+ *      flat layout, fails under pnpm.
+ *
  * WHY THIS GATE EXISTS
  * --------------------
- * 0.54.0 shipped all three faults at once — 209 .d.ts with a directive
+ * 0.54.0 shipped the first three faults at once — 209 .d.ts with a directive
  * prologue, 8 with undeclared type imports (@tiptap/*, @floating-ui/dom), and
  * 234 extensionless specifiers. A single barrel import produced 78 errors.
  * None of the 45 existing gates saw it, because our own consumer smoke test
  * had `skipLibCheck: true` — the setting that suppresses exactly this class.
+ * The fourth predates it and shipped too.
  *
- * All three are invisible on the most common consumer config (`bundler` +
+ * Every one is invisible on the most common consumer setup (npm + `bundler` +
  * `skipLibCheck: true`), which is why they must be asserted mechanically
  * rather than noticed.
  *
@@ -97,8 +103,22 @@ function walk(dir, acc = []) {
   return acc
 }
 
+// A 0-byte .js is ambiguous between ESM and CJS (no syntax to detect). Under
+// pnpm's symlinked node_modules that ambiguity surfaces as
+// ERR_REQUIRE_CYCLE_MODULE on import — so an exported types-only entry point
+// throws for pnpm consumers while working under npm's flat layout.
+function walkJs(dir, acc = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) walkJs(full, acc)
+    else if (full.endsWith('.js') && st.size === 0) acc.push(full.slice(distRoot.length + 1))
+  }
+  return acc
+}
+
 const files = walk(distRoot)
-const findings = { directive: [], undeclared: [], extensionless: [] }
+const findings = { directive: [], undeclared: [], extensionless: [], empty: walkJs(distRoot) }
 
 for (const file of files) {
   const rel = file.slice(distRoot.length + 1).split('\\').join('/')
@@ -120,7 +140,10 @@ for (const file of files) {
 }
 
 const total =
-  findings.directive.length + findings.undeclared.length + findings.extensionless.length
+  findings.directive.length +
+  findings.undeclared.length +
+  findings.extensionless.length +
+  findings.empty.length
 
 if (asJson) {
   console.log(JSON.stringify({ scanned: files.length, total, findings }, null, 2))
@@ -154,6 +177,11 @@ report(
   'No extensionless relative specifiers',
   findings.extensionless,
   'Fix: fix-dts-extensions.mjs must run in post-build (TS2834/TS2835 under node16/nodenext).'
+)
+report(
+  'No 0-byte emitted modules',
+  findings.empty,
+  'Fix: fix-empty-modules.mjs must run in post-build (ERR_REQUIRE_CYCLE_MODULE for pnpm consumers).'
 )
 
 if (total) {

--- a/scripts/build-skill.mjs
+++ b/scripts/build-skill.mjs
@@ -55,8 +55,20 @@ const LICENSE_DST = join(skillRoot, 'LICENSE')
 
 const checkMode = process.argv.includes('--check')
 
+/**
+ * Hash CONTENT, not line endings.
+ *
+ * With git's `core.autocrlf=true` (the Windows default) a checkout writes CRLF
+ * to disk while this script generates LF, so a byte-exact hash reports drift on
+ * files that are character-for-character identical — `git diff` shows nothing,
+ * yet the gate fails. That made the drift gate unusable on Windows and cost a
+ * chunk of a release check chasing a file with no real change.
+ *
+ * Normalising here keeps the gate honest on every platform: it fires on content
+ * drift and stays quiet on checkout conventions.
+ */
 function digest(content) {
-  return createHash('sha256').update(content).digest('hex')
+  return createHash('sha256').update(content.replace(/\r\n/g, '\n')).digest('hex')
 }
 
 function read(file) {

--- a/scripts/consumer-smoke-test.mjs
+++ b/scripts/consumer-smoke-test.mjs
@@ -14,7 +14,7 @@
  * and that's where the last three release regressions slipped through.
  */
 
-import { existsSync, readdirSync, rmSync, statSync, unlinkSync } from 'fs'
+import { existsSync, readdirSync, rmSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { readFileSync } from 'fs'
 import { execFileSync, spawnSync } from 'child_process'
 import { join, resolve, dirname } from 'path'
@@ -191,7 +191,98 @@ if (hits.length > 0) {
   process.exit(1)
 }
 
-// If next build succeeded and no red flags hit: pass
 pass(`next build (${VARIANT_LABEL}) completed without errors or known regressions`)
+
+// ── Step 5: type-resolution matrix ─────────────────────────────────────
+//
+// `next build` type-checks with the consumer's own tsconfig, which sets
+// `skipLibCheck: true` — the setting that suppresses every error originating
+// INSIDE a dependency's .d.ts. That blind spot let 0.54.0 ship 209 declaration
+// files carrying a `"use client"` prologue (TS1036), 8 with undeclared type
+// imports (TS2307), and 234 extensionless relative specifiers (TS2834/2835).
+// A consumer barrel import produced 78 errors; every gate we had stayed green.
+//
+// So type-check the SAME installed consumer across the axes that actually
+// change the answer: module resolution (`bundler` vs `nodenext`) × whether
+// declaration files are checked at all. Only `skipLibCheck: false` can see our
+// .d.ts, and only `nodenext` enforces explicit extensions.
+//
+// Errors are filtered to our own package plus the consumer's source — an
+// unrelated dependency shipping bad types is not our release blocker.
+
+step('Type-resolution matrix (bundler|nodenext × skipLibCheck on|off)')
+
+const MATRIX = [
+  { moduleResolution: 'bundler', module: 'ESNext', skipLibCheck: true },
+  { moduleResolution: 'bundler', module: 'ESNext', skipLibCheck: false },
+  { moduleResolution: 'nodenext', module: 'NodeNext', skipLibCheck: true },
+  { moduleResolution: 'nodenext', module: 'NodeNext', skipLibCheck: false },
+]
+
+const matrixFailures = []
+
+for (const cfg of MATRIX) {
+  const label = `${cfg.moduleResolution} + skipLibCheck:${cfg.skipLibCheck}`
+  const tsconfigPath = join(CONSUMER, `tsconfig.matrix.json`)
+  writeFileSync(
+    tsconfigPath,
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+          module: cfg.module,
+          moduleResolution: cfg.moduleResolution,
+          jsx: 'react-jsx',
+          strict: true,
+          skipLibCheck: cfg.skipLibCheck,
+          noEmit: true,
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+        },
+        include: ['app/**/*.ts', 'app/**/*.tsx'],
+      },
+      null,
+      2
+    )
+  )
+
+  // Invoke the consumer's own tsc entry directly. Going through `npx` would
+  // need shell:true on Windows, which concatenates argv unescaped (DEP0190).
+  const tscBin = join(CONSUMER, 'node_modules', 'typescript', 'bin', 'tsc')
+  const tsc = run('node', [tscBin, '-p', 'tsconfig.matrix.json'], {
+    cwd: CONSUMER,
+    shell: false,
+  })
+  const out = (tsc.stdout || '') + '\n' + (tsc.stderr || '')
+  const ours = out
+    .split('\n')
+    .filter((l) => /error TS\d+/.test(l))
+    .filter((l) => l.includes('@devalok/shilp-sutra') || l.startsWith('app'))
+
+  if (ours.length) {
+    matrixFailures.push({ label, errors: ours })
+    console.error(`  ${RED}✗ ${label} — ${ours.length} error(s)${RESET}`)
+  } else {
+    console.log(`  ${GREEN}✓${RESET} ${label}`)
+  }
+  if (existsSync(tsconfigPath)) unlinkSync(tsconfigPath)
+}
+
+if (matrixFailures.length) {
+  console.error(`\n${RED}${BOLD}✗ Type-resolution matrix failed${RESET}\n`)
+  for (const f of matrixFailures) {
+    console.error(`  ${RED}• ${f.label}${RESET}`)
+    for (const e of f.errors.slice(0, 8)) console.error(`      ${e.slice(0, 220)}`)
+    if (f.errors.length > 8) console.error(`      … and ${f.errors.length - 8} more`)
+  }
+  console.error(
+    `\nThese are errors a consumer sees from OUR declaration files.\n` +
+      `Run \`node scripts/audit-dts.mjs\` for a precise breakdown.`
+  )
+  process.exit(1)
+}
+pass('Type-resolution matrix clean across all four configurations')
+
 console.log(`\n${GREEN}${BOLD}✓ Consumer smoke test passed${RESET}`)
 console.log(`   Full build log: ${logPath}`)

--- a/scripts/consumer-strict-install.mjs
+++ b/scripts/consumer-strict-install.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * consumer-strict-install.mjs
+ *
+ * Installs the packed tarball into a throwaway consumer using **pnpm with
+ * hoisting disabled and auto-install-peers off**, imports EVERY subpath export,
+ * and checks both the types and the runtime.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM consumer-smoke-test.mjs
+ * -------------------------------------------------------
+ * The Next smoke consumer installs with npm-style resolution: dependencies are
+ * hoisted into a flat `node_modules`, and peers are auto-installed. Both hide
+ * real faults —
+ *
+ *   • A package we never declared still resolves, because something else
+ *     hoisted it to the top level.
+ *   • A peer we forgot to declare gets installed anyway.
+ *
+ * pnpm's strict, symlinked layout does neither: a module resolves only if we
+ * declared it. Running this found two faults that every npm-based test passed:
+ *
+ *   1. `@tiptap/pm` was missing from the peer set. TipTap's own .d.ts imports
+ *      '@tiptap/pm/state' and declares @tiptap/pm as *its* peer, so our
+ *      documented install line left six TS2307 errors from inside TipTap.
+ *   2. Two 0-byte emitted modules (types-only entry points) threw
+ *      ERR_REQUIRE_CYCLE_MODULE on import — an empty file gives Node's
+ *      module-type detection nothing to read, and under pnpm's symlinks that
+ *      ambiguity is fatal. Published 0.54.0 fails this way today.
+ *
+ * Neither is visible under npm. Keep this gate.
+ *
+ * Usage:
+ *   node scripts/consumer-strict-install.mjs           # build + pack + verify
+ *   node scripts/consumer-strict-install.mjs --no-build  # reuse existing dist
+ */
+
+import { spawnSync } from 'child_process'
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, '..')
+const CORE = join(ROOT, 'packages', 'core')
+const WORK = join(ROOT, 'tests', '.strict-consumer')
+const SKIP_BUILD = process.argv.includes('--no-build')
+
+const RED = '\x1b[31m'
+const GREEN = '\x1b[32m'
+const CYAN = '\x1b[36m'
+const BOLD = '\x1b[1m'
+const RESET = '\x1b[0m'
+
+const step = (m) => console.log(`\n${CYAN}▶ ${m}${RESET}`)
+const pass = (m) => console.log(`${GREEN}✓${RESET} ${m}`)
+const fail = (m, extra) => {
+  console.error(`\n${RED}${BOLD}✗ ${m}${RESET}`)
+  if (extra) console.error(String(extra).slice(0, 4000))
+  process.exit(1)
+}
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
+    ...opts,
+  })
+  return {
+    status: res.status ?? -1,
+    stdout: res.stdout?.toString('utf8') ?? '',
+    stderr: res.stderr?.toString('utf8') ?? '',
+  }
+}
+
+// ── Build + pack ────────────────────────────────────────────────────────
+if (!SKIP_BUILD) {
+  step('Building core')
+  const b = run('pnpm', ['run', 'build'], { cwd: CORE })
+  if (b.status !== 0) fail('core build failed', b.stderr || b.stdout)
+  pass('Core built')
+}
+
+step('Packing tarball')
+rmSync(WORK, { recursive: true, force: true })
+mkdirSync(join(WORK, 'src'), { recursive: true })
+const packed = run('pnpm', ['pack', '--pack-destination', WORK], { cwd: CORE })
+if (packed.status !== 0) fail('pnpm pack failed', packed.stderr || packed.stdout)
+const tgz = readdirSync(WORK).find((n) => n.endsWith('.tgz'))
+if (!tgz) fail('no tarball produced')
+pass(`Packed ${tgz}`)
+
+// ── Generate a module importing every subpath ───────────────────────────
+const pkg = JSON.parse(readFileSync(join(CORE, 'package.json'), 'utf8'))
+const skip = (k) =>
+  k.includes('*') ||
+  k === './css' ||
+  k === './tokens' ||
+  k === './package.json' ||
+  /\.(json|md|css)$/.test(k) ||
+  k.startsWith('./make-kit')
+const subpaths = Object.keys(pkg.exports).filter((k) => !skip(k))
+const specOf = (k) => (k === '.' ? '@devalok/shilp-sutra' : `@devalok/shilp-sutra/${k.slice(2)}`)
+
+writeFileSync(
+  join(WORK, 'src', 'all.ts'),
+  subpaths.map((k, i) => `import * as M${i} from '${specOf(k)}'`).join('\n') +
+    `\n\nexport const ALL = [\n${subpaths.map((k, i) => `  ['${specOf(k)}', M${i}],`).join('\n')}\n]\n`
+)
+writeFileSync(join(WORK, 'subpaths.json'), JSON.stringify(subpaths))
+
+// Every declared peer, so "missing peer" noise cannot masquerade as a defect.
+// react/react-dom come from the base install.
+//
+// These go straight into package.json rather than through `pnpm add <pkg>@<range>`:
+// on Windows `^` is cmd.exe's escape character, so a range passed through a
+// shell arrives as an exact pin (`^8.0.0` → `8.0.0`) and resolves to the oldest
+// release in the range — which for @tanstack/react-table has an unpublished
+// transitive and fails to install at all.
+const peerRanges = Object.fromEntries(
+  Object.entries(pkg.peerDependencies || {}).filter(([k]) => k !== 'react' && k !== 'react-dom')
+)
+
+writeFileSync(
+  join(WORK, 'package.json'),
+  JSON.stringify(
+    {
+      name: 'strict-consumer',
+      private: true,
+      version: '1.0.0',
+      type: 'module',
+      dependencies: {
+        '@devalok/shilp-sutra': `file:./${tgz}`,
+        react: '^19.0.0',
+        'react-dom': '^19.0.0',
+      },
+      devDependencies: {
+        typescript: '^5.9.0',
+        '@types/react': '^19.0.0',
+        '@types/react-dom': '^19.0.0',
+        ...peerRanges,
+      },
+    },
+    null,
+    2
+  )
+)
+
+// The point of the gate: no hoisting, no implicit peers.
+writeFileSync(
+  join(WORK, '.npmrc'),
+  'hoist=false\nshamefully-hoist=false\nauto-install-peers=false\nstrict-peer-dependencies=false\nnode-linker=isolated\n'
+)
+writeFileSync(
+  join(WORK, 'tsconfig.json'),
+  JSON.stringify(
+    {
+      compilerOptions: {
+        target: 'ES2022',
+        lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+        module: 'ESNext',
+        moduleResolution: 'bundler',
+        jsx: 'react-jsx',
+        strict: true,
+        skipLibCheck: false,
+        noEmit: true,
+        esModuleInterop: true,
+      },
+      include: ['src'],
+    },
+    null,
+    2
+  )
+)
+
+step(
+  `Installing under pnpm (hoisting off) with ${Object.keys(peerRanges).length} declared peers`
+)
+const inst = run('pnpm', ['install', '--ignore-workspace'], { cwd: WORK })
+if (inst.status !== 0) fail('pnpm install failed', inst.stderr || inst.stdout)
+pass(`Installed; ${subpaths.length} subpaths to verify`)
+
+// ── Types ───────────────────────────────────────────────────────────────
+step('Type-checking every subpath (skipLibCheck: false)')
+const tscBin = join(WORK, 'node_modules', 'typescript', 'bin', 'tsc')
+const tsc = run('node', [tscBin, '--noEmit'], { cwd: WORK, shell: false })
+const tscErrors = ((tsc.stdout || '') + (tsc.stderr || ''))
+  .split('\n')
+  .filter((l) => /error TS\d+/.test(l))
+if (tscErrors.length) {
+  fail(
+    `${tscErrors.length} type error(s) with every declared peer installed`,
+    tscErrors.slice(0, 30).join('\n') +
+      '\n\nEach one is something a pnpm consumer hits. If it names a package, that package is missing from peerDependencies (see TYPES_ONLY_COMPANIONS in derive-peer-map.mjs for the types-of-a-type-peer case).'
+  )
+}
+pass(`${subpaths.length} subpaths type-check clean`)
+
+// ── Runtime ─────────────────────────────────────────────────────────────
+step('SSR-importing every subpath in Node')
+writeFileSync(
+  join(WORK, 'ssr.mjs'),
+  `import { readFileSync } from 'fs'
+const subpaths = JSON.parse(readFileSync('./subpaths.json','utf8'))
+const failed = []
+for (const k of subpaths) {
+  const spec = k === '.' ? '@devalok/shilp-sutra' : \`@devalok/shilp-sutra/\${k.slice(2)}\`
+  try { await import(spec) }
+  catch (e) { failed.push(\`\${spec} :: \${e.code || ''} \${String(e.message).split('\\n')[0].slice(0,160)}\`) }
+}
+if (failed.length) { console.error(failed.join('\\n')); process.exit(1) }
+console.log('ok ' + subpaths.length)
+`
+)
+const ssr = run('node', ['ssr.mjs'], { cwd: WORK, shell: false })
+if (ssr.status !== 0) {
+  fail(
+    'subpath(s) failed to import at runtime',
+    (ssr.stdout || '') +
+      (ssr.stderr || '') +
+      '\n\nERR_REQUIRE_CYCLE_MODULE usually means a 0-byte emitted module — see fix-empty-modules.mjs.'
+  )
+}
+pass(`${subpaths.length} subpaths import cleanly`)
+
+rmSync(WORK, { recursive: true, force: true })
+console.log(`\n${GREEN}${BOLD}✓ Strict-install consumer check passed${RESET}`)

--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -12,7 +12,7 @@
  * execSync is safe here — no shell injection risk.
  */
 
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
 import { join, resolve, basename } from 'path'
 import { globSync } from 'node:fs'
@@ -285,6 +285,61 @@ gate('Recipe peer tables match source (derive-peer-map --check)', () => {
     return true
   } catch (e) {
     return e.stdout?.trim() || e.stderr?.trim() || 'derive-peer-map --check reported drift'
+  }
+})
+
+// Gate: the declaration files we are about to publish must be usable by a
+// consumer who actually type-checks them. Asserts no directive prologue in a
+// .d.ts (TS1036), no undeclared bare specifier (TS2307), and no extensionless
+// relative specifier (TS2834/2835). 0.54.0 shipped all three — 209 + 8 + 234
+// occurrences — and every existing gate stayed green, because our own smoke
+// consumer sets `skipLibCheck: true`, the setting that hides this entire class.
+gate('Published .d.ts are consumer-clean (audit-dts)', () => {
+  try {
+    execFileSync('node', ['scripts/audit-dts.mjs'], { cwd: ROOT, encoding: 'utf-8', stdio: 'pipe' })
+    return true
+  } catch (e) {
+    return e.stdout?.trim() || e.stderr?.trim() || 'audit-dts reported violations'
+  }
+})
+
+// Gate: simulate every module-resolution mode a consumer can use (node10,
+// node16 from CJS and ESM, bundler) against the packed tarball.
+//
+// Two rules are ignored because they are deliberate, not defects:
+//   • cjs-resolves-to-esm — we ship ESM only; CJS consumers use dynamic import.
+//   • no-resolution       — node10 (pre-`exports`) cannot see our subpaths, and
+//                           attw models JS/TS only, so it also reports our
+//                           CSS-only `./css` and `./tokens` entries as failures
+//                           when both in fact resolve.
+// `internal-resolution-error` is deliberately NOT ignored — that is the rule
+// that catches broken relative specifiers inside our own declarations, and the
+// one that would have blocked 0.54.0 (301 occurrences).
+gate('Type resolution across consumer configs (attw)', () => {
+  try {
+    execFileSync(
+      process.platform === 'win32' ? 'npx.cmd' : 'npx',
+      [
+        '--yes',
+        '@arethetypeswrong/cli@latest',
+        '--pack',
+        'packages/core',
+        '--ignore-rules',
+        'cjs-resolves-to-esm',
+        'no-resolution',
+      ],
+      {
+        cwd: ROOT,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        // Name the .cmd shim directly rather than passing shell:true — with a
+        // shell, Node concatenates argv without escaping (DEP0190).
+        ...(process.platform === 'win32' ? { shell: false } : {}),
+      }
+    )
+    return true
+  } catch (e) {
+    return e.stdout?.trim() || e.stderr?.trim() || 'attw reported type-resolution problems'
   }
 })
 

--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -315,27 +315,24 @@ gate('Published .d.ts are consumer-clean (audit-dts)', () => {
 // `internal-resolution-error` is deliberately NOT ignored — that is the rule
 // that catches broken relative specifiers inside our own declarations, and the
 // one that would have blocked 0.54.0 (301 occurrences).
+// attw is a PINNED devDependency invoked through its JS entry, not `npx
+// @latest`: a release gate must not reach the network, and a newly published
+// attw rule must not fail a release out of nowhere. Node also refuses to spawn
+// a Windows `.cmd` shim without a shell (EINVAL, post-CVE-2024-27980), so
+// `npx.cmd` is not an option here either.
 gate('Type resolution across consumer configs (attw)', () => {
   try {
     execFileSync(
-      process.platform === 'win32' ? 'npx.cmd' : 'npx',
+      process.execPath,
       [
-        '--yes',
-        '@arethetypeswrong/cli@latest',
+        join(ROOT, 'node_modules', '@arethetypeswrong', 'cli', 'dist', 'index.js'),
         '--pack',
         'packages/core',
         '--ignore-rules',
         'cjs-resolves-to-esm',
         'no-resolution',
       ],
-      {
-        cwd: ROOT,
-        encoding: 'utf-8',
-        stdio: 'pipe',
-        // Name the .cmd shim directly rather than passing shell:true — with a
-        // shell, Node concatenates argv without escaping (DEP0190).
-        ...(process.platform === 'win32' ? { shell: false } : {}),
-      }
+      { cwd: ROOT, encoding: 'utf-8', stdio: 'pipe' }
     )
     return true
   } catch (e) {

--- a/skills/shilp-sutra/references/setup-astro.md
+++ b/skills/shilp-sutra/references/setup-astro.md
@@ -40,6 +40,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/skills/shilp-sutra/references/setup-next-app-router.md
+++ b/skills/shilp-sutra/references/setup-next-app-router.md
@@ -53,6 +53,8 @@ Some components depend on third-party libraries that ship as optional peers. **I
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/skills/shilp-sutra/references/setup-remix.md
+++ b/skills/shilp-sutra/references/setup-remix.md
@@ -36,6 +36,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/skills/shilp-sutra/references/setup-tanstack-start.md
+++ b/skills/shilp-sutra/references/setup-tanstack-start.md
@@ -45,6 +45,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/skills/shilp-sutra/references/setup-vite.md
+++ b/skills/shilp-sutra/references/setup-vite.md
@@ -51,6 +51,8 @@ Some components ship hard peers as optional. **Install BEFORE first import.** �
 | `@devalok/shilp-sutra/composed/date-picker` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/composed/file-preview` | `pnpm add react-pdf react-zoom-pan-pinch` |
 | `@devalok/shilp-sutra/composed/markdown-viewer` | `pnpm add react-markdown react-syntax-highlighter remark-gfm` |
+| `@devalok/shilp-sutra/composed/rich-chat-input` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
+| `@devalok/shilp-sutra/composed/rich-text-editor` | `pnpm add -D @tiptap/pm @tiptap/react` *(types only — the runtime is bundled)* |
 | `@devalok/shilp-sutra/composed/schedule-view` | `pnpm add date-fns` |
 | `@devalok/shilp-sutra/ui/charts` | `pnpm add d3-axis d3-scale d3-selection d3-shape` |
 | `@devalok/shilp-sutra/ui/data-table` | `pnpm add @tanstack/react-table @tanstack/react-virtual` |

--- a/skills/shilp-sutra/references/troubleshoot.md
+++ b/skills/shilp-sutra/references/troubleshoot.md
@@ -208,6 +208,27 @@ pnpm add use-sync-external-store
 
 And open an issue at <https://github.com/devalok-design/shilp-sutra/issues> with the resolution graph (`pnpm why use-sync-external-store`) so we can fix the root cause.
 
+## Symptom: `Cannot find package 'sonner'` when you only imported a hook (or `'react-markdown'` from the AI barrel)
+
+**Diagnosis:** you imported a *barrel* rather than the component itself, and the barrel re-exports something with an optional peer.
+
+- `@devalok/shilp-sutra/hooks` re-exports `toast`, which needs `sonner`.
+- `@devalok/shilp-sutra/ai` re-exports the block renderer, which needs `react-markdown`.
+
+A bundler tree-shakes the unused branch away, so this is invisible in a client build. It bites at **runtime in Node** — SSR, a route handler, a test — where the import is evaluated for real.
+
+Fix — import the specific module instead of the barrel:
+
+```ts
+// needs sonner installed, because the barrel also exports toast
+import { useIsMobile } from '@devalok/shilp-sutra/hooks'
+
+// no optional peers at all
+import { useIsMobile } from '@devalok/shilp-sutra/hooks/use-mobile'
+```
+
+Every hook has its own subpath: `use-mobile`, `use-color-mode`, `use-touch-device`, `use-viewport-height`. Same rule applies across the library — a deep import never costs you more than that component needs.
+
 ## Symptom: `error TS2305: Module '"react"' has no exported member 'ReactSVG'`
 
 **This is an upstream `@tabler/icons-react` bug, not a shilp-sutra one** — but you will hit it following our install instructions, so it is documented here.

--- a/skills/shilp-sutra/references/troubleshoot.md
+++ b/skills/shilp-sutra/references/troubleshoot.md
@@ -198,6 +198,8 @@ In dev mode, calling `toast()` without a mounted `<Toaster />` logs a one-time c
 
 **Diagnosis:** Should not happen since v0.37.0 — `use-sync-external-store` was moved to runtime dependencies and is auto-installed transitively.
 
+**Why this dependency exists at all** (it is a hook built into React 18+, so it looks redundant): we do not use the shim ourselves. It is a TipTap transitive. TipTap's code is bundled into our `dist`, and that bundled chunk imports `use-sync-external-store/shim`. We externalize the shim rather than bundling it, because bundling forced a `createRequire` bridge into our Rollup runtime chunk that broke every Turbopack consumer. Externalized code must be resolvable from the consumer's tree, hence the declaration.
+
 If it still happens, install it explicitly:
 
 ```bash
@@ -205,6 +207,63 @@ pnpm add use-sync-external-store
 ```
 
 And open an issue at <https://github.com/devalok-design/shilp-sutra/issues> with the resolution graph (`pnpm why use-sync-external-store`) so we can fix the root cause.
+
+## Symptom: `error TS2305: Module '"react"' has no exported member 'ReactSVG'`
+
+**This is an upstream `@tabler/icons-react` bug, not a shilp-sutra one** — but you will hit it following our install instructions, so it is documented here.
+
+`@tabler/icons-react` (through 3.45.0, the current release) opens its type declarations with:
+
+```ts
+import { ReactSVG, … } from 'react'
+```
+
+React 18's types exported `ReactSVG`; React 19's removed it, keeping only `ReactSVGElement`. So on React 19 the icon package's own `.d.ts` fails to compile.
+
+You only see it with **all three**: React 19, `skipLibCheck: false`, and a direct `@tabler/icons-react` import in your own code. React 18 is unaffected, and the default `skipLibCheck: true` suppresses it.
+
+Workarounds, in order of preference:
+
+1. Leave `skipLibCheck: true` (the default in every framework scaffold). It suppresses errors inside dependency declarations — including this one.
+2. Import icons through our re-export instead of directly, so the broken declaration is never loaded into your program.
+3. Pin `@types/react` to 18 if your app is still on React 18.
+
+There is nothing to fix on our side: we neither wrap nor re-declare Tabler's types. Track it upstream at <https://github.com/tabler/tabler-icons/issues>.
+
+## Symptom: `error TS2307: Cannot find module '@devalok/shilp-sutra/ui/button'` under `"moduleResolution": "node"`
+
+**Diagnosis:** You are on TypeScript's legacy resolution mode, which predates and ignores the `exports` field in `package.json`. Our files live under `dist/`, and every public path is mapped through `exports` — legacy resolution looks for a literal `node_modules/@devalok/shilp-sutra/ui/button.js` and finds nothing.
+
+**Supported resolution modes:**
+
+| `moduleResolution` | Supported | Notes |
+|---|---|---|
+| `bundler` | ✅ | Recommended. Vite, Next.js, and most modern setups default to this. |
+| `node16` / `nodenext` | ✅ | Fully supported since 0.55.0. |
+| `node` (legacy) | ❌ | Cannot read `exports`. No subpath resolves. |
+
+Fix — in your `tsconfig.json`:
+
+```jsonc
+{ "compilerOptions": { "moduleResolution": "bundler" } }
+```
+
+## Symptom: `require('@devalok/shilp-sutra')` throws `ERR_REQUIRE_ESM`
+
+**Diagnosis:** The package is ESM-only — we ship no CommonJS build. Whether `require()` works depends on your Node version:
+
+| Node | `require('@devalok/shilp-sutra/ui/button')` |
+|---|---|
+| 22.12+ / 23+ | ✅ Works — `require(esm)` is supported and unflagged. Verified against every entry point, including the full `./ui` barrel. |
+| < 22.12 | ❌ `ERR_REQUIRE_ESM` |
+
+On older Node, use a dynamic import:
+
+```js
+const { Button } = await import('@devalok/shilp-sutra/ui/button')
+```
+
+Or move the consuming file to ESM (`"type": "module"`, or a `.mjs` extension). Every supported framework target — Next.js, Vite, Remix, Astro, TanStack Start — handles the ESM entry natively; this only affects hand-written CJS scripts.
 
 ## Symptom: Storybook MCP server `localhost:6006/mcp` returns 404
 

--- a/tests/smoke-consumer/package.json
+++ b/tests/smoke-consumer/package.json
@@ -21,6 +21,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.0",
+    "@tiptap/core": "^3.28.0",
+    "@tiptap/react": "^3.28.0",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/tests/smoke-consumer/tsconfig.json
+++ b/tests/smoke-consumer/tsconfig.json
@@ -7,7 +7,7 @@
       "esnext"
     ],
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Fixes #237.

A consumer installed 0.54.0 and got "a ton of TS errors from your package's `.d.ts` file". Reproduced exactly — their repro (`import '@devalok/shilp-sutra'`, `module: nodenext`, TypeScript 7.0.2) gives **79 errors** on the published build and **0** on this branch.

Every fault below is invisible on the most common consumer setup — npm + `moduleResolution: "bundler"` + `skipLibCheck: true` — which is why 45 green gates shipped them.

## Correctness

**`"use client"` was emitted into 209 of 284 `.d.ts`.** A declaration file is an ambient context, so the prologue is a statement: `TS1036`. The directive is a bundler/RSC concern read off the `.js` module graph; declarations are erased before anything runs. `inject-use-client.mjs` now skips `.d.ts` and strips stale directives.

**Eight `.d.ts` named packages declared nowhere** (`@floating-ui/dom`, `@tiptap/core`, `@tiptap/react`, `@tiptap/suggestion`) → `TS2307`. Root cause was a rule true only of runtime: *"a module is a consumer peer iff the build externalizes it."* Rollup inlines TipTap's JS, but TypeScript's declaration emitter does **not** inline third-party types, so the bare specifier survives with nothing declaring it.
- `@floating-ui/dom`'s `Placement` is inlined as an exported `SplitButtonPlacement` (same twelve members) — no install, no leak.
- The three `@tiptap` packages become optional **types-only** peers; the runtime stays bundled. `derive-peer-map.mjs` learns this category so `preflight` and the recipe tables say *"types only"* instead of implying a runtime need — the phantom-install trap the 2026-07-10 dogfood objected to.

**234 extensionless relative specifiers** broke `node16`/`nodenext` (`TS2834`/`TS2835`). New `fix-dts-extensions.mjs` appends `.js`, resolving directory specifiers to `/index.js` against the real emit.

**Two 0-byte emitted modules** (`ui/toast-types.js`, `ai/types.js`). A types-only entry has no runtime content, so the bundler emits nothing while `exports` still advertises a runtime path. An empty file gives Node's module-type detection nothing to read, and under pnpm's symlinks that throws `ERR_REQUIRE_CYCLE_MODULE`. Pre-existing — published 0.54.0 fails this way under pnpm and works under npm.

**`@tiptap/pm` was missing from the peer set.** TipTap's own `.d.ts` imports `@tiptap/pm/state` and declares `@tiptap/pm` as *its* peer, so `pnpm add -D @tiptap/react` still left six `TS2307` errors from inside TipTap. Not derivable from our imports, hence an explicit companion map.

**Hook barrel had no escape hatch.** `.../hooks` re-exports `toast`, so importing `useIsMobile` needs `sonner`. Only 2 of 4 hooks had deep subpaths; the missing two are added, and the behaviour is documented.

## Dependencies: 7 → 4, no consumer action

`diff`, `frimousse` and `@emoji-mart/data` were declared runtime dependencies while already fully bundled into `dist` — consumers installed packages they also received a copy of. Nothing resolves them at runtime, nothing names them in the types. The remaining four are load-bearing: `class-variance-authority` and `clsx` appear in our published types, `tw-animate-css` is resolved by the consumer's CSS build, and `use-sync-external-store` is an externalized TipTap transitive.

## Performance: bundle floor down 57%

All 25 vendored Radix primitives lived in one 231 KB chunk, so `<Button>` — needing only `Slot`/`Slottable` — also shipped Select, Dialog, Menu, Tooltip and Slider.

| scenario | before | no manualChunks | **this PR** |
|---|---|---|---|
| one `<Button>` | 209 KB | 56 KB | **90 KB** |
| 12 components | 252 KB | 586 KB | **213 KB** |

Removing the rule outright is a trap: without a pinned shared chunk Rollup duplicates the internals into every primitive chunk and a realistic app more than doubles. Splitting per primitive while pinning `_internal/` improves both.

## Gates, so this class cannot ship again

- **`scripts/audit-dts.mjs`** — no directive prologue, no undeclared bare specifier, no extensionless relative specifier, no 0-byte module. Has a `--root` flag so it can be aimed at a published tarball: reports 647 violations on 0.54.0, passes this build.
- **`scripts/consumer-strict-install.mjs`** — pnpm isolated (`hoist=false`, `auto-install-peers=false`), all 150 subpaths, types + runtime. This is the gate that found `@tiptap/pm` and the 0-byte modules.
- **`attw`** — pinned devDependency invoked via `process.execPath`, not `npx @latest`: no network at release time, and a new attw rule can't fail a release out of nowhere. Exits 1 on published 0.54.0, 0 here.
- Smoke consumer now runs `skipLibCheck: false`, plus a `bundler` × `nodenext` × `skipLibCheck` matrix.
- `publint` clean (one `repository.url` fix).
- `build-skill.mjs` drift gate normalises line endings — it was false-positiving on every Windows run (`autocrlf` CRLF vs generated LF), which made it unusable locally.

## Verification

npm · pnpm isolated · Bun · Yarn PnP · React 18 + 19 · TS 5.9 + 7.0.2 · bundler + nodenext · skipLibCheck on/off · Next 16 + Turbopack · Vite 7 · SSR · real browser.

- 150/150 subpaths type-check clean at `skipLibCheck: false` and import cleanly at runtime
- `attw` `InternalResolutionError`: 301 → 0
- e2e Vite app: builds, server-renders, 13/13 Playwright interaction checks, zero console errors
- 173 test files, 2278 tests
- `pre-publish-audit`: 50/50 gates

## Deliberately out of scope

- **`--color-surface-fg-subtle` fails WCAG AA** — 4.472:1 against the required 4.5 (verified independently, not just via axe). Brand token with system-wide visual impact; wants Setu sign-off and a Chromatic pass.
- **axe `button-name` on the Select trigger** — flagged critical; the button does have visible text, so it may be axe being conservative, but it wasn't conclusively cleared.
- **`@tabler/icons-react` React 19 incompatibility** — Tabler 3.45.0 imports `ReactSVG`, which React 19 removed. Upstream, not ours; documented in `troubleshoot.md` with workarounds. Not gated, so a third-party bug can't block our releases.
- **#212 / #213 (DataTable)** — both reporters' root-cause claims are partly inaccurate (#213's "resolves by numeric index" is contradicted by the source). Real bugs may sit underneath; they need their own reproduction.
- Our gates pin TS 5.9 while latest is 7.0.2 — worth adding to the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6LcHdZ1rHCqDK8UKWd52
