### PR TITLE
chore(release): promote the pending release to 0.57.0

### DIFF
--- a/.changeset/progress-accessible-name-warning.md
+++ b/.changeset/progress-accessible-name-warning.md
@@ -1,5 +1,5 @@
 ---
-"@devalok/shilp-sutra": patch
+"@devalok/shilp-sutra": minor
 ---
 
 **Progress:** warn in DEV when a bar has no accessible name.
@@ -16,5 +16,7 @@ It now warns once (latched at module scope, so a bar animating on every tick log
 **Deliberately a warning and not an auto-generated default.** A generated name like `"Progress: 72%"` would silence the audit while leaving the announcement exactly as uninformative — `aria-valuenow` already carries the number — and it would make the bar *look* labelled so nobody fixes it. Only the consumer knows what the bar measures.
 
 Runtime behaviour in production is unchanged; the warning is stripped with `process.env.NODE_ENV === 'production'`. No API change. Passing `label`, `aria-label` or `aria-labelledby` already suppressed the problem and continues to.
+
+**Released as a minor, not a patch.** The prop surface is untouched, but every consumer rendering an unlabelled `Progress` gets new console output on upgrade — a visible behaviour change in their dev loop, which pre-1.0 we bump minor for rather than slipping into a patch. Upgrading to 0.57.0 may surface warnings you have not seen before; each one is a real unlabelled bar.
 
 Also adds the component's first test file (8 cases: label wiring, explicit `aria-label`, explicit `aria-labelledby`, the warn firing, warn-once across re-renders and multiple instances, labelled indeterminate bars staying silent, and axe).


### PR DESCRIPTION
The only changeset pending against 0.56.0 is `progress-accessible-name-warning.md`, filed as a `patch`. This promotes it to `minor`, so the next release is **0.57.0** rather than 0.56.1.

## Why minor

The prop surface is untouched — `label`, `aria-label` and `aria-labelledby` behave exactly as before, and production runtime is unchanged (the warning is stripped under `NODE_ENV === "production"`).

What does change: every consumer rendering an unlabelled `Progress` gets new console output on upgrade. That is visible behaviour in their dev loop. Pre-1.0 we bump minor for that rather than slipping it into a patch — a patch should be invisible to anyone who was not already hitting the bug. Upgrading to 0.57.0 may surface warnings that were not there before; each one is a real unlabelled bar.

The changeset body now carries this rationale, so it lands in the CHANGELOG instead of leaving a `minor` section that reads "No API change" with no explanation.

## Mechanism

The changeset, not a hand-bump of `package.json` — hand-bumping breaks changesets' state tracking. `version.yml` regenerates the Version Packages PR from pending changesets and takes the highest bump, so #266 moves 0.56.1 → 0.57.0 once this merges.

## Not included

The DataTable stack (#251 → #260) carries its own `minor` changeset and stays unreleased. 0.57.0 is the Progress a11y warning alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
