### PR TITLE
chore(lint): run our own eslint plugin on our own source

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,9 @@ import tseslint from 'typescript-eslint'
 import reactHooks from 'eslint-plugin-react-hooks'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 import simpleImportSort from 'eslint-plugin-simple-import-sort'
+// Our own published plugin, applied to our own source. Resolved from
+// packages/eslint-plugin/dist, so `lint` dependsOn its build in turbo.json.
+import shilpSutra from '@devalok/eslint-plugin-shilp-sutra'
 
 export default tseslint.config(
   // ── Global ignores ──────────────────────────────────────────────────
@@ -129,5 +132,42 @@ export default tseslint.config(
     },
   },
 
-
+  // ── Our own plugin, applied to our own source ───────────────────────
+  //
+  // We publish @devalok/eslint-plugin-shilp-sutra to catch exactly the class of
+  // mistake that CLAUDE.md says rots silently here — and until now we did not
+  // run it on ourselves. The four rules below mirror release-ONLY gates in
+  // pre-publish-audit.mjs, which never execute on a PR. That gap cost a release
+  // cycle twice: 0.52.0 (radius tokens) and 0.53.0 (`bg-surface-2` in the
+  // schedule-view rebuild) both sailed through PR CI and failed post-merge.
+  // Running them here moves the failure to the PR, where it is cheap.
+  //
+  // Deliberately NOT the `flat/recommended` preset. That preset is written for
+  // CONSUMERS and several of its rules are wrong for this repo:
+  //   - prefer-per-component-import targets consumer barrel imports of
+  //     peer-cliff symbols; our source imports relatively.
+  //   - no-deprecated-button-variant / no-deprecated-chip / use-toast-deprecated
+  //     / no-iconbutton-children flag deprecated USAGE — we DEFINE those APIs,
+  //     so our source legitimately references them.
+  //   - no-tailwind-config-preset is about a consumer's tailwind config.
+  //   - require-mutation-annotation is a taste rule, not a correctness gate.
+  // Only the token/TW4-hygiene rules are true for both sides of the boundary.
+  //
+  // Note `**/*.stories.tsx` is globally ignored above, which matches the audit
+  // gate's own story exclusion — so this does not tighten coverage beyond it.
+  {
+    files: ['packages/*/src/**/*.{ts,tsx}'],
+    plugins: { 'shilp-sutra': shilpSutra },
+    rules: {
+      // Numbered surface aliases don't invert for dark mode; the named tiers do.
+      'shilp-sutra/no-deprecated-surface-token': 'error',
+      'shilp-sutra/no-deprecated-shadow-token': 'error',
+      // Bare `shadow` renders nothing in TW4.
+      'shilp-sutra/no-bare-shadow': 'error',
+      // `bg-gradient-to-*` is dead in TW4 — `bg-linear-to-*` replaced it.
+      'shilp-sutra/no-bg-gradient-to': 'error',
+      // `w-[--var]` is dead in TW4 — the shorthand is `w-(--var)`.
+      'shilp-sutra/no-css-var-bracket': 'error',
+    },
+  },
 )

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@arethetypeswrong/cli": "^0.18.0",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.1",
+    "@devalok/eslint-plugin-shilp-sutra": "workspace:*",
     "@storybook/addon-a11y": "^10.5.3",
     "@storybook/addon-docs": "^10.5.3",
     "@storybook/addon-mcp": "^0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@26.1.1)
+      '@devalok/eslint-plugin-shilp-sutra':
+        specifier: workspace:*
+        version: link:packages/eslint-plugin
       '@storybook/addon-a11y':
         specifier: ^10.5.3
         version: 10.5.3(storybook@10.5.3(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,9 @@
     "typecheck": {
       "dependsOn": ["^build"]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": ["@devalok/eslint-plugin-shilp-sutra#build"]
+    },
     "test": {
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
N4 from the re-verified audit backlog (#257). The single highest-leverage item on that list, and a config block in size.

**We publish `@devalok/eslint-plugin-shilp-sutra` to catch a specific class of mistake, and we were not running it on ourselves.** `eslint.config.js` registered `react-hooks`, `jsx-a11y` and `simple-import-sort` — not the plugin whose entire purpose is the token and TW4 hygiene that CLAUDE.md says rots silently in this repo.

## What now runs

Five rules at `error` on `packages/*/src`. Each mirrors a gate that lives **only** in `pre-publish-audit.mjs`, which never executes on a PR:

| Rule | Why it matters |
|---|---|
| `no-deprecated-surface-token` | numbered aliases don't invert for dark mode; the named tiers do |
| `no-deprecated-shadow-token` | renamed in 0.23.0 |
| `no-bare-shadow` | bare `shadow` renders nothing in TW4 |
| `no-bg-gradient-to` | TW3-era; TW4 renamed it to `bg-linear-to-*` |
| `no-css-var-bracket` | `w-[--var]` is dead; the shorthand is `w-(--var)` |

That gap cost a release cycle **twice** — 0.52.0 (radius tokens) and 0.53.0 (`bg-surface-2` in the schedule-view rebuild) both passed PR CI and failed post-merge in `integration.yml`. Same family, same root cause: the check existed but ran too late to be cheap. This moves it onto the PR, where fixing it is free.

## Why not the `flat/recommended` preset

Deliberate, and the reasoning is recorded in `eslint.config.js` so nobody "simplifies" it later. That preset is written for **consumers**, and several of its rules are actively wrong here:

- `prefer-per-component-import` targets consumer barrel imports of peer-cliff symbols — our source imports relatively.
- `no-deprecated-button-variant`, `no-deprecated-chip`, `use-toast-deprecated`, `no-iconbutton-children` flag deprecated **usage**. We *define* those APIs, so our source legitimately references them.
- `no-tailwind-config-preset` is about a consumer's tailwind config.
- `require-mutation-annotation` is a taste rule, not a correctness gate.

Only the token/TW4-hygiene rules hold on both sides of the boundary.

## Build order

The plugin resolves from `packages/eslint-plugin/dist` (tsup), which does not exist in a fresh checkout — so `turbo.json`'s `lint` task now `dependsOn` `@devalok/eslint-plugin-shilp-sutra#build`, and root gains the plugin as a `workspace:*` devDependency so `eslint.config.js` can resolve it.

## Verification — including against known-bad input, not just the happy path

- **`pnpm lint` exit 0, zero new violations.** The 87 pre-existing warnings are unchanged; our source was already clean on all five rules.
- **Zero violations can also mean a rule never loaded**, so each was probed with a deliberately bad file. `bg-surface-2 shadow bg-gradient-to-r w-[--probe-width]` produced exactly **4 errors from 4 distinct rules**; `shadow-01 shadow-05` produced **2 more** from the fifth. eslint exited 1 each time. Probe file deleted.
- **The build-order edge was tested through its real path:** deleted `packages/eslint-plugin/dist` entirely, ran `pnpm lint`, and turbo ran the plugin's build first, restored `dist`, and lint exited 0.
- `pnpm check:lockfile` passes in the clean sandbox. **The lockfile diff is exactly 3 lines** — one `link:packages/eslint-plugin` importer entry.

No changeset: root is private and no published package changed.

## Scope notes

- `**/*.stories.tsx` stays globally ignored, which matches the audit gate's own story exclusion — so this does not tighten coverage beyond what the release gate already enforced. (That's also why the audit reports 25 surface-token hits in stories and still passes.)
- `apps/site` is **not** covered: it runs `next lint` with its own config, and the root flat config's `files` glob is `packages/*/src/**`. Worth doing separately, but it's a different wiring problem.
- A side effect of the `dependsOn`: `site:lint` now also waits on the plugin build. Cached, so the cost is negligible, but it's real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKhuif5ZLRkWnaegdJ2n7q
