### PR TITLE
fix(a11y): Checkbox, Switch and Slider had no accessible name in FormField

### DIFF
--- a/.changeset/a11y-accessible-name-checkbox-switch-slider.md
+++ b/.changeset/a11y-accessible-name-checkbox-switch-slider.md
@@ -1,0 +1,15 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+Fix Checkbox, Switch and Slider having **no accessible name** inside the documented `FormField` + `Label` pattern — a screen reader announced them unnamed.
+
+All three read `useFormField()` and wired `state`, `aria-describedby` and `aria-required`, so they looked integrated. None of them adopted `fieldCtx.inputId`, so `<Label htmlFor>` resolved to an element that did not exist. The label rendered, was visible, and was associated with nothing.
+
+Checkbox and Switch now adopt the field `inputId` (explicit `id` still wins), matching Input, Textarea, Select, Combobox, Autocomplete, NumberInput and ColorInput.
+
+Slider needed a different mechanism. Radix renders `Slider.Root` as a `<span>` — not a labellable element — and puts `role="slider"` on the **thumb**, so `htmlFor` can never reach it. The thumb now takes `aria-labelledby` from the field label instead. An explicit `aria-label` still wins, and a range slider deliberately does *not* borrow the field label, because one label cannot disambiguate two thumbs — name each thumb yourself there.
+
+Found by reading the browser's accessibility tree for every labellable control in three states (no label / placeholder only / `FormField` + `Label`), rather than trusting the DOM or a scanner's summary. The three broken controls turned out to be exactly the three that `form-field-label-association.test.tsx` did not cover — the 0.49.x round fixed the text-like controls and stopped there. Every labellable control including Radio is now asserted, and the new cases assert the accessible **name** via role rather than only label association, because that is what a screen-reader user actually receives. Verified to fail without the fix and pass with it.
+
+No API change; no consumer action required beyond upgrading.

--- a/packages/core/src/ui/checkbox.tsx
+++ b/packages/core/src/ui/checkbox.tsx
@@ -113,6 +113,11 @@ const Checkbox = React.forwardRef<
       aria-describedby={ariaDescribedBy}
       aria-required={ariaRequired || undefined}
       {...props}
+      // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor>
+      // resolves. Without this the label renders, points at nothing, and the
+      // control has NO accessible name — a screen reader announces an unnamed
+      // checkbox even though the consumer wrote FormField + Label correctly.
+      id={props.id ?? fieldCtx.inputId}
     >
       <AnimatePresence>
         {isActive && (

--- a/packages/core/src/ui/form-field-label-association.test.tsx
+++ b/packages/core/src/ui/form-field-label-association.test.tsx
@@ -3,14 +3,18 @@ import { describe, expect, it } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { Autocomplete } from './autocomplete'
+import { Checkbox } from './checkbox'
 import { ColorInput } from './color-input'
 import { Combobox } from './combobox'
 import { FormField } from './form'
 import { Input } from './input'
 import { Label } from './label'
 import { NumberInput } from './number-input'
+import { RadioGroup, RadioGroupItem } from './radio'
 import { SearchInput } from './search-input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
+import { Slider } from './slider'
+import { Switch } from './switch'
 import { Textarea } from './textarea'
 
 /**
@@ -23,6 +27,19 @@ import { Textarea } from './textarea'
  *
  * `getByLabelText` succeeds ONLY when the control is programmatically
  * associated with its visible label — exactly the property that was broken.
+ *
+ * 0.55.x — SECOND ROUND. The original fix covered the text-like controls and
+ * stopped there. Checkbox, Switch and Slider read useFormField (state,
+ * aria-describedby, aria-required) so they LOOKED integrated, yet never adopted
+ * inputId — and none of them were asserted here. An accessibility-tree sweep
+ * found all three with an EMPTY accessible name in the documented pattern; a
+ * screen reader announced an unnamed checkbox. The three broken controls were
+ * exactly the three untested ones, so every labellable control is covered now.
+ *
+ * Slider is the odd one: Radix renders Root as a <span> (not labellable) with
+ * role="slider" on the THUMB, so htmlFor can never reach it — it takes
+ * aria-labelledby instead. Assert the accessible NAME via role, not just label
+ * association, since that is what a screen-reader user actually gets.
  */
 
 const OPTIONS = [
@@ -116,6 +133,85 @@ describe('FormField + Label association (each control adopts the field inputId)'
       </FormField>,
     )
     expect(screen.getByLabelText('Search')).toBeInTheDocument()
+  })
+
+  // ── The controls the 0.49.x round missed ────────────────────────────────
+  // Checkbox, Switch and Slider read useFormField (state, aria-describedby,
+  // aria-required) so they LOOKED integrated, but never adopted inputId — and
+  // none of them were covered here, which is exactly why it went unnoticed
+  // until an accessibility-tree sweep in 0.55.x. Assert on the accessible NAME
+  // via role, not just label association, because that is the property a
+  // screen-reader user actually depends on.
+
+  it('Checkbox', () => {
+    render(
+      <FormField>
+        <Label>Accept terms</Label>
+        <Checkbox />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Accept terms')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Accept terms' })).toBeInTheDocument()
+  })
+
+  it('Switch', () => {
+    render(
+      <FormField>
+        <Label>Email notifications</Label>
+        <Switch />
+      </FormField>,
+    )
+    expect(screen.getByLabelText('Email notifications')).toBeInTheDocument()
+    expect(screen.getByRole('switch', { name: 'Email notifications' })).toBeInTheDocument()
+  })
+
+  it('Slider names the thumb via aria-labelledby', () => {
+    // Radix renders Slider.Root as a <span> — not a labellable element — and
+    // puts role="slider" on the THUMB, so `<Label htmlFor>` can never name it
+    // the way it names Input. The thumb points at the field label instead.
+    render(
+      <FormField>
+        <Label>Volume</Label>
+        <Slider defaultValue={[40]} />
+      </FormField>,
+    )
+    expect(screen.getByRole('slider', { name: 'Volume' })).toBeInTheDocument()
+  })
+
+  it('Slider with an explicit aria-label keeps it', () => {
+    render(
+      <FormField>
+        <Label>Volume</Label>
+        <Slider defaultValue={[40]} aria-label="Playback volume" />
+      </FormField>,
+    )
+    expect(screen.getByRole('slider', { name: 'Playback volume' })).toBeInTheDocument()
+  })
+
+  it('range Slider does NOT borrow the field label for both thumbs', () => {
+    // One label cannot disambiguate two thumbs; the consumer must name each.
+    // Asserting this keeps a future "just add aria-labelledby to every thumb"
+    // change from producing two identically-named sliders.
+    render(
+      <FormField>
+        <Label>Price range</Label>
+        <Slider defaultValue={[20, 60]} />
+      </FormField>,
+    )
+    expect(screen.queryAllByRole('slider', { name: 'Price range' })).toHaveLength(0)
+  })
+
+  it('RadioGroup items are individually labellable', () => {
+    render(
+      <FormField>
+        <Label>Plan</Label>
+        <RadioGroup>
+          <Label htmlFor="plan-free">Free</Label>
+          <RadioGroupItem id="plan-free" value="free" />
+        </RadioGroup>
+      </FormField>,
+    )
+    expect(screen.getByRole('radio', { name: 'Free' })).toBeInTheDocument()
   })
 })
 

--- a/packages/core/src/ui/slider.tsx
+++ b/packages/core/src/ui/slider.tsx
@@ -107,6 +107,17 @@ const Slider = React.forwardRef<
         <SliderPrimitive.Thumb
           key={i}
           aria-label={thumbCount === 1 ? (ariaLabel as string | undefined) : undefined}
+          // `role="slider"` lives on the THUMB, and Radix renders Root as a
+          // <span> — not a labellable element — so `<Label htmlFor>` cannot name
+          // this control the way it names Input/Select. Without an explicit
+          // aria-label the thumb had NO accessible name even inside
+          // FormField + Label. Point it at the field's label instead.
+          //
+          // Single-thumb only: with a range, one label cannot disambiguate the
+          // two thumbs, so the consumer must name each (`aria-label` per thumb).
+          aria-labelledby={
+            thumbCount === 1 && !ariaLabel ? fieldCtx.labelId : undefined
+          }
           className={sliderThumbVariants({ size, color })}
         />
       ))}

--- a/packages/core/src/ui/switch.tsx
+++ b/packages/core/src/ui/switch.tsx
@@ -81,6 +81,10 @@ const Switch = React.forwardRef<
       aria-describedby={ariaDescribedBy}
       aria-required={ariaRequired || undefined}
       {...props}
+      // Explicit id wins; otherwise adopt FormField's inputId so <Label htmlFor>
+      // resolves. Without this the label points at nothing and the switch has NO
+      // accessible name, despite the consumer wiring FormField + Label correctly.
+      id={props.id ?? fieldCtx.inputId}
       ref={ref}
     >
       <SwitchPrimitives.Thumb asChild>


### PR DESCRIPTION
Three very common controls had **no accessible name** in the documented `FormField` + `Label` pattern. A screen reader announced an unnamed checkbox.

All three read `useFormField()` and wired `state`, `aria-describedby` and `aria-required` — so they *looked* integrated — but never adopted `fieldCtx.inputId`. `<Label htmlFor>` resolved to an element that didn't exist. The label rendered, was visible, and was associated with nothing.

## Accessible name, before → after

| control | bare | placeholder | **FormField + Label** |
|---|---|---|---|
| input | ∅ | "Your name" | ✅ "Name" |
| textarea | ∅ | "Your message" | ✅ "Message" |
| select | ∅ | ∅ | ✅ "Country" |
| combobox | "Select…" | "Pick a country" | ✅ "Country" |
| autocomplete | ∅ | "Pick a country" | ✅ "Country" |
| **checkbox** | ∅ | — | ∅ → ✅ **"Agree"** |
| **switch** | ∅ | — | ∅ → ✅ **"Notify"** |
| **slider** | ∅ | — | ∅ → ✅ **"Volume"** |

## The fix

Checkbox and Switch adopt the field `inputId` (explicit `id` still wins), matching every other control.

**Slider needed something different, and my first attempt was wrong.** Radix renders `Slider.Root` as a `<span>` — not a labellable element — and puts `role="slider"` on the **thumb**, so an `id` on Root can't be reached by `htmlFor` at all (and pointing a `<label for>` at a span is invalid anyway). Reverted that; the thumb takes `aria-labelledby` from the field label instead. Explicit `aria-label` still wins, and a **range** slider deliberately does *not* borrow the field label — one label can't disambiguate two thumbs.

## How it was found

I was chasing an axe `button-name` critical on **Select**. That turned out to be **my own test markup** — a bare `<Select>` with no label, i.e. consumer omission. Select is fine in the documented pattern, and my earlier report saying otherwise was wrong.

Rather than stop there, I swept **every** labellable control in three states and read the browser's computed accessible name from the accessibility tree via CDP — not the DOM, not a scanner's summary. That cleared the control I suspected and found three genuinely broken ones **no scanner run had flagged**.

The three broken controls were exactly the three `form-field-label-association.test.tsx` didn't cover. The 0.49.x round fixed the text-like controls and stopped — its own docblock lists them. **Coverage shape predicted bug shape.**

## Tests

Every labellable control including Radio is now asserted, and the new cases check the accessible **name via role** rather than only label association, since that's what a screen-reader user receives.

Verified in both directions — the three new cases **fail** with the source fixes reverted:

```
× Checkbox
× Switch
× Slider names the thumb via aria-labelledby
Tests  3 failed | 13 passed (16)
```

250 tests across the 26 affected files pass; typecheck and lint clean. No API change, no consumer action beyond upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EC6LcHdZ1rHCqDK8UKWd52