### PR TITLE
chore(deps): close all 8 open Dependabot alerts via pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,10 @@
       "esbuild@<0.28.1": "^0.28.1",
       "@hono/node-server@<2.0.5": "^2.0.5",
       "sharp@<0.35.0": "^0.35.0",
-      "postcss@<8.5.12": "^8.5.12"
+      "postcss@<8.5.12": "^8.5.12",
+      "undici@<7.29.0": "^7.29.0",
+      "hono@<4.12.34": "^4.12.34",
+      "ip-address@<10.2.2": "^10.2.2"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ overrides:
   '@hono/node-server@<2.0.5': ^2.0.5
   sharp@<0.35.0: ^0.35.0
   postcss@<8.5.12: ^8.5.12
+  undici@<7.29.0: ^7.29.0
+  hono@<4.12.34: ^4.12.34
+  ip-address@<10.2.2: ^10.2.2
 
 importers:
 
@@ -996,7 +999,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3776,8 +3779,8 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.13.0:
+    resolution: {integrity: sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -3839,8 +3842,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -5620,8 +5623,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -6583,9 +6586,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@hono/node-server@2.0.11(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.13.0)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.13.0
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -6814,7 +6817,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.13.0)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -6824,7 +6827,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -9031,7 +9034,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9352,7 +9355,7 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
-  hono@4.12.31: {}
+  hono@4.13.0: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -9404,7 +9407,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -9602,7 +9605,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -11592,7 +11595,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
Alerts were at **0** on 2026-07-24 (#208) and have accumulated back to **8** (1 high, 7 moderate). All three packages are transitive, and all three sit on code paths this repo never executes — so overrides are the right instrument rather than bumping a direct dependency.

| Package | Bump | Alerts | Chain |
|---|---|---|---|
| `undici` | 7.28.0 → 7.29.0 | 5 (1 **high**: cross-user information disclosure; + cookie attribute injection, CRLF injection via blob body `type`, whitespace disclosure, retry desync) | `jsdom@29.1.1` → `undici`. Test environment only, never shipped. |
| `hono` | 4.12.31 → 4.13.0 | ReDoS in CORS middleware via `Access-Control-Request-Headers` | `@modelcontextprotocol/sdk@1.29.0` → `@hono/node-server@2.0.11` → `hono` (peer) |
| `ip-address` | 10.2.0 → 10.4.0 | 2: IPv4-mapped/NAT64 IPv6 misclassification; CIDR suffix suppressing special-use detection | `@modelcontextprotocol/sdk@1.29.0` → `express-rate-limit@8.6.0` → `ip-address` |

**Both runtime chains are unreachable in our usage.** The MCP server's HTTP layer is native `node:http` (`packages/mcp-server/src/index.mjs:14,331`), so the SDK's optional `express` and `hono` transports are never constructed. Same rationale as the existing `@hono/node-server` override from #208.

`undici` is pinned `^7.29.0` rather than latest (8.10.0) **deliberately** — a major bump underneath jsdom is a bigger change than the advisory requires.

## Verification

- **`pnpm check:lockfile` passes** in a clean sandbox — the only condition under which pnpm actually re-validates. An in-repo `pnpm install --frozen-lockfile` short-circuits on an up-to-date `node_modules` and would report a poisoned lockfile as fine (the 0.56.0 lesson).
- **Full `pnpm-lock.yaml` diff read line by line**: 19 insertions, 16 deletions, every line explicable by these three overrides — the 3 override declarations, the `@hono/node-server` peer range narrowing `^4` → `^4.12.34` as a consequence, and 3 version bumps with their matching snapshot keys. No stray entries.
- One resolved version per package, no duplicates: `undici@7.29.0`, `hono@4.13.0`, `ip-address@10.4.0`.
- `packages/core` typecheck clean.
- **MCP server smoke: all 28 checks pass** — this is the package that actually consumes `hono` and `ip-address`.

Core unit tests deferred to CI rather than run locally: the full suite OOMs on Windows, and the only affected path is jsdom's internal fetch.

## Unrelated nit found while verifying

`packages/mcp-server/scripts/smoke.mjs:179` hardcodes the buildathon deadline as a literal (`'2026-08-04T23:30:00Z'`) instead of importing `isOpen()` from `src/buildathon.mjs`. The test logic itself is correct — it asserts both sides via `=== buildathonOpen`, so it flips rather than breaks at the cutoff — but it's why #253 had to hand-edit the smoke script when the date moved. Not fixed here to keep this PR to dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKhuif5ZLRkWnaegdJ2n7q