### PR TITLE
fix(tokens): surface-fg-subtle failed WCAG AA; compute contrast instead of asserting it

### DIFF
--- a/.changeset/contrast-surface-fg-subtle.md
+++ b/.changeset/contrast-surface-fg-subtle.md
@@ -1,0 +1,13 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Fix `--color-surface-fg-subtle` failing WCAG AA in the light theme, and add a gate so a contrast claim has to be computed rather than asserted.
+
+The token measured **4.472:1** on the light `surface-base` against AA's required 4.5 for normal text — a 0.028 miss. It is used for secondary text in 87 component files (descriptions, placeholders, captions, metadata), so every one of those was non-compliant to any audit tool a consumer runs. Dark theme was already fine at 5.816:1 and is unchanged.
+
+`--neutral-9` (light) goes `oklch(0.54 …)` from `0.55`, giving **4.664:1**. The two are visually near-indistinguishable — the fix costs nothing to look at and moves the token from failing to passing.
+
+The intermediate `0.545` also clears, at 4.567, and was rejected: 0.067 of headroom means a later tweak to `surface-base` would silently push it back under. That is not hypothetical — the token already carried the comment `/* darkened for WCAG AA 4.5:1 */`, so a previous adjustment had been made with exactly this intent and landed short. The value looked right, the comment claimed it was right, and nothing verified it. It reached npm and was found by an external accessibility audit of rendered output.
+
+So the durable part of this change is the new gate. `scripts/audit-contrast.mjs` computes OKLCH → sRGB → WCAG relative luminance straight from `primitives.css` and fails the release if a listed body-text pairing drops under AA. It runs in `pre-publish-audit`, and is verified in both directions: it reports the exact `4.472 / −0.028` on the old value and passes on the new one. Four pairings are covered today (`surface-fg-subtle` and `surface-fg-muted`, each on `surface-base`, in both themes).

--- a/packages/core/src/tokens/primitives.css
+++ b/packages/core/src/tokens/primitives.css
@@ -60,7 +60,12 @@
   --neutral-6:  oklch(0.78 0.0053 350);
   --neutral-7:  oklch(0.7 0.0074 350);
   --neutral-8:  oklch(0.62 0.0089 350);
-  --neutral-9:  oklch(0.55 0.01 350);
+  /* 0.55 → 0.54: at 0.55 this measured 4.472:1 on --neutral-2 (the light
+     surface-base), just under WCAG AA's 4.5 for normal text. 0.54 gives
+     4.664:1. The intermediate 0.545 also clears at 4.567, but with only
+     0.067 of headroom — a later tweak to surface-base would silently push it
+     back under, which is how the previous attempt at this fix landed short. */
+  --neutral-9:  oklch(0.54 0.01 350);
   --neutral-10: oklch(0.5 0.01 350);
   --neutral-11: oklch(0.43 0.0074 350);
   --neutral-12: oklch(0.32 0.0042 350);

--- a/packages/core/src/tokens/semantic.css
+++ b/packages/core/src/tokens/semantic.css
@@ -180,7 +180,7 @@
   --color-surface-fg-disabled:   var(--neutral-8);
   --color-surface-fg:            var(--neutral-12);
   --color-surface-fg-muted:      var(--neutral-11);
-  --color-surface-fg-subtle:     var(--neutral-9);  /* darkened for WCAG AA 4.5:1 */
+  --color-surface-fg-subtle:     var(--neutral-9);  /* 4.664:1 on surface-base — WCAG AA (verify, don't assume: see neutral-9) */
   --color-surface-border:        var(--neutral-6);  /* bumped for WCAG 1.4.11 (interactive/control edge) */
   --color-surface-border-strong: var(--neutral-7);
   --color-surface-border-subtle: var(--neutral-5);

--- a/scripts/audit-contrast.mjs
+++ b/scripts/audit-contrast.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * audit-contrast.mjs
+ *
+ * Computes the WCAG contrast ratio of foreground/background token pairings
+ * straight from `primitives.css`, and fails if any pairing used for body text
+ * drops under AA's 4.5:1.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `--color-surface-fg-subtle` shipped at 4.472:1 on the light `surface-base` —
+ * a miss of 0.028. It carried the comment `/* darkened for WCAG AA 4.5:1 *␘/`,
+ * so a previous adjustment had been made with exactly this intent and landed
+ * short. The value looked right, the comment claimed it was right, and nothing
+ * checked. It reached npm and was found by an external audit of the rendered
+ * app, not by us.
+ *
+ * A comment cannot verify a ratio. This can. Anything asserting WCAG
+ * compliance in this repo should be computed, not stated.
+ *
+ * SCOPE — deliberately narrow. Only pairings listed in PAIRINGS below are
+ * checked, because only a human knows which token lands on which surface as
+ * body-sized text. This is not a substitute for axe over rendered output; it
+ * is a guard on the specific pairings we have already reasoned about, so they
+ * cannot silently regress.
+ *
+ * Usage:
+ *   node scripts/audit-contrast.mjs
+ */
+
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const PRIMITIVES = join(ROOT, 'packages', 'core', 'src', 'tokens', 'primitives.css')
+
+/**
+ * Each entry: a foreground scale step rendered on a background scale step, per
+ * theme, at normal text size. `min` is the WCAG level that pairing must clear.
+ */
+const PAIRINGS = [
+  { theme: 'light', fg: 9, bg: 2, min: 4.5, as: '--color-surface-fg-subtle on --color-surface-base' },
+  { theme: 'dark', fg: 9, bg: 1, min: 4.5, as: '--color-surface-fg-subtle on --color-surface-base' },
+  { theme: 'light', fg: 11, bg: 2, min: 4.5, as: '--color-surface-fg-muted on --color-surface-base' },
+  { theme: 'dark', fg: 11, bg: 1, min: 4.5, as: '--color-surface-fg-muted on --color-surface-base' },
+]
+
+// ── OKLCH → sRGB → WCAG relative luminance ─────────────────────────────────
+function oklchToSrgb(L, C, H) {
+  const h = (H * Math.PI) / 180
+  const a = C * Math.cos(h)
+  const b2 = C * Math.sin(h)
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b2
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b2
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b2
+  const l = l_ ** 3
+  const m = m_ ** 3
+  const s = s_ ** 3
+  const r = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s
+  const g = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s
+  const b = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s
+  const enc = (v) => {
+    v = Math.max(0, Math.min(1, v))
+    return v <= 0.0031308 ? 12.92 * v : 1.055 * Math.pow(v, 1 / 2.4) - 0.055
+  }
+  return [enc(r), enc(g), enc(b)]
+}
+
+const luminance = (c) => {
+  const lin = (v) => (v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4))
+  return 0.2126 * lin(c[0]) + 0.7152 * lin(c[1]) + 0.0722 * lin(c[2])
+}
+
+const contrast = (a, b) => {
+  const A = luminance(a)
+  const B = luminance(b)
+  return (Math.max(A, B) + 0.05) / (Math.min(A, B) + 0.05)
+}
+
+const toHex = (c) =>
+  '#' + c.map((v) => Math.round(v * 255).toString(16).padStart(2, '0')).join('').toUpperCase()
+
+// ── Parse the light and dark blocks ────────────────────────────────────────
+const src = readFileSync(PRIMITIVES, 'utf8')
+const darkIdx = src.indexOf('.dark')
+if (darkIdx === -1) {
+  console.error('audit-contrast: no `.dark` block found in primitives.css — parser needs updating.')
+  process.exit(1)
+}
+const blocks = { light: src.slice(0, darkIdx), dark: src.slice(darkIdx) }
+
+function step(theme, n) {
+  const m = blocks[theme].match(
+    new RegExp(`--neutral-${n}:\\s*oklch\\(\\s*([0-9.]+)\\s+([0-9.]+)\\s+([0-9.]+)\\s*\\)`)
+  )
+  if (!m) {
+    console.error(`audit-contrast: --neutral-${n} not found in the ${theme} block.`)
+    process.exit(1)
+  }
+  return [parseFloat(m[1]), parseFloat(m[2]), parseFloat(m[3])]
+}
+
+console.log('# audit-contrast\n')
+let failures = 0
+
+for (const p of PAIRINGS) {
+  const fg = oklchToSrgb(...step(p.theme, p.fg))
+  const bg = oklchToSrgb(...step(p.theme, p.bg))
+  const r = contrast(fg, bg)
+  const ok = r >= p.min
+  if (!ok) failures++
+  const delta = (r - p.min).toFixed(3)
+  console.log(
+    `  ${ok ? '✓' : '✗'} ${p.theme.padEnd(5)} ${toHex(fg)} on ${toHex(bg)}  ` +
+      `${r.toFixed(3)}:1  (AA ${p.min}, ${ok ? '+' : ''}${delta})  ${p.as}`
+  )
+}
+
+if (failures) {
+  console.log(
+    `\naudit-contrast: FAILED — ${failures} pairing(s) under WCAG AA.\n` +
+      `Adjust the lightness of the offending --neutral-* step in primitives.css.\n` +
+      `Leave real headroom: a pairing that clears by <0.1 will regress the next\n` +
+      `time a surface token moves, which is how the 4.472 miss happened.`
+  )
+  process.exit(1)
+}
+console.log('\naudit-contrast: PASSED.')

--- a/scripts/pre-publish-audit.mjs
+++ b/scripts/pre-publish-audit.mjs
@@ -303,6 +303,25 @@ gate('Published .d.ts are consumer-clean (audit-dts)', () => {
   }
 })
 
+// Gate: token pairings we render body text on must clear WCAG AA, computed
+// from primitives.css rather than asserted. `--color-surface-fg-subtle`
+// shipped at 4.472:1 while carrying the comment "darkened for WCAG AA 4.5:1" —
+// a previous fix that landed 0.028 short. The value looked right, the comment
+// claimed it was right, and nothing checked; it took an external audit of the
+// rendered app to catch. A comment cannot verify a ratio.
+gate('Token contrast pairings meet WCAG AA (audit-contrast)', () => {
+  try {
+    execFileSync('node', ['scripts/audit-contrast.mjs'], {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    })
+    return true
+  } catch (e) {
+    return e.stdout?.trim() || e.stderr?.trim() || 'audit-contrast reported a pairing under AA'
+  }
+})
+
 // Gate: simulate every module-resolution mode a consumer can use (node10,
 // node16 from CJS and ESM, bundler) against the packed tarball.
 //


### PR DESCRIPTION
`--color-surface-fg-subtle` measured **4.472:1** on the light `surface-base` against AA's required **4.5** for normal text. It's used for secondary text in **87 component files** — descriptions, placeholders, captions, metadata — so all of them were non-compliant to any audit tool a consumer runs. Dark was already fine at 5.816:1 and is untouched.

Found by running axe over rendered output, then verified independently by computing OKLCH → sRGB → WCAG luminance rather than trusting the scanner.

## The change

`--neutral-9` (light) `0.55` → `0.54` → **4.664:1**.

| lightness | hex | ratio | margin | |
|---|---|---|---|---|
| 0.55 | `#766F72` | 4.472 | −0.028 | ✕ current |
| 0.545 | `#756E71` | 4.567 | +0.067 | passes, thin |
| **0.54** | `#746C6F` | **4.664** | **+0.164** | ✓ **this PR** |

The two are visually near-indistinguishable — confirmed by eye against real text at real sizes. The fix costs nothing to look at.

`0.545` was rejected deliberately. 0.067 of headroom means a later tweak to `surface-base` pushes it back under — and that isn't hypothetical: **the token already carried `/* darkened for WCAG AA 4.5:1 */`**, so a previous adjustment was made with exactly this intent and landed 0.028 short. The value looked right, the comment claimed it was right, nothing verified it.

## The durable half: a gate, not a number

`scripts/audit-contrast.mjs` computes contrast straight from `primitives.css` and fails the release if a listed body-text pairing drops under AA. Wired into `pre-publish-audit`.

Verified **both directions** — reports the exact `4.472 / −0.028` on the old value, passes on the new:

```
✓ light #746C6F on #F5F5F5  4.664:1  (AA 4.5, +0.164)  surface-fg-subtle on surface-base
✓ dark  #8E878A on #040404  5.816:1  (AA 4.5, +1.316)  surface-fg-subtle on surface-base
✓ light #534E50 on #F5F5F5  7.461:1  (AA 4.5, +2.961)  surface-fg-muted on surface-base
✓ dark  #B4AFB1 on #040404  9.499:1  (AA 4.5, +4.999)  surface-fg-muted on surface-base
```

Scope is deliberately narrow: only pairings a human has reasoned about are listed, because only a human knows which token lands on which surface as body-sized text. It does **not** replace axe over rendered output — it stops already-reasoned pairings from silently regressing.

## Verification

- Build emits `oklch(0.54 0.01 350)` into shipped `dist` CSS
- Token mappings confirmed against `semantic.css` — `fg-subtle`=neutral-9, `fg-muted`=neutral-11, `surface-base`=neutral-2 (light) / neutral-1 (dark)
- typecheck + lint clean; no test pins the old value
- **Wants Chromatic** — 87 files get 1% darker secondary text, so please eyeball the snapshots

## ⚠️ Setu was not consulted

Setu returned **502 on every endpoint across five attempts over ~15 minutes**, so this pairing has **not** had a `setu_check`. Shipped on an explicit call with the maths independently verified. Worth a retro-check when Setu is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6LcHdZ1rHCqDK8UKWd52