### PR TITLE
fix(exports): expose ./package.json so tooling can read our manifest

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     },
     "./css": "./dist/tokens/shilp-sutra.css",
     "./tokens": "./dist/tokens/index.css",
+    "./package.json": "./package.json",
     "./BREAKING.json": "./BREAKING.json",
     "./BREAKING.schema.json": "./BREAKING.schema.json",
     "./ui": {


### PR DESCRIPTION
Reading a dependency's `package.json` is routine for build tools, bundler plugins and dependency-analysis tooling — checking a version, deciding how to handle a package. Ours refused:

```
ERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './package.json' is not defined by "exports"
```

Surfaced by our own verification script, which tried to read the installed version and got knocked back. The error names the *consumer's* call site rather than us, so it's the kind of thing someone loses time to without suspecting this package.

`publint` doesn't flag the omission and the ecosystem is split on it, so this is a judgement call rather than a defect — one line, no meaningful downside, removes a papercut.

**Verified** against a packed tarball: `require('@devalok/shilp-sutra/package.json')` resolves and returns `0.55.0`.

---

### Not included: the WCAG contrast token

`--color-surface-fg-subtle` measures **4.472:1** against AA's required 4.5 in the light theme, and the agreed fix is `--neutral-9` light `0.55 → 0.54` (→ **4.664**, visually indistinguishable). It is deliberately **not** in this PR — Setu is returning 502 on every endpoint, and no colour pairing ships without a `setu_check`. It follows as its own PR once Setu is reachable, with Chromatic, since 87 component files consume that token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6LcHdZ1rHCqDK8UKWd52