### PR TITLE
fix(ci): integration affected-detection failed open, silently skipping every core gate

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # `Detect affected packages` diffs against `github.event.before`.
+          # The default `fetch-depth: 1` does not fetch that commit, so the
+          # diff died with `fatal: bad object` and every core gate below was
+          # skipped. fetch-depth: 0 guarantees the base commit is present.
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -56,6 +62,16 @@ jobs:
       # Core-only gates (consumer-smoke, css-coverage) don't apply to a
       # brand/eslint-only push. Skip them there. Fail safe: anything ambiguous
       # -> run full gates.
+      # FAIL CLOSED. This gate decides whether the core-only gates below run at
+      # all, so anything that is not a confident "core is untouched" must run
+      # them. The previous version failed OPEN: a shallow checkout meant
+      # `github.event.before` was not in the clone, `git diff` exited with
+      # `fatal: bad object`, the `elif` was therefore false, and control fell
+      # through to `else` -> core=false. Every consumer gate (smoke, strict
+      # install, compiled-CSS coverage) silently skipped on every push while
+      # the workflow reported success — a safety net that quietly unhooked
+      # itself. Verifying the base commit exists BEFORE diffing keeps a git
+      # failure from ever reading as "nothing changed".
       - name: Detect affected packages
         id: affected
         run: |
@@ -63,11 +79,16 @@ jobs:
           BEFORE="${{ github.event.before }}"
           if [ "${{ github.event_name }}" != "push" ] || [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
             echo "core=true" >> "$GITHUB_OUTPUT"
+            echo "Affected: non-push or no base ref -> full gates."
+          elif ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "core=true" >> "$GITHUB_OUTPUT"
+            echo "Affected: base commit $BEFORE not in this clone -> cannot diff, running full gates."
           elif git diff --name-only "$BEFORE" "${{ github.sha }}" | grep -qE '^packages/core/'; then
             echo "core=true" >> "$GITHUB_OUTPUT"
+            echo "Affected: packages/core changed -> full gates."
           else
             echo "core=false" >> "$GITHUB_OUTPUT"
-            echo "packages/core untouched -> skipping core-only integration gates."
+            echo "Affected: packages/core untouched -> skipping core-only integration gates."
           fi
 
       # Build is required for the dist-reading gates below (audit, consumer-smoke,


### PR DESCRIPTION
`Detect affected packages` gates the five core-only steps in `integration.yml`. It was failing **open**, so none of them ran.

The checkout had no `fetch-depth`, so `github.event.before` wasn't in the shallow clone:

```
fatal: bad object af7f3212a96490575a318ac267e5090f77f879ea
packages/core untouched -> skipping core-only integration gates.
```

The failed `git diff` made the `elif` false, control fell to `else`, and `core=false`. **A git error was read as "nothing changed."**

### Impact

Skipped on every push to main, while the workflow reported success:

- Consumer smoke (Next 16 + Turbopack + TW4)
- Consumer strict install (pnpm isolated, all subpaths)
- Compiled-CSS coverage (Turbopack)
- Consumer smoke (Next 15 + Webpack)
- Compiled-CSS coverage (Webpack)

Confirmed across the last several Integration runs — chronic, not a one-off. This workflow exists to be the post-merge net for gates PR CI can't run, so it has been green while doing nothing.

### Fix

- `fetch-depth: 0` so the base commit is present.
- An explicit `git cat-file -e "$BEFORE^{commit}"` guard **before** diffing — an unresolvable base now runs full gates and logs why.

The guard matters more than the fetch depth. Depth alone fixes today's symptom; any future git failure would silently unhook the net again. A gate that decides whether other gates run must fail closed.

### Verified

Against a deliberately absent base commit:

| | result |
|---|---|
| old logic | `core=false` — gates skip |
| new logic | `core=true` — gates run, reason logged |

Non-push, empty base, zero-sha, real-base-with-core-changes and no-change cases all still resolve correctly. YAML parses; all 5 gated steps still wired to `core == 'true'`.

### Not touched

`release.yml` already sets `fetch-depth: 0`, and as `workflow_dispatch` it takes the non-push branch → `core=true` regardless. No equivalent bug, and editing the publish path on speculation is what cost five failed releases on 0.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6LcHdZ1rHCqDK8UKWd52