### PR TITLE
chore(buildathon): extend deadline to 4 August 2026

### DIFF
--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -23,7 +23,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${SITE_URL}/showcase`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${SITE_URL}/theming`, lastModified: now, changeFrequency: 'monthly', priority: 0.95 },
     { url: `${SITE_URL}/agents`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
-    // Time-boxed: drop this entry after the buildathon closes (31 Jul 2026).
+    // Time-boxed: drop this entry after the buildathon closes (4 Aug 2026).
     { url: `${SITE_URL}/buildathon`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
     { url: `${SITE_URL}/docs`, lastModified: now, changeFrequency: 'weekly', priority: 0.8 },
     { url: `${SITE_URL}/aurora`, lastModified: now, changeFrequency: 'monthly', priority: 0.5 },

--- a/apps/site/lib/buildathon.ts
+++ b/apps/site/lib/buildathon.ts
@@ -13,10 +13,10 @@ export const FORM_URL =
 export const MCP_URL = 'https://shilp-sutra.devalok.in/mcp'
 export const CONTACT_EMAIL = 'hello@devalok.in'
 
-export const DATES = '25-31 July, 2026'
-export const CLOSES = '31 July, 11:59 PM IST'
+export const DATES = '25 July - 4 August, 2026'
+export const CLOSES = '4 August, 11:59 PM IST'
 /** Short form, for places where the time of day is noise (e.g. a hero plate). */
-export const CLOSES_SHORT = '31 July'
+export const CLOSES_SHORT = '4 August'
 export const PRIZE = '$15,000'
 
 /**
@@ -24,7 +24,7 @@ export const PRIZE = '$15,000'
  * few hours later so a timezone slip does not cost anyone their entry; that
  * slack is deliberately not surfaced here.
  */
-export const CLOSES_AT = Date.parse('2026-07-31T18:29:00Z') // 31 Jul 23:59 +05:30
+export const CLOSES_AT = Date.parse('2026-08-04T18:29:00Z') // 4 Aug 23:59 +05:30
 
 export function isOpen(now = Date.now()) {
   return now < CLOSES_AT

--- a/packages/mcp-server/scripts/smoke.mjs
+++ b/packages/mcp-server/scripts/smoke.mjs
@@ -176,7 +176,7 @@ try {
   // Only FAILURE paths are exercised. A submit_entry call that passed every
   // validation would POST a real row into the live response sheet, so no smoke
   // check may ever supply a fully valid entry.
-  const buildathonOpen = Date.now() < Date.parse('2026-07-31T23:30:00Z')
+  const buildathonOpen = Date.now() < Date.parse('2026-08-04T23:30:00Z')
   check('how_to_use carries the buildathon block while open', howText.includes('buildathon') === buildathonOpen, howText.slice(0, 120))
 
   const noConsent = await call('submit_entry', { fullName: 'A', email: 'a@b.co', phone: '1', mode: 'solo', projectTitle: 'P', oneLiner: 'x', repoUrl: 'https://github.com/a/b', videoUrl: 'https://x.co', liveUrl: 'https://x.co', humanConfirmed: false }, 21)

--- a/packages/mcp-server/src/buildathon.mjs
+++ b/packages/mcp-server/src/buildathon.mjs
@@ -30,14 +30,14 @@ const FORM_ACTION = `https://docs.google.com/forms/d/e/${FORM_ID}/formResponse`
 
 export const PAGE_URL = 'https://shilp-sutra.devalok.in/buildathon'
 
-// Announced close is 31 July 2026, 11:59 PM IST. The real cutoff sits at 05:00
+// Announced close is 4 August 2026, 11:59 PM IST. The real cutoff sits at 05:00
 // IST the next morning so a timezone slip does not cost someone their entry.
 // The slack is intentionally NOT advertised anywhere public.
 const DEADLINE_MS = process.env.BUILDATHON_DEADLINE
   ? Date.parse(process.env.BUILDATHON_DEADLINE)
-  : Date.parse('2026-07-31T23:30:00Z') // 2026-08-01 05:00 +05:30
+  : Date.parse('2026-08-04T23:30:00Z') // 2026-08-05 05:00 +05:30
 
-export const ANNOUNCED_CLOSE = '31 July 2026, 11:59 PM IST'
+export const ANNOUNCED_CLOSE = '4 August 2026, 11:59 PM IST'
 
 export function isOpen(now = Date.now()) {
   return now < DEADLINE_MS

--- a/packages/mcp-server/src/index.mjs
+++ b/packages/mcp-server/src/index.mjs
@@ -300,7 +300,7 @@ function buildServer(ctx = {}) {
 
   server.tool(
     'submit_entry',
-    'Submit an entry to Build with Shilp Sutra, the online buildathon by Devalok. Open to everyone, solo or team; entries close 31 July 2026, 11:59 PM IST. ' +
+    'Submit an entry to Build with Shilp Sutra, the online buildathon by Devalok. Open to everyone, solo or team; entries close 4 August 2026, 11:59 PM IST. ' +
       'The winner receives $15,000 worth of brand identity, GTM strategy, and ongoing support from Devalok Design and Strategy Studio. ' +
       'Judged on beauty, functionality, and Bharat-oriented problem solving. To enter: a public GitHub repository, a demo video, and a live demo URL, on a project that runs on shilp-sutra. ' +
       'Already building at the Cursor India or Sarvam AI buildathons? The same project can be entered here too. ' +


### PR DESCRIPTION
 ## Summary

  Buildathon submissions were closing 31 July; extended to 4 August to give entrants more build time.
  Updated both source-of-truth files (`packages/mcp-server/src/buildathon.mjs` and
  `apps/site/lib/buildathon.ts`) plus two spots that duplicate the date as a literal string rather
  than importing the constant: the `submit_entry` tool description in `index.mjs` and the smoke test's
  independent deadline check in `scripts/smoke.mjs`.

  ## Linked issues

  Closes #

  ## Checklist

  ### Always

  - [x] `pnpm typecheck && pnpm lint && pnpm test` clean locally
  - [ ] Changeset added (`pnpm changeset`) at the right bump level — see
  [Versioning](../blob/main/CONTRIBUTING.md#versioning--breaking-changes)
  - [ ] Storybook stories updated if visuals changed
  - [ ] `pre-publish-audit.mjs` clean (CI runs it on `main`; run locally for risky changes)

  ### If this PR fixes agent-filed feedback (`ai-agent-feedback` label)

  N/A — not agent-filed feedback.

  ### If this PR introduces a breaking change

  N/A — not a breaking change.

  ### If this PR adds a new component

  N/A — no new component.

  ## Notes for the reviewer

  - No changeset: both touched packages (`apps/site`, `packages/mcp-server`) are `"private": true` and
  never published to npm, so there's nothing for `changesets` to version.
  - Left `apps/site/app/buildathon/opengraph-image.jpg` and its `opengraph-image.alt.txt` (still says
  "25-31 July 2026") untouched — that's a static, manually-designed asset with the date likely baked
  into the pixels, not something I can regenerate. Flagging for whoever owns that asset to redesign
  with the new date.
  - Deadline mechanics unchanged: MCP-side keeps its undocumented grace window (announced close 11:59
  PM IST, real cutoff 05:00 IST the next morning) — just shifted forward by 4 days.