### PR TITLE
fix(DataTable): finish the virtual-expand fix, keep the Export default, close the test/story gaps on #251

### DIFF
--- a/.changeset/datatable-bug-fixes.md
+++ b/.changeset/datatable-bug-fixes.md
@@ -2,21 +2,24 @@
 "@devalok/shilp-sutra": minor
 ---
 
-**DataTable:** fix mount echo, virtualRows+expandable silent no-op, enableExport wiring, filterable+card gap — and add filterableColumns, rowClassName, onSelectionChange IDs
+**DataTable:** fix mount echo, virtualRows+expandable overlap, enableExport wiring, filterable+card gap — and add filterableColumns, rowClassName, onSelectionChange IDs
 
 **Bug fixes (closes #212, #213, #249):**
 
 - `onSelectionChange` no longer fires on mount with `[]`. A first-render guard (`isFirstRenderRef`) was added alongside the existing `isSyncingFromPropRef`. Any handler that called `router.refresh()`, triggered a refetch, or wrote to external state would cascade from this single spurious call.
 
-- `virtualRows + expandable` was a silent no-op: `DataTableExpandedRow` was only rendered in the non-virtual path. The expand toggle fired, `row.getIsExpanded()` returned `true`, zero content appeared. Fixed by rendering the expanded row in the virtual items map. DEV `console.warn` added for the fixed-height limitation.
-
-- `enableExport` existed on `DataTableToolbar` but was never forwarded through `DataTableProps`. Added alongside `onExport`. Defaults to `false` when server-side `pagination` is active.
+- `virtualRows + expandable` was a silent no-op: `DataTableExpandedRow` was only rendered in the non-virtual path. The expand toggle fired, `row.getIsExpanded()` returned `true`, zero content appeared. Fixed completely rather than partially: each windowed row now renders as its own `<tbody>` carrying `data-index` and the virtualizer's `measureElement` ref, with `aria-hidden` spacer row groups reserving the un-rendered remainder. Because the measured group holds both the data row and its expanded detail row, the panel's real height lands in `getTotalSize()` — it can no longer resolve to the same offset as the row below it and paint on top of it.
 
 - `filterable + mobileView="card"`: filter inputs now render above the card list in `DataTableCards`. Previously lived inside `<thead>` which card mode never renders.
+
+**Changed (virtual rendering — visual):**
+
+- Virtual rows are no longer absolutely positioned with a forced `height: virtualRowHeight` and `display: flex` cells. They sit in normal table flow at their measured height, so column widths track `<thead>` again instead of being divided evenly. `virtualRowHeight` is now the pre-measurement ESTIMATE: it sets the initial scroll extent and how many rows render before the first measurement pass, not the final row height.
 
 **New props (closes #250 — all backward compatible):**
 
 - `onSelectionChange` second arg: `selectedIds: Set<string>` — complement of the `selectedIds` controlled prop. Existing single-arg handlers unaffected.
 - `filterableColumns?: string[]` — restrict filter inputs to specific column IDs without touching `ColumnDef`.
-- `rowClassName?: (row: TData) => string | undefined` — conditional classes on `<tr>` in table and card layouts.
-- `enableExport?: boolean` and `onExport?: (visibleRows: TData[]) => void` — control or override CSV export from `DataTableProps`.
+- `rowClassName?: (row: TData) => string | undefined` — conditional classes on the `<tr>` (table layout) or the `Card` (card layout).
+- `enableExport?: boolean` — was stranded on `DataTableToolbar` and never forwarded through `DataTableProps`. Now exposed. **The default is unchanged (`true`):** the Export button has rendered unconditionally since the toolbar existed, so defaulting it off — even only under server-side `pagination` — would silently delete a live affordance on upgrade. Opt out with `enableExport={false}`.
+- `onExport?: (visibleRows: TData[]) => void` — replaces the built-in CSV export. `DataTableToolbar.onExport` was widened from `() => void` to the same signature (a widening: a `() => void` handler still assigns), so the prop forwards straight through and the two components no longer carry two different `onExport` shapes.

--- a/packages/core/docs/components/ui/data-table-toolbar.md
+++ b/packages/core/docs/components/ui/data-table-toolbar.md
@@ -11,10 +11,11 @@
     onGlobalFilterChange: (value: string) => void
     density: 'compact' | 'standard' | 'comfortable'
     onDensityChange: (density: Density) => void
-    enableExport: boolean
+    enableExport: boolean — show the Export CSV button (default true)
+    onExport: (visibleRows: TData[]) => void — replaces the built-in CSV logic; receives the currently visible filtered rows
 
 ## Defaults
-    none
+    enableExport=true, globalFilter=false
 
 ## Example
 ```jsx
@@ -44,11 +45,11 @@ import { DataTableToolbar } from '@devalok/shilp-sutra/ui/data-table-toolbar'
 - Prefer DataTable's `toolbar={true}` prop over rendering this directly
 
 ## Changes
+### v0.57.0
+- **Added** `onExport?: (visibleRows: TData[]) => void` — when provided, replaces the built-in CSV logic. Same signature as `DataTable`'s `onExport`, so the prop forwards straight through.
+
 ### v0.5.0
 - **Changed** (BREAKING) Removed from `@devalok/shilp-sutra/ui` barrel export — must use `@devalok/shilp-sutra/ui/data-table-toolbar`
 
 ### v0.1.0
 - **Added** Initial release
-
-### v0.57.0
-- **Added** `onExport?: () => void` — when provided, replaces the built-in CSV logic.

--- a/packages/core/docs/components/ui/data-table.md
+++ b/packages/core/docs/components/ui/data-table.md
@@ -5,20 +5,23 @@
 - Category: ui
 
 ## Props
-    columns: ColumnDef<TData>[] (TanStack column definitions)
+    columns: ColumnDef<TData, TValue>[] (TanStack column definitions)
     data: TData[]
+    className: string — class name for the wrapper div
     sortable: boolean — enable column sorting
-    onSort: (key: string, dir: 'asc' | 'desc' | false) => void — server-side sort callback (enables manualSorting)
+    onSort: (key: string, direction: 'asc' | 'desc' | false) => void — server-side sort callback (enables manualSorting)
     filterable: boolean — enable per-column filters
+    filterableColumns: string[] — restrict filter inputs to these column IDs (only with filterable; omit for all filterable columns)
     globalFilter: boolean — enable global search
     paginated: boolean — enable client-side pagination
     pagination: { page: number, pageSize: number, total: number, onPageChange: (page: number) => void } — server-side pagination (1-based page)
     pageSize: number (default 10)
+    pageSizeOptions: number[] — page-size selector options (default [10, 20, 50, 100])
     selectable: boolean — enable row selection with checkboxes
     selectedIds: Set<string> — controlled selection state
     selectableFilter: (row: TData) => boolean — disable selection on certain rows
     getRowId: (row: TData) => string — custom row ID accessor
-    onSelectionChange: (selectedRows: TData[]) => void
+    onSelectionChange: (selectedRows: TData[], selectedIds: Set<string>) => void — does NOT fire on mount
     expandable: boolean — enable row expansion
     renderExpanded: (row: TData) => ReactNode — expanded row content
     singleExpand: boolean — only one row expanded at a time
@@ -27,15 +30,22 @@
     noResultsText: string (default "No results.")
     stickyHeader: boolean — sticky table header
     onRowClick: (row: TData) => void — row click handler (excludes interactive element clicks)
+    rowClassName: (row: TData) => string | undefined — conditional per-row class (the <tr> in table mode, the Card in card mode)
     bulkActions: BulkAction<TData>[] — floating action bar on selection — { label, onClick, color?: 'default'|'error', disabled? }
     toolbar: boolean — show DataTableToolbar (column visibility, density, CSV export)
+    enableExport: boolean — show the toolbar's Export CSV button (default true)
+    onExport: (visibleRows: TData[]) => void — replace the built-in CSV export
     editable: boolean — enable double-click cell editing
+    onCellEdit: (rowIndex: number, columnId: string, value: unknown) => void — fired on cell edit commit
     virtualRows: boolean — virtualize rows for large datasets
+    virtualRowHeight: number — ESTIMATED row height in px (default 48); real heights are measured after mount
+    maxHeight: number — max height of the virtual scroll container in px (default 600)
+    mobileView: 'card' | 'table' — stacked cards below the sm breakpoint (default 'table')
     columnPinning: { left?: string[], right?: string[] }
     density: 'compact' | 'standard' | 'comfortable'
 
 ## Defaults
-    pageSize=10, noResultsText="No results."
+    pageSize=10, noResultsText="No results.", enableExport=true, mobileView='table', virtualRowHeight=48, maxHeight=600, density='standard'
 
 ## Example
 ```jsx
@@ -75,7 +85,11 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 **Row click model:**
 - `onRowClick` fires on row-level click BUT excludes clicks on checkboxes, buttons, links, and inputs automatically. No manual `stopPropagation` needed for standard interactive elements.
 
-**Virtualization:** `virtualRows={true}` enables row virtualization via `@tanstack/react-virtual`. Turn it on for 1000+ row datasets; the scroll container must have a bounded height.
+**Virtualization:** `virtualRows={true}` enables row virtualization via `@tanstack/react-virtual`. Turn it on for 1000+ row datasets; the scroll container must have a bounded height. Rows stay in normal table flow (each windowed row is its own `<tbody>` measured by the virtualizer, with spacer row groups reserving the un-rendered remainder), so column widths keep tracking `<thead>` and `virtualRowHeight` is only the pre-measurement estimate.
+
+**Virtualization + expansion:** `virtualRows` and `expandable` compose. Because each row group is measured, an expanded detail panel of any height contributes to the total scroll size and pushes the rows below it down. The reveal is instant in virtual mode (no height animation) — an animating height would fire a resize on every frame.
+
+**Toolbar export:** the Export button renders whenever `toolbar` is on. The built-in CSV export walks `getFilteredRowModel()`, which under server-side `pagination` is only the current page — pass `onExport` to fetch the full set yourself, or `enableExport={false}` to drop the button.
 
 **Density integration:** density is forwarded to `Table`'s `density` prop, which sets `--table-py` (compact 4 / standard 8 / comfortable 12px → rows ≈ 29 / 37 / 45px; header tracks it). DataTableToolbar's density switcher updates this at runtime; the prop sets the initial state only.
 
@@ -88,8 +102,23 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 - onRowClick does NOT fire when clicking checkboxes, buttons, links, or inputs
 - Use density="compact" for Karm-style h-9 rows
 - `virtualRows={true}` requires a bounded scroll container — unbounded height silently disables virtualization
+- `onSelectionChange` does NOT fire on mount, and does NOT fire when selection is synced from the `selectedIds` prop — only on genuine selection changes
+- `filterableColumns` is ignored unless `filterable` is also set
+- `rowClassName` returns are passed through `cn()` verbatim — a class that does not exist in the token set silently does nothing (use the real scale steps, e.g. `bg-error-3`, not invented names like `bg-error-subtle`)
 
 ## Changes
+### v0.57.0
+- **Fixed** `onSelectionChange` no longer fires on mount with `[]` — first-render guard added. Root cause of the cascade reported in #213.
+- **Fixed** `virtualRows + expandable` was a silent no-op — the expanded row was only rendered on the non-virtual path. Virtual rows now render one measured `<tbody>` per windowed row (with spacer row groups for the remainder) so the expanded panel renders, contributes its real height to `getTotalSize()`, and cannot overlap the row below.
+- **Changed** Virtual rows are no longer absolutely positioned with a forced `virtualRowHeight`; they sit in normal table flow at their measured height, so column widths track `<thead>`. `virtualRowHeight` is now the pre-measurement ESTIMATE.
+- **Fixed** `enableExport` was stranded on `DataTableToolbar` and never wired through `DataTableProps`. Now exposed with an `onExport` override. Default is unchanged (`true`) — the Export button still renders whenever `toolbar` is on.
+- **Fixed** `filterable + mobileView="card"` rendered no filter inputs — they now render above the card list in `DataTableCards` (card mode renders no `<thead>` for them to live in).
+- **Added** `onSelectionChange` receives `selectedIds: Set<string>` as second argument — complement of the `selectedIds` prop.
+- **Added** `filterableColumns?: string[]` — restrict filter inputs to specific column IDs.
+- **Added** `rowClassName?: (row: TData) => string | undefined` — conditional row classes in table and card layouts.
+- **Added** `enableExport?: boolean` — hide the toolbar's Export CSV button from `DataTableProps`.
+- **Added** `onExport?: (visibleRows: TData[]) => void` — override built-in CSV with a custom export handler.
+
 ### v0.45.0
 - **Fixed** Expander a11y per the expando-row spec: `aria-expanded` on the toggle button, visually-hidden "Expand rows" column header; chevron rotation uses `duration-fast-02 ease-productive-standard`.
 - **Added** Expanded-row content animates open/closed (height + opacity via framer, `springs.smooth`), self-guarded with `useReducedMotion` — instant swap for reduced-motion users. Virtualized tables keep the instant reveal (a height animation would fight the virtualizer's measurements).
@@ -124,14 +153,3 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 
 ### v0.1.0
 - **Added** Initial release
-
-### v0.57.0
-- **Fixed** `onSelectionChange` no longer fires on mount with `[]` — first-render guard added. Root cause of the cascade reported in #213.
-- **Fixed** `virtualRows + expandable` was a silent no-op — `DataTableExpandedRow` now renders in the virtual path, offset below the data row. DEV `console.warn` added for fixed-height limitation.
-- **Fixed** `enableExport` was stranded on `DataTableToolbar` and never wired through `DataTableProps`. Now exposed with `onExport` override.
-- **Fixed** `filterable + mobileView="card"` rendered no filter inputs — filter inputs now render above the card list in `DataTableCards`.
-- **Added** `onSelectionChange` receives `selectedIds: Set<string>` as second argument — complement of `selectedIds` prop.
-- **Added** `filterableColumns?: string[]` — restrict filter inputs to specific column IDs.
-- **Added** `rowClassName?: (row: TData) => string | undefined` — conditional row classes in both table and card layouts.
-- **Added** `enableExport?: boolean` — control CSV export visibility from `DataTableProps` (defaults to `false` when server pagination is active).
-- **Added** `onExport?: (visibleRows: TData[]) => void` — override built-in CSV with custom export handler.

--- a/packages/core/src/ui/__tests__/data-table-integration.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-integration.test.tsx
@@ -1,7 +1,7 @@
 import { type ColumnDef } from '@tanstack/react-table'
 import { render, screen, waitFor,within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach,beforeEach, describe, expect, it, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 
 import { DataTable } from '../data-table'
@@ -935,12 +935,31 @@ describe('DataTable — enableExport + onExport', () => {
     expect(screen.queryByLabelText('Export table as CSV')).not.toBeInTheDocument()
   })
 
-  it('Export button hidden by default when server pagination is active', () => {
+  it('Export button still shows by default, including with server pagination', () => {
+    // The button has rendered unconditionally since the toolbar existed. Hiding
+    // it by default — even only under server pagination — would silently delete
+    // a live affordance from every consumer on upgrade.
+    const { rerender } = render(<DataTable columns={columns} data={data} toolbar />)
+    expect(screen.getByLabelText('Export table as CSV')).toBeInTheDocument()
+
+    rerender(
+      <DataTable
+        columns={columns}
+        data={data}
+        toolbar
+        pagination={{ page: 1, pageSize: 2, total: 10, onPageChange: vi.fn() }}
+      />,
+    )
+    expect(screen.getByLabelText('Export table as CSV')).toBeInTheDocument()
+  })
+
+  it('Export button hidden with server pagination when opted out explicitly', () => {
     render(
       <DataTable
         columns={columns}
         data={data}
         toolbar
+        enableExport={false}
         pagination={{ page: 1, pageSize: 2, total: 10, onPageChange: vi.fn() }}
       />,
     )
@@ -998,19 +1017,339 @@ describe('DataTable — rowClassName', () => {
       <DataTable
         columns={columns}
         data={data}
-        rowClassName={(row) => row.role === 'Engineer' ? 'bg-error-subtle' : undefined}
+        rowClassName={(row) => row.role === 'Engineer' ? 'bg-error-3' : undefined}
       />,
     )
     const rows = screen.getAllByRole('row')
     // row[0]=header, row[1]=Alice(Engineer), row[2]=Bob(Designer), row[4]=Dave(Engineer)
-    expect(rows[1]).toHaveClass('bg-error-subtle')
-    expect(rows[2]).not.toHaveClass('bg-error-subtle')
-    expect(rows[4]).toHaveClass('bg-error-subtle')
+    expect(rows[1]).toHaveClass('bg-error-3')
+    expect(rows[2]).not.toHaveClass('bg-error-3')
+    expect(rows[4]).toHaveClass('bg-error-3')
   })
 
   it('does not add class when rowClassName returns undefined', () => {
     render(<DataTable columns={columns} data={data} rowClassName={() => undefined} />)
     const rows = screen.getAllByRole('row')
     expect(rows[1].className).not.toContain('undefined')
+  })
+})
+
+// ============================================================
+// Feature: mobileView="card" (#212)
+// ============================================================
+
+/**
+ * Force the below-sm media query DataTable reads for card mode. The global
+ * test-setup mock answers `matches: false` to everything, which is desktop —
+ * card mode would never activate. Follows the `use-mobile.test.ts` pattern:
+ * a hand-rolled MediaQueryList stub installed on `window.matchMedia`.
+ */
+function mockBelowSmViewport(matches: boolean) {
+  const original = window.matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes('639px') ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  })
+  return () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: original,
+    })
+  }
+}
+
+describe('DataTable — mobileView="card"', () => {
+  it('renders cards instead of a table below sm', () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      render(<DataTable columns={columns} data={data} mobileView="card" />)
+      expect(screen.queryByRole('table')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('listitem')).toHaveLength(4)
+    } finally {
+      restore()
+    }
+  })
+
+  it('keeps the table above sm even with mobileView="card"', () => {
+    const restore = mockBelowSmViewport(false)
+    try {
+      render(<DataTable columns={columns} data={data} mobileView="card" />)
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument()
+    } finally {
+      restore()
+    }
+  })
+
+  it('renders filter inputs ABOVE the card list when filterable', () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      const { container } = render(
+        <DataTable columns={columns} data={data} mobileView="card" filterable />,
+      )
+      const nameFilter = screen.getByPlaceholderText('Filter Name...')
+      expect(nameFilter).toBeInTheDocument()
+      expect(screen.getByPlaceholderText('Filter Email...')).toBeInTheDocument()
+
+      // Document order: the filter input precedes the first card.
+      const firstCard = screen.getAllByRole('listitem')[0]
+      expect(
+        nameFilter.compareDocumentPosition(firstCard) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy()
+      // ...and it is not inside a card either.
+      expect(container.querySelector('[role="listitem"] input')).toBeNull()
+    } finally {
+      restore()
+    }
+  })
+
+  it('card filter inputs actually filter the card list', async () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      render(<DataTable columns={columns} data={data} mobileView="card" filterable />)
+      const user = userEvent.setup()
+      await user.type(screen.getByPlaceholderText('Filter Name...'), 'Alice')
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+      expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+      expect(screen.getAllByRole('listitem')).toHaveLength(1)
+    } finally {
+      restore()
+    }
+  })
+
+  it('respects filterableColumns in card mode', () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          mobileView="card"
+          filterable
+          filterableColumns={['name']}
+        />,
+      )
+      expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+      expect(screen.queryByPlaceholderText('Filter Email...')).not.toBeInTheDocument()
+    } finally {
+      restore()
+    }
+  })
+
+  it('applies rowClassName to cards', () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      render(
+        <DataTable
+          columns={columns}
+          data={data}
+          mobileView="card"
+          rowClassName={(row) => (row.role === 'Engineer' ? 'bg-error-3' : undefined)}
+        />,
+      )
+      const cards = screen.getAllByRole('listitem')
+      // data order: Alice(Engineer), Bob(Designer), Carol(Manager), Dave(Engineer)
+      expect(cards[0]).toHaveClass('bg-error-3')
+      expect(cards[1]).not.toHaveClass('bg-error-3')
+      expect(cards[3]).toHaveClass('bg-error-3')
+    } finally {
+      restore()
+    }
+  })
+
+  it('has no a11y violations in card mode with filters', async () => {
+    const restore = mockBelowSmViewport(true)
+    try {
+      const { container } = render(
+        <DataTable columns={columns} data={data} mobileView="card" filterable selectable />,
+      )
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    } finally {
+      restore()
+    }
+  })
+})
+
+// ============================================================
+// Bug fix: virtualRows + expandable (#249 bug 2)
+// ============================================================
+
+/**
+ * `@tanstack/react-virtual` reads `offsetHeight` (never getBoundingClientRect) for
+ * both the scroll viewport and each measured item, and bails out entirely when the
+ * viewport measures 0 — which is every element in jsdom. Without this stub a
+ * virtualized table renders a `<thead>` and nothing else, so no virtual assertion
+ * is possible at all.
+ *
+ * `TBODY` is the measured row group; the `overflow-y: auto` div is DataTable's
+ * scroll container.
+ */
+function mockVirtualLayout({ viewport = 500, rowGroup = 48 } = {}) {
+  const original = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'offsetHeight',
+  )
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.tagName === 'TBODY') return rowGroup
+      if (this.style?.overflowY === 'auto') return viewport
+      return 0
+    },
+  })
+  return () => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original)
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight
+    }
+  }
+}
+
+const manyRows: Person[] = Array.from({ length: 100 }, (_, i) => ({
+  id: `row-${i}`,
+  name: `Person ${i}`,
+  email: `person${i}@example.com`,
+  role: i % 2 === 0 ? 'Engineer' : 'Designer',
+  age: 20 + (i % 40),
+}))
+
+describe('DataTable — virtualRows', () => {
+  let restoreLayout: () => void
+
+  beforeEach(() => {
+    restoreLayout = mockVirtualLayout()
+  })
+  afterEach(() => {
+    restoreLayout()
+  })
+
+  it('renders rows in virtual mode', () => {
+    render(<DataTable columns={columns} data={data} virtualRows maxHeight={400} />)
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.getByText('Dave Brown')).toBeInTheDocument()
+  })
+
+  it('windows a large dataset and pads the un-rendered remainder', () => {
+    const { container } = render(
+      <DataTable columns={columns} data={manyRows} virtualRows maxHeight={500} />,
+    )
+    const groups = container.querySelectorAll('tbody[data-index]')
+    // Far fewer than 100 rows in the DOM — that is the whole point.
+    expect(groups.length).toBeGreaterThan(0)
+    expect(groups.length).toBeLessThan(manyRows.length)
+
+    // The un-rendered tail is reserved by an aria-hidden spacer row group so the
+    // scroll extent stays honest.
+    const spacer = container.querySelector('tbody[aria-hidden="true"]')
+    expect(spacer).not.toBeNull()
+    const spacerCell = spacer!.querySelector('td')!
+    expect(parseFloat(spacerCell.style.height)).toBeGreaterThan(0)
+    expect(spacerCell.getAttribute('colspan')).toBe(String(columns.length))
+  })
+
+  it('renders expanded content in the DOM when a virtual row is expanded', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        virtualRows
+        maxHeight={400}
+        expandable
+        renderExpanded={(row) => <div>Detail for {row.name}</div>}
+      />,
+    )
+    const user = userEvent.setup()
+    expect(screen.queryByText('Detail for Alice Smith')).not.toBeInTheDocument()
+
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    expect(screen.getByText('Detail for Alice Smith')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Collapse row'))
+    expect(screen.queryByText('Detail for Alice Smith')).not.toBeInTheDocument()
+  })
+
+  it('measures each row group so expanded height is accounted for (no overlap)', async () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={data}
+        virtualRows
+        maxHeight={400}
+        expandable
+        renderExpanded={(row) => <div>Detail for {row.name}</div>}
+      />,
+    )
+    // One <tbody> per windowed row, each tagged with the index the virtualizer
+    // measures it under. This is what makes getTotalSize() include the expanded
+    // panel — without it the panel and the next row share an offset.
+    const groups = container.querySelectorAll('tbody[data-index]')
+    expect(groups.length).toBe(4)
+    expect(Array.from(groups).map((g) => g.getAttribute('data-index'))).toEqual([
+      '0',
+      '1',
+      '2',
+      '3',
+    ])
+
+    // No absolute positioning: rows stay in table flow, so an expanded panel
+    // cannot paint on top of the row after it.
+    const user = userEvent.setup()
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    const expandedRow = screen.getByText('Detail for Alice Smith').closest('tr')!
+    expect(expandedRow.style.position).toBe('')
+    expect(expandedRow.style.transform).toBe('')
+    // The expanded row is a sibling INSIDE the measured group, not a stray row.
+    expect(expandedRow.parentElement).toBe(groups[0])
+    expect(groups[0].querySelectorAll('tr')).toHaveLength(2)
+  })
+
+  it('does not warn on virtualRows + expandable', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        virtualRows
+        maxHeight={400}
+        expandable
+        renderExpanded={(row) => <div>Detail for {row.name}</div>}
+      />,
+    )
+    const dataTableWarnings = warn.mock.calls.filter((c) =>
+      String(c[0]).includes('[DataTable]'),
+    )
+    expect(dataTableWarnings).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('has no a11y violations in virtual mode with an expanded row', async () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={data}
+        virtualRows
+        maxHeight={400}
+        expandable
+        renderExpanded={(row) => <div>Detail for {row.name}</div>}
+      />,
+    )
+    const user = userEvent.setup()
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 })

--- a/packages/core/src/ui/data-table-body.tsx
+++ b/packages/core/src/ui/data-table-body.tsx
@@ -1,6 +1,4 @@
 'use client'
-// Bundlers (Vite, Next.js, webpack) define process.env.NODE_ENV; guard for raw ESM.
-declare const process: { env: { NODE_ENV?: string } } | undefined
 
 import { flexRender,type Row } from '@tanstack/react-table'
 import { type VirtualItem } from '@tanstack/react-virtual'
@@ -77,13 +75,7 @@ function CellEditInput({
 // ── DataRow ─────────────────────────────────────────────────────
 
 /** Render a single data row (shared between virtual and non-virtual paths) */
-function DataTableRow<TData>({
-  row,
-  style,
-}: {
-  row: Row<TData>
-  style?: React.CSSProperties
-}) {
+function DataTableRow<TData>({ row }: { row: Row<TData> }) {
   const {
     table,
     columnPinningState,
@@ -91,7 +83,6 @@ function DataTableRow<TData>({
     editingCell,
     setEditingCell,
     onCellEdit,
-    virtualRows,
     onRowClick,
     rowClassName,
   } = useDataTableContext<TData>()
@@ -111,9 +102,7 @@ function DataTableRow<TData>({
   return (
     <TableRow
       data-state={row.getIsSelected() && 'selected'}
-      style={style}
       className={cn(
-        virtualRows ? 'absolute w-full flex' : undefined,
         onRowClick && 'cursor-pointer',
         rowClassName?.(row.original),
       )}
@@ -130,7 +119,6 @@ function DataTableRow<TData>({
             key={cell.id}
             className={cn(
               pinned.className,
-              virtualRows && 'flex-1',
               getColumnMetaClasses(
                 cell.column.columnDef.meta as Record<string, unknown>,
               ),
@@ -167,13 +155,7 @@ function DataTableRow<TData>({
 // ── ExpandedRow ─────────────────────────────────────────────────
 
 /** Render expanded content row below the data row */
-function DataTableExpandedRow<TData>({
-  row,
-  style,
-}: {
-  row: Row<TData>
-  style?: React.CSSProperties
-}) {
+function DataTableExpandedRow<TData>({ row }: { row: Row<TData> }) {
   const { allColumns, expandable, renderExpanded, virtualRows } =
     useDataTableContext<TData>()
   // Self-guarded (StatFlash pattern) — reveal collapses to an instant swap
@@ -184,16 +166,14 @@ function DataTableExpandedRow<TData>({
 
   const expanded = row.getIsExpanded()
 
-  // Virtual rows are absolutely positioned with measured heights — a height
-  // animation would fight the virtualizer, so the reveal is instant there.
+  // In virtual mode the reveal is instant: the row group's height is watched by
+  // the virtualizer's ResizeObserver, and an animating height would fire a
+  // resize on every frame of the spring.
   if (virtualRows) {
     if (!expanded) return null
     return (
-      <TableRow style={style} className="absolute w-full flex">
-        <TableCell
-          colSpan={allColumns.length}
-          className="bg-surface-base p-ds-05 flex-1"
-        >
+      <TableRow>
+        <TableCell colSpan={allColumns.length} className="bg-surface-base p-ds-05">
           {renderExpanded(row.original)}
         </TableCell>
       </TableRow>
@@ -203,7 +183,7 @@ function DataTableExpandedRow<TData>({
   return (
     <AnimatePresence initial={false}>
       {expanded && (
-        <TableRow style={style}>
+        <TableRow>
           <TableCell
             colSpan={allColumns.length}
             // A recess, not a raised layer — surface-raised would vanish on a
@@ -283,6 +263,7 @@ export function DataTableBody<TData>({
   emptyState,
   virtualItems,
   totalVirtualSize,
+  measureRow,
 }: {
   loading?: boolean
   skeletonRowCount: number
@@ -290,8 +271,10 @@ export function DataTableBody<TData>({
   emptyState?: React.ReactNode
   virtualItems?: VirtualItem[]
   totalVirtualSize?: number
+  /** `virtualizer.measureElement` — attached to each virtual row group */
+  measureRow?: (node: HTMLTableSectionElement | null) => void
 }) {
-  const { table, allColumns, virtualRows, expandable } = useDataTableContext<TData>()
+  const { table, allColumns, virtualRows } = useDataTableContext<TData>()
   const rows = table.getRowModel().rows
 
   // Loading state: show skeleton rows
@@ -318,58 +301,48 @@ export function DataTableBody<TData>({
   }
 
   if (virtualRows && virtualItems) {
-    // DEV warning: virtualRows + expandable is supported but expanded rows use a
-    // fixed height equal to virtualRowHeight — the virtualizer cannot measure
-    // dynamic content. Pass a virtualRowHeight large enough to contain your
-    // renderExpanded content, or switch to non-virtual mode for expandable tables.
-    if (typeof process !== "undefined" && process?.env.NODE_ENV !== "production" && expandable) {
-      console.warn(
-        '[DataTable] virtualRows + expandable: expanded row content renders at a ' +
-        'fixed height (virtualRowHeight prop, default 48px). If your expanded content ' +
-        'is taller, increase virtualRowHeight to match or use non-virtual mode.',
-      )
-    }
+    // Each windowed row gets its OWN <tbody> (valid HTML — a table may hold any
+    // number of row groups) carrying `data-index` + the virtualizer's
+    // `measureElement` ref. That group is what gets measured, so a row's height
+    // INCLUDES its expanded detail row and `getTotalSize()` stays truthful.
+    //
+    // Rows stay in normal table flow; the window is positioned by spacer row
+    // groups above and below instead of absolute offsets. Two consequences worth
+    // knowing: an expanded panel can never paint on top of the next row (flow
+    // layout forbids it), and column widths keep tracking <thead> because the
+    // cells are still real table cells.
+    const firstItem = virtualItems[0]
+    const lastItem = virtualItems[virtualItems.length - 1]
+    const padTop = firstItem ? firstItem.start : 0
+    const padBottom = lastItem ? Math.max(0, (totalVirtualSize ?? 0) - lastItem.end) : 0
+    const spacerCell = (height: number) => (
+      <tbody aria-hidden="true">
+        <tr>
+          <td colSpan={allColumns.length} style={{ height, padding: 0, border: 0 }} />
+        </tr>
+      </tbody>
+    )
+
     return (
-      <TableBody
-        style={{
-          height: `${totalVirtualSize}px`,
-          position: 'relative',
-        }}
-      >
+      <>
+        {padTop > 0 && spacerCell(padTop)}
         {virtualItems.map((virtualRow) => {
           const row = rows[virtualRow.index]
+          const isLastRow = virtualRow.index === rows.length - 1
           return (
-            <React.Fragment key={row.id}>
-              <DataTableRow
-                row={row}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: `${virtualRow.size}px`,
-                  transform: `translateY(${virtualRow.start}px)`,
-                }}
-              />
-              {/* Expanded content renders immediately after the data row.
-                  It is absolutely positioned offset by the row's own height so it
-                  sits below rather than on top of the row. The virtualizer total
-                  size does not account for this extra height — keep renderExpanded
-                  content short or use non-virtual mode for tall expansions. */}
-              <DataTableExpandedRow
-                row={row}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  transform: `translateY(calc(${virtualRow.start}px + ${virtualRow.size}px))`,
-                }}
-              />
-            </React.Fragment>
+            <tbody
+              key={row.id}
+              ref={measureRow}
+              data-index={virtualRow.index}
+              className={cn(isLastRow && '[&_tr:last-child]:border-0')}
+            >
+              <DataTableRow row={row} />
+              <DataTableExpandedRow row={row} />
+            </tbody>
           )
         })}
-      </TableBody>
+        {padBottom > 0 && spacerCell(padBottom)}
+      </>
     )
   }
 

--- a/packages/core/src/ui/data-table-toolbar.tsx
+++ b/packages/core/src/ui/data-table-toolbar.tsx
@@ -42,13 +42,17 @@ export interface DataTableToolbarProps<TData> extends Omit<React.HTMLAttributes<
   onGlobalFilterChange: (value: string) => void
   density: Density
   onDensityChange: (density: Density) => void
+  /** Show the Export CSV button. @default true */
   enableExport?: boolean
   /**
    * Override the default CSV export. When provided, clicking Export calls this
    * instead of the built-in client-side CSV logic. Receives the currently visible
    * filtered rows so you can trigger a server fetch or apply custom formatting.
+   *
+   * Same signature as `DataTable`'s `onExport`, so the prop can be forwarded
+   * straight through.
    */
-  onExport?: () => void
+  onExport?: (visibleRows: TData[]) => void
 }
 
 const toolbarIconClass = 'text-surface-fg-subtle'
@@ -185,7 +189,13 @@ export function DataTableToolbar<TData>({
             variant="outline"
             color="neutral"
             size="sm"
-            onClick={() => (onExport ? onExport() : exportToCsv(table))}
+            onClick={() =>
+              onExport
+                ? onExport(
+                    table.getFilteredRowModel().rows.map((r) => r.original),
+                  )
+                : exportToCsv(table)
+            }
             aria-label="Export table as CSV"
           >
             <Icon icon={IconDownload} size="sm" className={toolbarIconClass} />

--- a/packages/core/src/ui/data-table.stories.tsx
+++ b/packages/core/src/ui/data-table.stories.tsx
@@ -370,6 +370,55 @@ export const VirtualizedLargeDataset: Story = {
   ),
 }
 
+/**
+ * `virtualRows` + `expandable`. Each windowed row is its own measured row group,
+ * so an expanded panel of any height pushes the rows below it instead of painting
+ * over them — `virtualRowHeight` is only the pre-measurement estimate.
+ */
+export const VirtualizedExpandable: Story = {
+  render: () => (
+    <div className="space-y-ds-04">
+      <p className="text-ds-sm text-surface-fg-muted">
+        10,000 virtualized rows with expandable detail panels. Expand a row, then
+        scroll — the rows below shift down by the panel&apos;s real height.
+      </p>
+      <DataTable
+        columns={plainColumns}
+        data={hugeData}
+        virtualRows
+        virtualRowHeight={48}
+        maxHeight={600}
+        expandable
+        renderExpanded={(row) => (
+          <div className="space-y-ds-02 text-ds-sm">
+            <p className="font-semibold text-surface-fg">{row.title}</p>
+            <p className="text-surface-fg-muted">
+              Deliberately tall content so the height difference is visible: this
+              panel is several lines of prose plus a metadata list, none of which
+              would fit inside a 48px row.
+            </p>
+            <dl className="grid grid-cols-[auto_1fr] gap-x-ds-04 gap-y-ds-01">
+              <dt className="font-medium text-surface-fg-muted">ID</dt>
+              <dd className="text-surface-fg">{row.id}</dd>
+              <dt className="font-medium text-surface-fg-muted">Status</dt>
+              <dd className="text-surface-fg">{row.status}</dd>
+              <dt className="font-medium text-surface-fg-muted">Priority</dt>
+              <dd className="text-surface-fg">{row.priority}</dd>
+            </dl>
+          </div>
+        )}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getAllByLabelText('Expand row')[0])
+    await waitFor(() =>
+      expect(canvas.getByText('TASK-00001', { selector: 'dd' })).toBeVisible(),
+    )
+  },
+}
+
 // --- Full Featured ---
 
 function FullFeaturedDemo() {
@@ -738,6 +787,141 @@ export const OnRowClick: Story = {
         data={filterData}
         getRowId={(row) => row.id}
         onRowClick={(row) => alert(`Clicked: ${row.title}`)}
+      />
+    </div>
+  ),
+}
+
+// --- Per-column filter control ---
+
+/**
+ * `filterableColumns` narrows which columns get a filter input without touching
+ * `enableColumnFilter` on every `ColumnDef`.
+ */
+export const FilterableColumns: Story = {
+  render: () => (
+    <div className="space-y-ds-04">
+      <p className="text-ds-sm text-surface-fg-muted">
+        Only Title and Status get filter inputs — ID and Priority are filterable in
+        the model but have no input.
+      </p>
+      <DataTable
+        columns={columns}
+        data={filterData}
+        filterable
+        filterableColumns={['title', 'status']}
+      />
+    </div>
+  ),
+}
+
+// --- Conditional row styling ---
+
+/**
+ * `rowClassName` returns a class per row. Use the real error/warning scale steps
+ * (`bg-error-3`, `bg-warning-3`) — a step-3 tint stays legible under the row hover
+ * and selected states.
+ */
+export const ConditionalRowStyling: Story = {
+  render: () => (
+    <div className="space-y-ds-04">
+      <p className="text-ds-sm text-surface-fg-muted">
+        High-priority rows are tinted with <code>bg-error-3</code>, in-progress rows
+        with <code>bg-warning-3</code>.
+      </p>
+      <DataTable
+        columns={columns}
+        data={filterData}
+        rowClassName={(row) => {
+          if (row.priority === 'high') return 'bg-error-3'
+          if (row.status === 'in-progress') return 'bg-warning-3'
+          return undefined
+        }}
+      />
+    </div>
+  ),
+}
+
+// --- Export control ---
+
+/**
+ * The toolbar's Export button renders whenever `toolbar` is on. `enableExport={false}`
+ * hides it; `onExport` replaces the built-in CSV with your own handler and hands you
+ * the currently visible (filtered) rows.
+ */
+function ExportControlDemo() {
+  const [lastExport, setLastExport] = useState<string>('')
+
+  return (
+    <div className="space-y-ds-05">
+      <div className="space-y-ds-03">
+        <p className="text-ds-sm text-surface-fg-muted">
+          Custom <code>onExport</code> — receives the visible filtered rows instead
+          of downloading a CSV. Filter first, then export.
+        </p>
+        {lastExport && (
+          <p className="text-ds-sm font-medium text-accent-11">{lastExport}</p>
+        )}
+        <DataTable
+          columns={columns}
+          data={filterData}
+          toolbar
+          globalFilter
+          onExport={(rows) =>
+            setLastExport(
+              `Exported ${rows.length} row(s): ${rows.map((r) => r.id).join(', ')}`,
+            )
+          }
+        />
+      </div>
+
+      <div className="space-y-ds-03">
+        <p className="text-ds-sm text-surface-fg-muted">
+          <code>enableExport={'{false}'}</code> — no Export button. Worth doing with
+          server-side pagination, where the built-in CSV can only see one page.
+        </p>
+        <DataTable columns={columns} data={filterData} toolbar enableExport={false} />
+      </div>
+    </div>
+  )
+}
+
+export const ExportControl: Story = {
+  render: () => <ExportControlDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Only the first table has an Export button.
+    const exportButtons = canvas.getAllByLabelText('Export table as CSV')
+    expect(exportButtons).toHaveLength(1)
+    await userEvent.click(exportButtons[0])
+    await waitFor(() => expect(canvas.getByText(/Exported 10 row\(s\)/)).toBeVisible())
+  },
+}
+
+// --- Mobile card view ---
+
+/**
+ * `mobileView="card"` swaps the table for stacked cards below the `sm` breakpoint.
+ * With `filterable`, the per-column filter inputs move above the card list — card
+ * mode renders no `<thead>` for them to live in.
+ */
+export const MobileCardView: Story = {
+  globals: { viewport: 'mobile' },
+  render: () => (
+    <div className="space-y-ds-04">
+      <p className="text-ds-sm text-surface-fg-muted">
+        Below <code>sm</code> (640px) rows render as cards. Filter inputs sit above
+        the list.
+      </p>
+      <DataTable
+        columns={columns}
+        data={filterData}
+        mobileView="card"
+        filterable
+        filterableColumns={['title', 'status']}
+        selectable
+        getRowId={(row) => row.id}
+        rowClassName={(row) => (row.priority === 'high' ? 'bg-error-3' : undefined)}
       />
     </div>
   ),

--- a/packages/core/src/ui/data-table.tsx
+++ b/packages/core/src/ui/data-table.tsx
@@ -161,7 +161,11 @@ export interface DataTableProps<TData, TValue> {
   // --- Virtualization ---
   /** Enable row virtualization for large datasets */
   virtualRows?: boolean
-  /** Height of each virtual row in pixels (default 48) */
+  /**
+   * Estimated height of each virtual row in pixels (default 48). Real heights are
+   * measured after mount, so this only has to be close — it decides the initial
+   * scroll extent and how many rows render before the first measurement pass.
+   */
   virtualRowHeight?: number
   /** Maximum height of the scrollable container in pixels (default 600) */
   maxHeight?: number
@@ -217,16 +221,17 @@ export interface DataTableProps<TData, TValue> {
 
   // --- Toolbar export ---
   /**
-   * Whether to show the Export CSV button in the toolbar. Defaults to `true` for
-   * client-side tables and `false` when `pagination` (server-side) is active —
-   * because the toolbar can only export the current page's rows in that case.
-   * Pass `true` to force-show it, or use `onExport` to supply all rows yourself.
+   * Whether to show the Export CSV button in the toolbar. Defaults to `true`
+   * (the button has always rendered whenever `toolbar` is on). Pass `false` to
+   * hide it — worth doing with server-side `pagination`, where the built-in CSV
+   * export can only see the current page's rows; `onExport` is the other answer
+   * there, since it lets you fetch the full set yourself.
    */
   enableExport?: boolean
   /**
    * Override the default client-side CSV export. Receives the currently visible
-   * rows so you can trigger a server-side full export or apply custom formatting.
-   * When provided, the built-in CSV logic is skipped entirely.
+   * (filtered) rows so you can trigger a server-side full export or apply custom
+   * formatting. When provided, the built-in CSV logic is skipped entirely.
    */
   onExport?: (visibleRows: TData[]) => void
 
@@ -245,11 +250,14 @@ export interface DataTableProps<TData, TValue> {
 
   // --- Conditional row styling ---
   /**
-   * Return a className string for a given row. Applied to the `<tr>` element
-   * in both table and card (`mobileView="card"`) layouts.
+   * Return a className string for a given row — applied to the `<tr>` in table
+   * layout and to the `Card` in `mobileView="card"` layout.
+   *
+   * The return value is passed through `cn()` verbatim, so an invented class
+   * silently does nothing. Use real token steps (`bg-error-3`, `bg-warning-3`).
    *
    * @example
-   * rowClassName={(row) => row.status === 'overdue' ? 'bg-error-subtle' : undefined}
+   * rowClassName={(row) => row.status === 'overdue' ? 'bg-error-3' : undefined}
    */
   rowClassName?: (row: TData) => string | undefined
 }
@@ -584,8 +592,13 @@ export function DataTable<TData, TValue>({
 
   const rows = table.getRowModel().rows
 
-  // Virtualizer — always called but only active when virtualRows is true
-  const virtualizer = useVirtualizer({
+  // Virtualizer — always called but only active when virtualRows is true.
+  // `virtualRowHeight` is only the ESTIMATE: each rendered row group carries
+  // `virtualizer.measureElement` as its ref, so real heights (including an
+  // expanded row's detail panel) are measured and folded into `getTotalSize()`.
+  // Without that, an expanded panel and the row after it resolve to the same
+  // offset and paint on top of each other.
+  const virtualizer = useVirtualizer<HTMLDivElement, HTMLTableSectionElement>({
     count: virtualRows ? rows.length : 0,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => virtualRowHeight,
@@ -660,6 +673,7 @@ export function DataTable<TData, TValue>({
   // Virtual items for body
   const virtualItems = virtualRows ? virtualizer.getVirtualItems() : undefined
   const totalVirtualSize = virtualRows ? virtualizer.getTotalSize() : undefined
+  const measureRow = virtualizer.measureElement
 
   // Determine if we need a scroll wrapper for virtualization
   const tableContent = (
@@ -672,6 +686,7 @@ export function DataTable<TData, TValue>({
         emptyState={emptyState}
         virtualItems={virtualItems}
         totalVirtualSize={totalVirtualSize}
+        measureRow={measureRow}
       />
     </Table>
   )
@@ -688,20 +703,12 @@ export function DataTable<TData, TValue>({
             onGlobalFilterChange={setGlobalFilterValue}
             density={density}
             onDensityChange={setDensity}
-            // Default to false when server pagination is active — the toolbar can
-            // only see the current page's rows, so a silent partial export is worse
-            // than no export. Pass enableExport={true} or onExport to override.
-            enableExport={enableExport ?? !useServerPagination}
-            onExport={
-              onExport
-                ? () => {
-                    const visibleRows = table.getFilteredRowModel().rows.map(
-                      (r) => r.original,
-                    )
-                    onExport(visibleRows)
-                  }
-                : undefined
-            }
+            // Defaults to true — the Export button has shipped unconditionally
+            // since the toolbar existed, so defaulting it off (even only for
+            // server pagination) would silently delete a live affordance from
+            // every consumer on upgrade. Opt out with enableExport={false}.
+            enableExport={enableExport ?? true}
+            onExport={onExport}
           />
         )}
 


### PR DESCRIPTION
Stacks onto **#251** (targets its branch, not `main`, so @bastitva0-blip's PR stays intact and lands as the thing that merges). Review found #251's mount-echo fix and most of the new props to be genuinely correct — those are untouched. This closes the gaps.

## The two that mattered

**The `virtualRows` + `expandable` fix was half-finished, and the half that was missing turned a silent no-op into a visible overlap.** `useVirtualizer` had `estimateSize: () => virtualRowHeight` and no measurement, while the expanded panel was absolutely positioned at `translateY(start + size)` with no height — which with uniform sizes is *exactly* `nextVirtualRow.start`. #251's own comment admitted "the virtualizer total size does not account for this extra height."

Fixed by restructuring, not by arithmetic. Each windowed row now renders as **its own `<tbody>`** (valid HTML — a table may hold any number of row groups) carrying `data-index` + the virtualizer's `measureElement` ref, with `aria-hidden` spacer row groups reserving the un-rendered remainder. Because the measured group contains the data row **and** its expanded row, the panel's real height lands in `getTotalSize()`, so overlap is **structurally impossible** rather than avoided by a calculation. It also degrades safely: if `ResizeObserver` under-reports on a `display: table-row-group` in some browser, rows still lay out in flow and only the scroll extent falls back to estimates — whereas the absolute variant fails *visibly*.

> Note the measurement fix was the **ref**, not the option: `measureElement` already defaults correctly in `@tanstack/virtual-core` 3.14.7; what was missing was `ref={virtualizer.measureElement}` + `data-index` on the measured element.

**`enableExport` was silently removing a shipped button.** The toolbar defaults it `true` and `DataTable` never passed it, so Export always rendered; #251 passed `enableExport ?? !useServerPagination`, which drops it for every consumer using `toolbar` with server `pagination`. Now `enableExport ?? true` — nothing disappears, opt out explicitly with `enableExport={false}`. #251's test was **inverted, not deleted**: it now asserts the button renders by default *and* under server pagination, plus a second case asserting absence with the explicit prop. Bump stays `minor` honestly.

## ⚠️ Chromatic needs a human look before this merges

Virtual rows are no longer forced to `height: virtualRowHeight` with `display: flex` cells — `virtualRowHeight` is now the pre-measurement **estimate**. They sit in normal table flow at measured height, so **column widths track `<thead>` again instead of being divided evenly**. That is a real visual change to the existing `VirtualizedLargeDataset` story. It is the one thing that cannot be verified from jsdom, and I have not eyeballed it. Documented in the changeset and the component doc.

## Also

- **`bg-error-subtle` does not exist** — it was in the shipped `rowClassName` JSDoc `@example` and in new test assertions, passing only because `cn()` forwards any string. Now `bg-error-3` (verified against `--color-error-2..11` in `packages/core/src/tokens/semantic.css:210`). The one remaining mention is deliberate: the doc now names it as an example of an invented class.
- **`onExport` unified, not just re-documented.** `DataTableToolbar.onExport` went `() => void` → `(visibleRows: TData[]) => void` and `DataTable` forwards it through instead of wrapping. Per CLAUDE.md's classification rule this is a **widening** for providers (a `() => void` handler still assigns under the new type; the reverse did not hold), so non-breaking. One signature instead of two.
- **Props table rewritten off `DataTableProps` in the `.tsx`**, not off any generated doc. Also filled in `## Defaults`, documented `mobileView` (shipped earlier, never documented), and moved the `v0.57.0` section *above* `v0.1.0` — #251 appended it to the bottom of a reverse-chronological list.
- **The render-body `console.warn` is deleted rather than latched.** It described a limitation that no longer exists; latching a false warning is worse than removing it.
- **Tests: 69 → 83.** New coverage for `mobileView="card"` (zero existed), `virtualRows` (zero existed), the Export default, and `rowClassName` on the card path.

## Verification

| Check | Result |
|---|---|
| `typecheck` | exit 0 |
| `lint` | exit 0 (87 warnings, all pre-existing, none in data-table) |
| `npx vitest run data-table` | **83 passed / 83** |
| `build` | exit 0, all 9 post-build steps |
| `pre-publish-audit.mjs` (**release-only gates**) | **exit 0, all gates passed** — incl. no deprecated surface tokens, no deprecated shadow tokens, semantic radius roles, no bare `shadow` |
| `pnpm-lock.yaml` | untouched |

The audit was run deliberately, because those four token gates do **not** run in PR CI — that is what cost the 0.52.0 and 0.53.0 release cycles.

## Corrections to the review that produced this

Worth recording so the next person doesn't chase them: `bg-error-subtle` was **not** in the changeset (only two files had it); `pnpm -F @devalok/shilp-sutra test -- data-table` **does not filter** — pnpm forwards `--` literally and the run doesn't narrow, which is the Windows OOM, the working invocation is `npx vitest run data-table` from `packages/core`; and the toolbar line numbers were off by ~400. Every *claim* held; only the coordinates didn't.

## Known gap

jsdom cannot verify real measurement — `@tanstack/react-virtual` reads `offsetHeight` and bails at `outerSize === 0`, which is every element in jsdom (before a `mockVirtualLayout()` stub, a virtualized table rendered a `<thead>` and nothing else, which is exactly why #251 had zero virtual coverage). The tests assert structure — one `data-index`'d group per row, expanded row inside it, no `position`/`transform` on it, windowing and spacer arithmetic, axe clean — but cannot assert pixel heights. That is Chromatic's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKhuif5ZLRkWnaegdJ2n7q