### PR TITLE
fix(a11y): warn when Progress has no accessible name

### DIFF
--- a/.changeset/progress-accessible-name-warning.md
+++ b/.changeset/progress-accessible-name-warning.md
@@ -1,0 +1,20 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+**Progress:** warn in DEV when a bar has no accessible name.
+
+`<Progress value={72} />` rendered `role="progressbar"` with no `aria-label`, `aria-labelledby` or `title`, so a screen reader announced "progressbar, 72%" — the value, but not what is progressing. Lighthouse flags it as `aria-progressbar-name`.
+
+It now warns once (latched at module scope, so a bar animating on every tick logs once rather than once per frame) and names both escape hatches:
+
+```tsx
+<Progress value={72} label="Storage used" />          // visible text, wires aria-labelledby
+<Progress value={72} aria-label="Upload progress" />  // visually unlabelled
+```
+
+**Deliberately a warning and not an auto-generated default.** A generated name like `"Progress: 72%"` would silence the audit while leaving the announcement exactly as uninformative — `aria-valuenow` already carries the number — and it would make the bar *look* labelled so nobody fixes it. Only the consumer knows what the bar measures.
+
+Runtime behaviour in production is unchanged; the warning is stripped with `process.env.NODE_ENV === 'production'`. No API change. Passing `label`, `aria-label` or `aria-labelledby` already suppressed the problem and continues to.
+
+Also adds the component's first test file (8 cases: label wiring, explicit `aria-label`, explicit `aria-labelledby`, the warn firing, warn-once across re-renders and multiple instances, labelled indeterminate bars staying silent, and axe).

--- a/packages/core/docs/components/ui/progress.md
+++ b/packages/core/docs/components/ui/progress.md
@@ -66,6 +66,7 @@ common cases, or the compound parts (`Progress.Root` / `Track` / `Indicator` /
 - Omit `value` (or pass `null`) for indeterminate.
 - Pass an explicit `color` to override `autoColor`.
 - Compound `Progress.Track` needs a name — an `aria-label`, or a `Progress.Label` whose `id` the Track's `aria-labelledby` points to. A Track with neither is an unnamed progressbar (axe will flag it).
+- **`<Progress value={72} />` with no name warns in DEV.** `aria-valuenow` already carries the number, so an unnamed bar announces as "progressbar, 72%" — the reader learns the value but not *what* is progressing. Pass `label` (renders visible text and wires `aria-labelledby`) or `aria-label` when the bar must stay visually unlabelled. The component deliberately does **not** invent a default like "Progress: 72%": that would silence the audit while leaving the announcement equally uninformative, and only you know what the bar measures. Warns once per session, not per render.
 - `Progress.Indicator` / `Segment` / `Value` throw if rendered outside `Progress.Root`.
 
 ## Changes

--- a/packages/core/src/ui/__tests__/progress.test.tsx
+++ b/packages/core/src/ui/__tests__/progress.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { Progress } from '../progress'
+
+/**
+ * The missing-accessible-name warning is latched at module scope so a bar that
+ * re-renders on every value tick logs once instead of once per frame. That makes
+ * the latch global across a test file, so any case asserting the warn FIRES has
+ * to start from a fresh module registry — hence `vi.resetModules()` plus a
+ * dynamic import rather than the top-level `Progress` binding.
+ */
+async function freshProgress() {
+  vi.resetModules()
+  return (await import('../progress')).Progress
+}
+
+describe('Progress', () => {
+  it('renders a progressbar with the value', () => {
+    render(<Progress value={72} aria-label="Upload" />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toBeInTheDocument()
+    expect(bar).toHaveAttribute('aria-valuenow', '72')
+  })
+
+  it('has no axe violations when labelled', async () => {
+    const { container } = render(<Progress value={72} label="Storage used" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  describe('accessible name', () => {
+    let warn: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      warn.mockRestore()
+    })
+
+    it('wires aria-labelledby from `label`', () => {
+      render(<Progress value={40} label="Storage used" />)
+      // Accessible name comes from the visible label, so the bar is findable by it.
+      expect(screen.getByRole('progressbar', { name: 'Storage used' })).toBeInTheDocument()
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('honours an explicit aria-label', () => {
+      render(<Progress value={40} aria-label="Upload progress" />)
+      expect(screen.getByRole('progressbar', { name: 'Upload progress' })).toBeInTheDocument()
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('honours an explicit aria-labelledby', () => {
+      render(
+        <>
+          <span id="ext-label">External label</span>
+          <Progress value={40} aria-labelledby="ext-label" />
+        </>,
+      )
+      expect(screen.getByRole('progressbar', { name: 'External label' })).toBeInTheDocument()
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it('warns in DEV when there is no accessible name at all', async () => {
+      const Fresh = await freshProgress()
+      render(<Fresh value={72} />)
+
+      expect(screen.getByRole('progressbar')).not.toHaveAccessibleName()
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(warn.mock.calls[0][0]).toContain('[shilp-sutra] <Progress> has no accessible name')
+      // The message must name both escape hatches, or it isn't actionable.
+      expect(warn.mock.calls[0][0]).toContain('label')
+      expect(warn.mock.calls[0][0]).toContain('aria-label')
+    })
+
+    it('warns only once however many unlabelled bars render', async () => {
+      const Fresh = await freshProgress()
+      const { rerender } = render(<Fresh value={10} />)
+      rerender(<Fresh value={20} />)
+      rerender(<Fresh value={30} />)
+      render(
+        <>
+          <Fresh value={40} />
+          <Fresh value={50} />
+        </>,
+      )
+      expect(warn).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not warn when a value-less (indeterminate) bar is labelled', async () => {
+      const Fresh = await freshProgress()
+      render(<Fresh label="Loading" />)
+      expect(warn).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/core/src/ui/progress.tsx
+++ b/packages/core/src/ui/progress.tsx
@@ -8,6 +8,9 @@ import * as React from 'react'
 import { springs } from './lib/motion'
 import { cn } from './lib/utils'
 
+// Bundlers (Vite, Next.js, webpack) define process.env.NODE_ENV; guard for raw ESM.
+declare const process: { env: { NODE_ENV?: string } } | undefined
+
 /* ---------------------------------------------------------------------------
  * Progress — a linear progress bar.
  *
@@ -283,6 +286,33 @@ export interface ProgressProps
   indicatorClassName?: string
 }
 
+/**
+ * `role="progressbar"` with no accessible name announces as just "progressbar,
+ * 72%" — the value is already carried by `aria-valuenow`, so what a screen
+ * reader is missing is WHAT is progressing.
+ *
+ * This warns rather than auto-generating a name on purpose. A generated default
+ * ("Progress", or "Progress: 72%") would silence the Lighthouse audit while
+ * leaving the announcement just as uninformative, which is worse than the
+ * current state: the bar looks labelled and nobody fixes it. Only the consumer
+ * knows what the bar measures.
+ *
+ * Latched at module scope so a bar that re-renders on every value tick logs
+ * once, not once per frame — same pattern as Card's unwrapped-text warning.
+ */
+let warnedMissingProgressName = false
+
+function warnOnMissingAccessibleName(): void {
+  if (warnedMissingProgressName) return
+  if (typeof process === 'undefined' || process?.env?.NODE_ENV === 'production') return
+  warnedMissingProgressName = true
+  console.warn(
+    '[shilp-sutra] <Progress> has no accessible name, so it announces as just "progressbar" with a percentage. ' +
+      'Pass `label` (renders visible text and wires aria-labelledby) or `aria-label` if the bar must stay unlabelled visually. ' +
+      'Example: <Progress value={72} label="Storage used" /> or <Progress value={72} aria-label="Upload progress" />.',
+  )
+}
+
 const ProgressBase = React.forwardRef<HTMLDivElement, ProgressProps>(
   (
     {
@@ -294,6 +324,7 @@ const ProgressBase = React.forwardRef<HTMLDivElement, ProgressProps>(
   ) => {
     const labelId = React.useId()
     const hasLabel = label != null
+    if (!hasLabel && !ariaLabel && !ariaLabelledby) warnOnMissingAccessibleName()
     return (
       <ProgressRoot ref={ref} value={value} max={max} size={size ?? 'md'} className={className} {...props}>
         {hasLabel && <ProgressLabel id={labelId}>{label}</ProgressLabel>}


### PR DESCRIPTION
Second half of **#255** (the `packages/core` item; the four site items are in the Lighthouse PR).

`<Progress value={72} />` rendered `role="progressbar"` with no `aria-label`, `aria-labelledby` or `title`, so a screen reader announced **"progressbar, 72%"** — the value, but not *what* is progressing. Lighthouse reports it as `aria-progressbar-name`, and it is one of four weighted audits currently holding the site's accessibility score at 89.

The composite already wired `aria-labelledby` from `label` and honoured an explicit `aria-label`; the gap was only the case where a consumer passes neither (`packages/core/src/ui/progress.tsx:299-302`).

## Why a warning and not an auto-generated default

The issue offered both options. This takes the warning, on purpose:

A generated name — `"Progress"`, or `"Progress: 72%"` — would **satisfy the audit while leaving the announcement exactly as uninformative**. `aria-valuenow` already carries the number, so the reader gains nothing. Worse, the bar would then *look* labelled, so nobody would ever fix it. Only the consumer knows what the bar measures. Silencing an a11y audit without improving the experience is worse than the current honest failure.

```tsx
<Progress value={72} label="Storage used" />          // visible text, wires aria-labelledby
<Progress value={72} aria-label="Upload progress" />  // visually unlabelled
```

Latched at module scope so a bar animating on every value tick logs **once**, not once per frame — same pattern as `warnedUnwrappedText` in `ui/card.tsx`. Stripped in production via `NODE_ENV`.

**No API change, no production runtime change.** Anything already passing `label` / `aria-label` / `aria-labelledby` was never affected. Bumped `patch`.

## Tests

The component had **no test file at all**. Adds one — 8 cases: `label` wiring, explicit `aria-label`, explicit `aria-labelledby`, the warn firing with a message naming both escape hatches, warn-once across re-renders *and* across multiple instances, a labelled indeterminate bar staying silent, and axe. The warn-firing cases go through `vi.resetModules()` + dynamic import, because the module-scope latch is shared across a test file — worth knowing if you extend them.

## Verification

- `typecheck` clean
- **8/8 tests pass**
- `pre-publish-audit.mjs` release-only token gates pass: no deprecated surface tokens, no deprecated shadow tokens, semantic radius roles, no bare `shadow`. Run deliberately, because those four don't run in PR CI — the 0.52.0/0.53.0 lesson.

## What this does NOT do

**It does not, by itself, raise the site's Lighthouse accessibility score.** The warn tells a developer to add a name; it doesn't add one. I tried to locate the offending element on `/` and could not by static analysis — there is no `<Progress>` anywhere in `apps/site/components/`, and none of the three DS components that render `role="progressbar"` (`composed/global-loading`, `ui/progress-ring`, `ui/file-upload`) appear in the homepage-reachable tree. Confirming it needs a local Lighthouse run, which currently dies on Windows in `chrome-launcher`'s temp cleanup.

The useful part: **this warning is the tool that will find it.** Run the site in dev and the console names the component directly. I did not want to guess at a call site and claim a score fix I hadn't measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKhuif5ZLRkWnaegdJ2n7q