### PR TITLE
test: close #268 test-coverage gaps + additive DataTable/Diff/DateSeparator props

### DIFF
--- a/.changeset/eslint-require-progress-label.md
+++ b/.changeset/eslint-require-progress-label.md
@@ -1,0 +1,5 @@
+---
+"@devalok/eslint-plugin-shilp-sutra": minor
+---
+
+New rule `require-progress-label`: statically catches `<Progress>` usage with no accessible name (`aria-label`, `aria-labelledby`, or `label`), the same condition the component itself already warns about at runtime in dev. Added to the `recommended` (`warn`) and `strict` (`error`) presets, legacy and flat.

--- a/.changeset/issue-268-test-coverage-and-feature-gaps.md
+++ b/.changeset/issue-268-test-coverage-and-feature-gaps.md
@@ -1,0 +1,16 @@
+---
+"@devalok/shilp-sutra": minor
+---
+
+**Test coverage:** closes the gaps tracked in #268 — added missing unit tests for `Diff`, `DataTableCards`, `DataTableBulkActions`, `DataTablePagination`, `DataTableHeader`, `DataTableBody`/inline cell editing, `BlockShell`, and expanded shallow coverage for `Sidebar` (collapsed state, `toggleSidebar`, keyboard shortcut, rail, mobile `Sheet`), `NotificationPreferences` (add/delete/mute callbacks, loading/empty states), `GlobalLoading` (loading-state transitions), `useViewportHeight` (SSR fallback, Visual Viewport resize, window-resize fallback, cleanup), and the `DatePicker`/`DateRangePicker`/`DateTimePicker` family (keyboard nav, `minDate`/`maxDate`, clearing).
+
+**New features (all additive, non-breaking):**
+
+- `BulkAction.icon?: IconInput` — renders an icon before the label in `DataTable`'s bulk-action buttons.
+- `DataTable`'s bulk-actions bar now supports `bulkActionsPosition?: 'bottom' | 'top' | 'inline'` (default `'bottom'`, matching prior behavior) instead of hard-coded fixed positioning.
+- `DateSeparator` gained `locale?: string` and `timeZone?: string` props — the default "Today"/"Yesterday"/date label now supports non-`en-US` locales and IANA time zones instead of always using the browser's local time zone and English month names.
+- `Diff` gained a `language?: string` prop for line-level syntax highlighting (inline/split, `line` granularity), lazy-loading `react-syntax-highlighter` with the same one-dark theme as `MarkdownViewer`.
+- `Diff` gained `beforeParseError?: (raw: string) => ReactNode` and `afterParseError?: (raw: string) => ReactNode` slot props, letting callers customize the fallback shown when `before`/`after` fails to parse as JSON in `fields` mode (previously a single fixed message covered both sides).
+- New hook `useContainerSize()` — a `ResizeObserver`-based hook returning `{ ref, width, height }` for element-level responsive components.
+
+**DataTable:** verified (via new tests) that `rowClassName` and `filterableColumns` — added in a prior changeset — actually work in `mobileView="card"`, and that `onExport` receives the currently visible (filtered) rows rather than the full data set.

--- a/packages/core/docs/components/composed/diff.md
+++ b/packages/core/docs/components/composed/diff.md
@@ -17,6 +17,9 @@
     afterLabel: string (new-side column label, split mode)
     onAcceptHunk: (hunk) => void (adds per-change Accept control)
     onRejectHunk: (hunk) => void (adds per-change Reject control)
+    language: string (syntax-highlight full lines as this language — inline/split, "line" granularity only; lazy-loads react-syntax-highlighter, one-dark theme, same pattern as MarkdownViewer)
+    beforeParseError: (raw: string) => ReactNode (custom render when `before` fails to parse as JSON in fields mode; default is a plain message)
+    afterParseError: (raw: string) => ReactNode (custom render when `after` fails to parse as JSON in fields mode; default is a plain message)
 
 ## Defaults
     mode="inline", granularity="line", collapseUnchanged={true}, collapseThreshold={6}, contextLines={3}, showSummary={true}, beforeLabel="Committed", afterLabel="Pending"
@@ -44,7 +47,12 @@
 - **Semantic colour:** additions use the `success` scale, removals the `error` scale — flips correctly in dark.
 
 ## Gotchas
-- `fields` mode requires valid JSON on both sides; it reports a clear message otherwise. For YAML, parse to an object and `JSON.stringify` before passing.
-- `granularity="word"` is for prose; it renders a flowing word-level diff, not line gutters.
+- `fields` mode requires valid JSON on both sides; it reports a clear message per side otherwise (override with `beforeParseError`/`afterParseError`). For YAML, parse to an object and `JSON.stringify` before passing.
+- `granularity="word"` is for prose; it renders a flowing word-level diff, not line gutters. `language` has no effect in word granularity or `fields` mode.
 - Accept/Reject controls only appear when the matching handler is provided — the Diff itself doesn't mutate content; the consumer applies the decision.
 - Hunk = a contiguous run of added/removed lines; `onAcceptHunk`/`onRejectHunk` receive `{ index, before, after }`.
+
+## Changes
+### Unreleased
+- **Added** `language?: string` — syntax-highlight full lines (inline/split, line granularity) via lazy-loaded `react-syntax-highlighter`.
+- **Added** `beforeParseError?: (raw: string) => ReactNode` / `afterParseError?: (raw: string) => ReactNode` — customize the fallback shown per side when `fields` mode JSON parsing fails (previously one fixed message covered both sides).

--- a/packages/core/docs/components/ui/chat.md
+++ b/packages/core/docs/components/ui/chat.md
@@ -155,13 +155,16 @@ Horizontal rule with a formatted date label.
 
 ### Props
     date: Date | string (REQUIRED)
-    format: (date: Date) => string — custom date formatter
+    format: (date: Date) => string — custom date formatter (overrides locale/timeZone)
+    locale: string — BCP 47 locale for the default label's month name (default 'en-US')
+    timeZone: string — IANA time zone for the "Today"/"Yesterday" day-boundary comparison and formatting (default: browser's local time zone)
     className: string
 
 ### Example
 ```jsx
 <DateSeparator date={new Date()} />
 <DateSeparator date="2026-03-25" format={(d) => d.toLocaleDateString()} />
+<DateSeparator date={new Date()} locale="fr-FR" timeZone="Europe/Paris" />
 ```
 
 ---
@@ -219,5 +222,8 @@ Animated bouncing dots with a text description of who is typing.
 - DateSeparator's default formatter shows "Today", "Yesterday", or "Mon DD" / "Mon DD, YYYY"
 
 ## Changes
+### Unreleased
+- **Added** `DateSeparator` gained `locale?: string` and `timeZone?: string` props — the default label previously always used `en-US` month names and the browser's local time zone.
+
 ### v0.29.0
 - **Added** Initial release — 7 chat primitives (MessageList, Message, SystemMessage, MessageInput, DateSeparator, UnreadSeparator, TypingIndicator)

--- a/packages/core/docs/components/ui/data-table.md
+++ b/packages/core/docs/components/ui/data-table.md
@@ -31,7 +31,8 @@
     stickyHeader: boolean — sticky table header
     onRowClick: (row: TData) => void — row click handler (excludes interactive element clicks)
     rowClassName: (row: TData) => string | undefined — conditional per-row class (the <tr> in table mode, the Card in card mode)
-    bulkActions: BulkAction<TData>[] — floating action bar on selection — { label, onClick, color?: 'default'|'error', disabled? }
+    bulkActions: BulkAction<TData>[] — floating action bar on selection — { label, onClick, icon?: IconInput, color?: 'accent'|'error', disabled? }
+    bulkActionsPosition: 'bottom' | 'top' | 'inline' — where the bulk-actions bar renders (default 'bottom')
     toolbar: boolean — show DataTableToolbar (column visibility, density, CSV export)
     enableExport: boolean — show the toolbar's Export CSV button (default true)
     onExport: (visibleRows: TData[]) => void — replace the built-in CSV export
@@ -107,6 +108,10 @@ import { DataTable } from '@devalok/shilp-sutra/ui/data-table'
 - `rowClassName` returns are passed through `cn()` verbatim — a class that does not exist in the token set silently does nothing (use the real scale steps, e.g. `bg-error-3`, not invented names like `bg-error-subtle`)
 
 ## Changes
+### Unreleased
+- **Added** `bulkActions[].icon?: IconInput` — icon rendered before the label in a bulk-action button.
+- **Added** `bulkActionsPosition?: 'bottom' | 'top' | 'inline'` — where the bulk-actions bar renders (default `'bottom'`, matching prior behavior).
+
 ### v0.57.0
 - **Fixed** `onSelectionChange` no longer fires on mount with `[]` — first-render guard added. Root cause of the cascade reported in #213.
 - **Fixed** `virtualRows + expandable` was a silent no-op — the expanded row was only rendered on the non-virtual path. Virtual rows now render one measured `<tbody>` per windowed row (with spacer row groups for the remainder) so the expanded panel renders, contributes its real height to `getTotalSize()`, and cannot overlap the row below.

--- a/packages/core/src/ai/__tests__/blocks/block-shell.test.tsx
+++ b/packages/core/src/ai/__tests__/blocks/block-shell.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { BlockShell } from '../../blocks/block-shell'
+
+describe('BlockShell', () => {
+  describe('confidence levels', () => {
+    it('low: sets data-confidence="low" and applies the warning treatment', () => {
+      const { container } = render(
+        <BlockShell confidence="low">low content</BlockShell>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root).toHaveAttribute('data-confidence', 'low')
+      expect(root.className).toContain('bg-warning-2')
+      expect(root.className).toContain('relative')
+      expect(root.className).toContain('rounded-surface')
+      expect(root.className).toContain('pt-ds-07')
+    })
+
+    it('medium: sets data-confidence="medium" and does NOT apply the warning treatment', () => {
+      const { container } = render(
+        <BlockShell confidence="medium">medium content</BlockShell>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root).toHaveAttribute('data-confidence', 'medium')
+      expect(root.className).not.toContain('bg-warning-2')
+    })
+
+    it('high: sets data-confidence="high" and does NOT apply the warning treatment', () => {
+      const { container } = render(
+        <BlockShell confidence="high">high content</BlockShell>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root).toHaveAttribute('data-confidence', 'high')
+      expect(root.className).not.toContain('bg-warning-2')
+    })
+
+    it('omitted confidence: renders without a data-confidence attribute and without the warning treatment', () => {
+      const { container } = render(<BlockShell>no confidence</BlockShell>)
+      const root = container.firstChild as HTMLElement
+      // React drops an attribute entirely when its value is undefined.
+      expect(root.hasAttribute('data-confidence')).toBe(false)
+      expect(root.className).not.toContain('bg-warning-2')
+    })
+  })
+
+  describe('warning classes / low-confidence chip', () => {
+    it('renders the "Low confidence" chip when confidence="low"', () => {
+      render(<BlockShell confidence="low">content</BlockShell>)
+      expect(screen.getByText('Low confidence')).toBeInTheDocument()
+    })
+
+    it.each(['medium', 'high', undefined] as const)(
+      'does not render the "Low confidence" chip when confidence=%s',
+      (confidence) => {
+        render(<BlockShell confidence={confidence}>content</BlockShell>)
+        expect(screen.queryByText('Low confidence')).not.toBeInTheDocument()
+      },
+    )
+  })
+
+  describe('independence between instances', () => {
+    it('two siblings with different confidence levels render independently', () => {
+      render(
+        <>
+          <BlockShell confidence="low" className="instance-a">
+            Instance A
+          </BlockShell>
+          <BlockShell confidence="high" className="instance-b">
+            Instance B
+          </BlockShell>
+        </>,
+      )
+
+      const instanceA = screen.getByText('Instance A').closest('.instance-a')
+      const instanceB = screen.getByText('Instance B').closest('.instance-b')
+
+      expect(instanceA).toHaveAttribute('data-confidence', 'low')
+      expect(instanceB).toHaveAttribute('data-confidence', 'high')
+
+      // Only the low-confidence instance carries the warning wash.
+      expect(instanceA?.className).toContain('bg-warning-2')
+      expect(instanceB?.className).not.toContain('bg-warning-2')
+
+      // Only the low-confidence instance shows the chip, and there is exactly one.
+      expect(screen.getAllByText('Low confidence')).toHaveLength(1)
+      expect(instanceA).toContainElement(screen.getByText('Low confidence'))
+    })
+
+    it('re-rendering one instance does not affect an unrelated sibling instance', () => {
+      const { rerender } = render(
+        <>
+          <BlockShell confidence="low" className="instance-a">
+            Instance A
+          </BlockShell>
+          <BlockShell confidence="low" className="instance-b">
+            Instance B
+          </BlockShell>
+        </>,
+      )
+
+      expect(screen.getAllByText('Low confidence')).toHaveLength(2)
+
+      rerender(
+        <>
+          <BlockShell confidence="high" className="instance-a">
+            Instance A
+          </BlockShell>
+          <BlockShell confidence="low" className="instance-b">
+            Instance B
+          </BlockShell>
+        </>,
+      )
+
+      // Instance A dropped its warning treatment; instance B, untouched by the
+      // prop change, must still carry its own independently.
+      const instanceA = screen.getByText('Instance A').closest('.instance-a')
+      const instanceB = screen.getByText('Instance B').closest('.instance-b')
+      expect(instanceA).toHaveAttribute('data-confidence', 'high')
+      expect(instanceA?.className).not.toContain('bg-warning-2')
+      expect(instanceB).toHaveAttribute('data-confidence', 'low')
+      expect(instanceB?.className).toContain('bg-warning-2')
+      expect(screen.getAllByText('Low confidence')).toHaveLength(1)
+    })
+  })
+
+  describe('smoke', () => {
+    it('renders its children', () => {
+      render(
+        <BlockShell>
+          <p>child content</p>
+        </BlockShell>,
+      )
+      expect(screen.getByText('child content')).toBeInTheDocument()
+    })
+
+    it('merges a custom className onto the root element', () => {
+      const { container } = render(
+        <BlockShell className="custom-class">content</BlockShell>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('custom-class')
+    })
+
+    it('merges a custom className alongside the low-confidence warning classes', () => {
+      const { container } = render(
+        <BlockShell confidence="low" className="custom-class">
+          content
+        </BlockShell>,
+      )
+      const root = container.firstChild as HTMLElement
+      expect(root.className).toContain('custom-class')
+      expect(root.className).toContain('bg-warning-2')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('has no axe violations for a low-confidence block', async () => {
+      const { container } = render(
+        <BlockShell confidence="low">
+          <p>Some AI-generated content that may be unreliable.</p>
+        </BlockShell>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+
+    it('has no axe violations for a high-confidence block', async () => {
+      const { container } = render(
+        <BlockShell confidence="high">
+          <p>Some AI-generated content.</p>
+        </BlockShell>,
+      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/packages/core/src/composed/__tests__/global-loading.test.tsx
+++ b/packages/core/src/composed/__tests__/global-loading.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react'
+import { createRef } from 'react'
 import { describe, expect,it } from 'vitest'
 import { axe } from 'vitest-axe'
 
@@ -15,5 +16,88 @@ describe('GlobalLoading', () => {
     const { container } = render(<GlobalLoading isLoading={false} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+
+  it('renders the progressbar as active (not aria-hidden) with a "Loading" valuetext when isLoading is true', () => {
+    const { getByRole } = render(<GlobalLoading isLoading={true} />)
+    const bar = getByRole('progressbar', { hidden: true })
+
+    expect(bar).toHaveAttribute('aria-hidden', 'false')
+    expect(bar).toHaveAttribute('aria-valuetext', 'Loading')
+    expect(bar).toHaveAttribute('aria-label', 'Page loading')
+
+    // The inner fill indicator is expanded and fully opaque while loading.
+    const fill = bar.firstElementChild as HTMLElement
+    expect(fill).toHaveClass('w-4/5')
+    expect(fill).toHaveClass('opacity-100')
+  })
+
+  it('renders the progressbar as aria-hidden with no valuetext, and the fill collapsed, when isLoading is false', () => {
+    const { getByRole } = render(<GlobalLoading isLoading={false} />)
+    const bar = getByRole('progressbar', { hidden: true })
+
+    expect(bar).toHaveAttribute('aria-hidden', 'true')
+    expect(bar).not.toHaveAttribute('aria-valuetext')
+
+    // Mounting directly with isLoading=false means the bar never animated in,
+    // so the fill starts fully collapsed and transparent.
+    const fill = bar.firstElementChild as HTMLElement
+    expect(fill).toHaveClass('w-0')
+    expect(fill).toHaveClass('opacity-0')
+  })
+
+  it('transitions from loading to not-loading: aria-hidden flips true and the fill leaves its expanded state', () => {
+    const { getByRole, rerender } = render(<GlobalLoading isLoading={true} />)
+    const bar = getByRole('progressbar', { hidden: true })
+    const fill = bar.firstElementChild as HTMLElement
+
+    expect(bar).toHaveAttribute('aria-hidden', 'false')
+    expect(fill).toHaveClass('w-4/5')
+    expect(fill).toHaveClass('opacity-100')
+
+    rerender(<GlobalLoading isLoading={false} />)
+
+    expect(bar).toHaveAttribute('aria-hidden', 'true')
+    expect(bar).not.toHaveAttribute('aria-valuetext')
+    // Having been loading, the bar plays a "complete" animation (full width,
+    // still opaque, with a glow) rather than snapping straight to collapsed.
+    expect(fill).toHaveClass('w-full')
+    expect(fill).toHaveClass('opacity-100')
+    expect(fill).not.toHaveClass('w-4/5')
+    expect(fill.style.boxShadow).toBe('0 0 8px var(--color-accent-9)')
+  })
+
+  it('transitions from not-loading to loading: aria-hidden flips false and the fill expands again', () => {
+    const { getByRole, rerender } = render(<GlobalLoading isLoading={false} />)
+    const bar = getByRole('progressbar', { hidden: true })
+    const fill = bar.firstElementChild as HTMLElement
+
+    expect(bar).toHaveAttribute('aria-hidden', 'true')
+
+    rerender(<GlobalLoading isLoading={true} />)
+
+    expect(bar).toHaveAttribute('aria-hidden', 'false')
+    expect(bar).toHaveAttribute('aria-valuetext', 'Loading')
+    expect(fill).toHaveClass('w-4/5')
+    expect(fill).toHaveClass('opacity-100')
+    expect(fill).not.toHaveClass('w-0')
+  })
+
+  it('forwards the ref to the underlying progressbar div', () => {
+    const ref = createRef<HTMLDivElement>()
+    render(<GlobalLoading isLoading={true} ref={ref} />)
+
+    expect(ref.current).not.toBeNull()
+    expect(ref.current).toHaveAttribute('role', 'progressbar')
+  })
+
+  it('spreads arbitrary div props (from GlobalLoadingProps extending ComponentPropsWithoutRef<"div">) onto the root', () => {
+    const { getByTestId } = render(
+      <GlobalLoading isLoading={true} data-testid="global-loading-bar" id="page-loader" />,
+    )
+    const bar = getByTestId('global-loading-bar')
+
+    expect(bar).toHaveAttribute('id', 'page-loader')
+    expect(bar).toHaveAttribute('role', 'progressbar')
   })
 })

--- a/packages/core/src/composed/date-picker/__tests__/date-picker.test.tsx
+++ b/packages/core/src/composed/date-picker/__tests__/date-picker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { format } from 'date-fns'
 import { describe, expect, it, vi } from 'vitest'
@@ -151,6 +151,14 @@ describe('DatePicker', () => {
     const { container } = render(<DatePicker />)
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('clearing the value (controlled) reverts to the placeholder', () => {
+    const { rerender } = render(<DatePicker value={new Date(2026, 2, 15)} placeholder="Pick a date" />)
+    expect(screen.getByText('Mar 15, 2026')).toBeInTheDocument()
+    rerender(<DatePicker value={null} placeholder="Pick a date" />)
+    expect(screen.getByText('Pick a date')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Pick a date')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -227,6 +235,40 @@ describe('DateRangePicker', () => {
   it('has no accessibility violations in closed state', async () => {
     const { container } = render(<DateRangePicker />)
     expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('disables dates outside minDate/maxDate', async () => {
+    const user = userEvent.setup()
+    render(
+      <DateRangePicker
+        startDate={new Date(2026, 2, 1)}
+        minDate={new Date(2026, 2, 5)}
+        maxDate={new Date(2026, 2, 25)}
+      />,
+    )
+    await user.click(screen.getByRole('button'))
+    expect(
+      screen.getByRole('gridcell', { name: 'Wednesday, March 4, 2026' }),
+    ).toHaveAttribute('aria-disabled', 'true')
+    expect(
+      screen.getByRole('gridcell', { name: 'Thursday, March 26, 2026' }),
+    ).toHaveAttribute('aria-disabled', 'true')
+    expect(
+      screen.getByRole('gridcell', { name: 'Sunday, March 15, 2026' }),
+    ).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('clearing the range (controlled) reverts to the placeholder', () => {
+    const { rerender } = render(
+      <DateRangePicker
+        startDate={new Date(2026, 2, 1)}
+        endDate={new Date(2026, 2, 15)}
+        placeholder="Pick a date range"
+      />,
+    )
+    expect(screen.getByText('Mar 1, 2026 - Mar 15, 2026')).toBeInTheDocument()
+    rerender(<DateRangePicker startDate={null} endDate={null} placeholder="Pick a date range" />)
+    expect(screen.getByText('Pick a date range')).toBeInTheDocument()
   })
 })
 
@@ -391,6 +433,33 @@ describe('DateTimePicker', () => {
     const { container } = render(<DateTimePicker />)
     expect(await axe(container)).toHaveNoViolations()
   })
+
+  it('disables dates outside minDate/maxDate', async () => {
+    const user = userEvent.setup()
+    render(
+      <DateTimePicker
+        value={new Date(2026, 2, 15, 10, 0)}
+        minDate={new Date(2026, 2, 5)}
+        maxDate={new Date(2026, 2, 25)}
+      />,
+    )
+    await user.click(screen.getByRole('button'))
+    expect(
+      screen.getByRole('gridcell', { name: 'Wednesday, March 4, 2026' }),
+    ).toHaveAttribute('aria-disabled', 'true')
+    expect(
+      screen.getByRole('gridcell', { name: 'Thursday, March 26, 2026' }),
+    ).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  it('clearing the value (controlled) reverts to the placeholder', () => {
+    const { rerender } = render(
+      <DateTimePicker value={new Date(2026, 2, 15, 14, 30)} placeholder="Pick date & time" />,
+    )
+    expect(screen.getByText('Mar 15, 2026 2:30 PM')).toBeInTheDocument()
+    rerender(<DateTimePicker value={null} placeholder="Pick date & time" />)
+    expect(screen.getByText('Pick date & time')).toBeInTheDocument()
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -504,6 +573,84 @@ describe('CalendarGrid', () => {
     expect(onMonthChange).toHaveBeenCalledOnce()
     const newMonth: Date = onMonthChange.mock.calls[0][0]
     expect(newMonth.getMonth()).toBe(3) // April
+  })
+
+  it('moves focus one day right on ArrowRight', async () => {
+    const user = userEvent.setup()
+    render(<CalendarGrid {...baseProps} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByRole('gridcell', { name: 'Wednesday, March 11, 2026' })).toHaveFocus()
+  })
+
+  it('moves focus one day left on ArrowLeft', async () => {
+    const user = userEvent.setup()
+    render(<CalendarGrid {...baseProps} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(screen.getByRole('gridcell', { name: 'Monday, March 9, 2026' })).toHaveFocus()
+  })
+
+  it('moves focus one week down on ArrowDown and up on ArrowUp', async () => {
+    const user = userEvent.setup()
+    render(<CalendarGrid {...baseProps} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard('{ArrowDown}')
+    expect(screen.getByRole('gridcell', { name: 'Tuesday, March 17, 2026' })).toHaveFocus()
+    await user.keyboard('{ArrowUp}')
+    expect(screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })).toHaveFocus()
+  })
+
+  it('Home moves focus to the first day of the month, End to the last', async () => {
+    const user = userEvent.setup()
+    render(<CalendarGrid {...baseProps} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard('{Home}')
+    expect(screen.getByRole('gridcell', { name: 'Sunday, March 1, 2026' })).toHaveFocus()
+    await user.keyboard('{End}')
+    expect(screen.getByRole('gridcell', { name: 'Tuesday, March 31, 2026' })).toHaveFocus()
+  })
+
+  it('Enter selects the focused day', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<CalendarGrid {...baseProps} onSelect={onSelect} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard('{Enter}')
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(onSelect.mock.calls[0][0].getDate()).toBe(10)
+  })
+
+  it('Space selects the focused day', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<CalendarGrid {...baseProps} onSelect={onSelect} />)
+    const day10 = screen.getByRole('gridcell', { name: 'Tuesday, March 10, 2026' })
+    day10.focus()
+    await user.keyboard(' ')
+    expect(onSelect).toHaveBeenCalledOnce()
+    expect(onSelect.mock.calls[0][0].getDate()).toBe(10)
+  })
+
+  it('does not select a disabled day on Enter', () => {
+    const onSelect = vi.fn()
+    render(
+      <CalendarGrid
+        {...baseProps}
+        onSelect={onSelect}
+        minDate={new Date(2026, 2, 5)}
+      />,
+    )
+    // Day 4 is disabled (before minDate) — dispatch Enter directly on it,
+    // since a native `disabled` button can't receive real keyboard focus.
+    const day4 = screen.getByRole('gridcell', { name: 'Wednesday, March 4, 2026' })
+    fireEvent.keyDown(day4, { key: 'Enter' })
+    expect(onSelect).not.toHaveBeenCalled()
   })
 
   it('hides prev/next nav when told to', () => {

--- a/packages/core/src/composed/diff.stories.tsx
+++ b/packages/core/src/composed/diff.stories.tsx
@@ -100,6 +100,37 @@ export const Fields: Story = {
   args: { before: jsonBefore, after: jsonAfter, mode: 'fields' },
 }
 
+export const SyntaxHighlighted: Story = {
+  name: 'Syntax highlighted (language)',
+  args: { before: configBefore, after: configAfter, mode: 'split', language: 'yaml' },
+}
+
+export const FieldsParseErrors: Story = {
+  name: 'Fields — invalid JSON (default + custom slots)',
+  render: () => (
+    <div style={{ maxWidth: 640, display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-surface-fg-subtle)', marginBottom: 8 }}>
+          Default fallback message
+        </div>
+        <Diff before="not valid json" after={jsonAfter} mode="fields" />
+      </div>
+      <div>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-surface-fg-subtle)', marginBottom: 8 }}>
+          Custom beforeParseError / afterParseError
+        </div>
+        <Diff
+          before="not valid json"
+          after="also not valid"
+          mode="fields"
+          beforeParseError={(raw) => <span>Committed value isn&rsquo;t JSON: {raw}</span>}
+          afterParseError={(raw) => <span>Pending value isn&rsquo;t JSON: {raw}</span>}
+        />
+      </div>
+    </div>
+  ),
+}
+
 export const SplitWordHighlight: Story = {
   name: 'Split + intra-line words',
   args: { before: proseBefore, after: proseAfter, mode: 'split', granularity: 'line' },

--- a/packages/core/src/composed/diff.test.tsx
+++ b/packages/core/src/composed/diff.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { Diff } from './diff'
+
+const mockUseReducedMotion = vi.fn(() => false)
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
+  return { ...actual, useReducedMotion: () => mockUseReducedMotion() }
+})
+
+describe('Diff', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Diff before="a" after="b" />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('merges className', () => {
+    const { container } = render(<Diff before="a" after="b" className="custom" />)
+    expect(container.firstChild).toHaveClass('custom')
+  })
+
+  it('forwards ref', () => {
+    const ref = React.createRef<HTMLDivElement>()
+    render(<Diff before="a" after="b" ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<Diff before="line one\nline two" after="line one\nline three" />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  describe('inline mode (default)', () => {
+    it('shows the +N / -N / change-count summary', () => {
+      render(<Diff before="a\nb\nc" after="a\nx\nc" />)
+      expect(screen.getByText('1 change')).toBeInTheDocument()
+    })
+
+    it('shows "No changes" when before equals after', () => {
+      render(<Diff before="same" after="same" />)
+      expect(screen.getByText('No changes')).toBeInTheDocument()
+    })
+
+    it('hides the summary when showSummary is false', () => {
+      render(<Diff before="a" after="b" showSummary={false} />)
+      expect(screen.queryByText(/change/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('split mode', () => {
+    it('shows column labels', () => {
+      render(<Diff before="a" after="b" mode="split" />)
+      expect(screen.getByText('Committed')).toBeInTheDocument()
+      expect(screen.getByText('Pending')).toBeInTheDocument()
+    })
+
+    it('respects custom beforeLabel/afterLabel', () => {
+      render(<Diff before="a" after="b" mode="split" beforeLabel="Old" afterLabel="New" />)
+      expect(screen.getByText('Old')).toBeInTheDocument()
+      expect(screen.getByText('New')).toBeInTheDocument()
+    })
+  })
+
+  describe('fields mode', () => {
+    it('renders added/removed/changed field rows', () => {
+      const before = JSON.stringify({ a: 1, b: 2 })
+      const after = JSON.stringify({ a: 1, b: 3, c: 4 })
+      render(<Diff before={before} after={after} mode="fields" />)
+      expect(screen.getByText('b')).toBeInTheDocument()
+      expect(screen.getByText('c')).toBeInTheDocument()
+      expect(screen.getByText('Changed')).toBeInTheDocument()
+      expect(screen.getByText('Added')).toBeInTheDocument()
+    })
+
+    it('shows "No field changes." when JSON is identical', () => {
+      const json = JSON.stringify({ a: 1 })
+      render(<Diff before={json} after={json} mode="fields" />)
+      expect(screen.getByText('No field changes.')).toBeInTheDocument()
+    })
+
+    it('shows a default error message when before fails to parse', () => {
+      render(<Diff before="not json" after={JSON.stringify({ a: 1 })} mode="fields" />)
+      expect(screen.getByText('Fields mode needs valid before JSON.')).toBeInTheDocument()
+    })
+
+    it('shows a default error message when after fails to parse', () => {
+      render(<Diff before={JSON.stringify({ a: 1 })} after="not json" mode="fields" />)
+      expect(screen.getByText('Fields mode needs valid after JSON.')).toBeInTheDocument()
+    })
+
+    it('shows both default error messages when both sides fail to parse', () => {
+      render(<Diff before="nope" after="nope either" mode="fields" />)
+      expect(screen.getByText('Fields mode needs valid before JSON.')).toBeInTheDocument()
+      expect(screen.getByText('Fields mode needs valid after JSON.')).toBeInTheDocument()
+    })
+
+    it('uses a custom beforeParseError render function', () => {
+      render(
+        <Diff
+          before="bad"
+          after={JSON.stringify({ a: 1 })}
+          mode="fields"
+          beforeParseError={(raw) => <span>Custom before error: {raw}</span>}
+        />,
+      )
+      expect(screen.getByText('Custom before error: bad')).toBeInTheDocument()
+      expect(screen.queryByText('Fields mode needs valid before JSON.')).not.toBeInTheDocument()
+    })
+
+    it('uses a custom afterParseError render function', () => {
+      render(
+        <Diff
+          before={JSON.stringify({ a: 1 })}
+          after="bad"
+          mode="fields"
+          afterParseError={(raw) => <span>Custom after error: {raw}</span>}
+        />,
+      )
+      expect(screen.getByText('Custom after error: bad')).toBeInTheDocument()
+      expect(screen.queryByText('Fields mode needs valid after JSON.')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('collapse/expand', () => {
+    const manyContextLines = Array.from({ length: 10 }, (_, i) => `context ${i}`).join('\n')
+    const before = `${manyContextLines}\nold line`
+    const after = `${manyContextLines}\nnew line`
+
+    it('collapses long unchanged runs behind an expander by default', () => {
+      render(<Diff before={before} after={after} />)
+      expect(screen.getByText(/Expand \d+ unchanged lines?/)).toBeInTheDocument()
+    })
+
+    it('expands hidden lines when the expander is clicked', async () => {
+      render(<Diff before={before} after={after} />)
+      const expandButton = screen.getByText(/Expand \d+ unchanged lines?/)
+      expandButton.click()
+      await waitFor(() => {
+        expect(screen.getByText('context 0')).toBeInTheDocument()
+      })
+    })
+
+    it('never collapses when collapseUnchanged is false', () => {
+      render(<Diff before={before} after={after} collapseUnchanged={false} />)
+      expect(screen.queryByText(/Expand \d+ unchanged lines?/)).not.toBeInTheDocument()
+      expect(screen.getByText('context 0')).toBeInTheDocument()
+    })
+
+    it('respects a custom collapseThreshold', () => {
+      render(<Diff before={before} after={after} collapseThreshold={20} />)
+      expect(screen.queryByText(/Expand \d+ unchanged lines?/)).not.toBeInTheDocument()
+    })
+
+    it('expands under reduced motion too', async () => {
+      mockUseReducedMotion.mockReturnValue(true)
+      render(<Diff before={before} after={after} />)
+      const expandButton = screen.getByText(/Expand \d+ unchanged lines?/)
+      expandButton.click()
+      await waitFor(() => {
+        expect(screen.getByText('context 0')).toBeInTheDocument()
+      })
+      mockUseReducedMotion.mockReturnValue(false)
+    })
+  })
+
+  describe('accept/reject callbacks', () => {
+    it('does not render controls when neither callback is provided', () => {
+      render(<Diff before="a" after="b" />)
+      expect(screen.queryByLabelText(/Accept change/)).not.toBeInTheDocument()
+      expect(screen.queryByLabelText(/Reject change/)).not.toBeInTheDocument()
+    })
+
+    it('calls onAcceptHunk with the hunk on click', () => {
+      const onAcceptHunk = vi.fn()
+      render(<Diff before="a" after="b" onAcceptHunk={onAcceptHunk} />)
+      screen.getByLabelText('Accept change 1').click()
+      expect(onAcceptHunk).toHaveBeenCalledWith({ index: 0, before: 'a', after: 'b' })
+    })
+
+    it('calls onRejectHunk with the hunk on click', () => {
+      const onRejectHunk = vi.fn()
+      render(<Diff before="a" after="b" onRejectHunk={onRejectHunk} />)
+      screen.getByLabelText('Reject change 1').click()
+      expect(onRejectHunk).toHaveBeenCalledWith({ index: 0, before: 'a', after: 'b' })
+    })
+  })
+
+  describe('word granularity', () => {
+    it('renders added/removed words as marks', () => {
+      const { container } = render(<Diff before="the quick fox" after="the slow fox" granularity="word" />)
+      const marks = container.querySelectorAll('mark')
+      expect(marks.length).toBeGreaterThan(0)
+    })
+
+    it('counts diff groups, not lines, for the change count', () => {
+      render(<Diff before="the quick fox" after="the slow fox" granularity="word" />)
+      expect(screen.getByText('2 changes')).toBeInTheDocument()
+    })
+  })
+
+  describe('language (syntax highlighting)', () => {
+    it('still renders the line text with a language set', async () => {
+      render(<Diff before="const a = 1;" after="const a = 2;" language="typescript" />)
+      await waitFor(() => {
+        expect(screen.getByText((_, node) => node?.textContent === 'const a = 1;')).toBeInTheDocument()
+      })
+      expect(screen.getByText((_, node) => node?.textContent === 'const a = 2;')).toBeInTheDocument()
+    })
+
+    it('has no effect on word granularity', () => {
+      const { container } = render(
+        <Diff before="the quick fox" after="the slow fox" granularity="word" language="typescript" />,
+      )
+      expect(container.textContent).toContain('quick')
+      expect(container.textContent).toContain('slow')
+    })
+
+    it('has no effect on fields mode', () => {
+      const before = JSON.stringify({ a: 1 })
+      const after = JSON.stringify({ a: 2 })
+      render(<Diff before={before} after={after} mode="fields" language="json" />)
+      expect(screen.getByText('a')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/core/src/composed/diff.tsx
+++ b/packages/core/src/composed/diff.tsx
@@ -9,6 +9,52 @@ import { Button } from '../ui/button'
 import { Icon } from '../ui/icon'
 import { cn } from '../ui/lib/utils'
 
+// Shared lazy-loaded module cache — same lazy-load + one-dark theme pattern as
+// MarkdownViewer's CodeBlock, so multiple highlighted lines only fetch once.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let highlighterPromise: Promise<{ Highlighter: any; style: any }> | null = null
+function loadHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = Promise.all([
+      import('react-syntax-highlighter'),
+      import('react-syntax-highlighter/dist/esm/styles/prism/one-dark'),
+    ]).then(([hlMod, styleMod]) => ({
+      Highlighter: hlMod.Prism ?? hlMod.default,
+      style: styleMod.default,
+    }))
+  }
+  return highlighterPromise
+}
+
+/** A single syntax-highlighted line. Falls back to plain text until the highlighter loads. */
+function CodeText({ language, text }: { language?: string; text: string }) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [modules, setModules] = React.useState<{ Highlighter: any; style: any } | null>(null)
+
+  React.useEffect(() => {
+    if (!language) return
+    let cancelled = false
+    loadHighlighter().then((m) => { if (!cancelled) setModules(m) }).catch(() => { /* fallback to plain text */ })
+    return () => { cancelled = true }
+  }, [language])
+
+  if (!language || !modules) return <>{text || ' '}</>
+
+  const { Highlighter, style } = modules
+  return (
+    <Highlighter
+      language={language}
+      style={style}
+      PreTag="span"
+      CodeTag="span"
+      customStyle={{ margin: 0, padding: 0, background: 'transparent', display: 'inline' }}
+      codeTagProps={{ style: { background: 'transparent' } }}
+    >
+      {text || ' '}
+    </Highlighter>
+  )
+}
+
 /** Animates newly-revealed unchanged rows open (height + fade). Instant under reduced-motion. */
 function Reveal({ children }: { children: React.ReactNode }) {
   const reduce = useReducedMotion()
@@ -78,6 +124,24 @@ export interface DiffProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'o
   onAcceptHunk?: (hunk: DiffHunk) => void
   /** When provided, each hunk shows a Reject control. */
   onRejectHunk?: (hunk: DiffHunk) => void
+  /**
+   * Syntax-highlight full (non-word-diff) lines as this language. Lazy-loads
+   * `react-syntax-highlighter` with the same one-dark theme as `MarkdownViewer`,
+   * falling back to plain text until it resolves. Only affects `line`
+   * granularity in `inline`/`split` modes — ignored for `word` granularity
+   * (already word-highlighted) and `fields` mode (structured, not code).
+   */
+  language?: string
+  /**
+   * Custom render for a `before` value that fails to parse as JSON in
+   * `fields` mode. Receives the raw string. @default a plain error message
+   */
+  beforeParseError?: (raw: string) => React.ReactNode
+  /**
+   * Custom render for an `after` value that fails to parse as JSON in
+   * `fields` mode. Receives the raw string. @default a plain error message
+   */
+  afterParseError?: (raw: string) => React.ReactNode
 }
 
 // ------------------------------- row model ---------------------------------
@@ -214,6 +278,7 @@ function InlineRows({
   onExpand,
   onAcceptHunk,
   onRejectHunk,
+  language,
 }: {
   segs: RenderItem[]
   collapsibles: Map<number, Row[]>
@@ -221,6 +286,7 @@ function InlineRows({
   onExpand: (i: number) => void
   onAcceptHunk?: (h: DiffHunk) => void
   onRejectHunk?: (h: DiffHunk) => void
+  language?: string
 }) {
   const hasReview = !!onAcceptHunk || !!onRejectHunk
   return (
@@ -231,7 +297,7 @@ function InlineRows({
           if (expanded.has(item.key)) {
             return (
               <Reveal key={`reveal-${item.key}`}>
-                {hidden.map((r) => <CtxLine key={`${item.key}-${r.oldNo}`} row={r} split={false} />)}
+                {hidden.map((r) => <CtxLine key={`${item.key}-${r.oldNo}`} row={r} split={false} language={language} />)}
               </Reveal>
             )
           }
@@ -247,7 +313,7 @@ function InlineRows({
             </button>
           )
         }
-        if (item.t === 'ctx') return <CtxLine key={`c-${i}`} row={item.row} split={false} />
+        if (item.t === 'ctx') return <CtxLine key={`c-${i}`} row={item.row} split={false} language={language} />
         // change block
         return (
           <div key={`h-${i}`} className="group relative">
@@ -256,7 +322,7 @@ function InlineRows({
                 <span className={cn(GUTTER, 'min-w-[3.5ch]')}>{r.oldNo}</span>
                 <span className={cn(GUTTER, 'min-w-[3.5ch] text-error-11/60')} />
                 <span className={cn(SIGN, 'text-error-11')}>&minus;</span>
-                <span className={cn(CELL, 'flex-1 text-error-11')}>{r.text || ' '}</span>
+                <span className={cn(CELL, 'flex-1 text-error-11')}>{language ? <CodeText language={language} text={r.text} /> : (r.text || ' ')}</span>
               </div>
             ))}
             {item.adds.map((r, j) => (
@@ -264,7 +330,7 @@ function InlineRows({
                 <span className={cn(GUTTER, 'min-w-[3.5ch] text-success-11/60')} />
                 <span className={cn(GUTTER, 'min-w-[3.5ch]')}>{r.newNo}</span>
                 <span className={cn(SIGN, 'text-success-11')}>+</span>
-                <span className={cn(CELL, 'flex-1 text-success-11')}>{r.text || ' '}</span>
+                <span className={cn(CELL, 'flex-1 text-success-11')}>{language ? <CodeText language={language} text={r.text} /> : (r.text || ' ')}</span>
               </div>
             ))}
             {hasReview && (
@@ -279,13 +345,15 @@ function InlineRows({
   )
 }
 
-function CtxLine({ row, split }: { row: Row; split: boolean }) {
+function CtxLine({ row, split, language }: { row: Row; split: boolean; language?: string }) {
   return (
     <div className="flex bg-surface-raised">
       <span className={cn(GUTTER, 'min-w-[3.5ch]')}>{row.oldNo}</span>
       {!split && <span className={cn(GUTTER, 'min-w-[3.5ch]')}>{row.newNo}</span>}
       <span className={cn(SIGN, 'text-surface-fg-subtle')}>&nbsp;</span>
-      <span className={cn(CELL, 'flex-1 text-surface-fg-muted')}>{row.text || ' '}</span>
+      <span className={cn(CELL, 'flex-1 text-surface-fg-muted')}>
+        {language ? <CodeText language={language} text={row.text} /> : (row.text || ' ')}
+      </span>
     </div>
   )
 }
@@ -297,6 +365,7 @@ function SplitRows({
   onExpand,
   onAcceptHunk,
   onRejectHunk,
+  language,
 }: {
   segs: RenderItem[]
   collapsibles: Map<number, Row[]>
@@ -304,6 +373,7 @@ function SplitRows({
   onExpand: (i: number) => void
   onAcceptHunk?: (h: DiffHunk) => void
   onRejectHunk?: (h: DiffHunk) => void
+  language?: string
 }) {
   const hasReview = !!onAcceptHunk || !!onRejectHunk
   const sideCell = (no: number | undefined, node: React.ReactNode, tone: string, sign: string) => (
@@ -323,8 +393,8 @@ function SplitRows({
               <Reveal key={`reveal-${item.key}`}>
                 {hidden.map((r) => (
                   <div key={`${item.key}-${r.oldNo}`} className="flex divide-x divide-surface-border-subtle/30">
-                    {sideCell(r.oldNo, r.text || ' ', 'bg-surface-raised text-surface-fg-muted', ' ')}
-                    {sideCell(r.newNo, r.text || ' ', 'bg-surface-raised text-surface-fg-muted', ' ')}
+                    {sideCell(r.oldNo, language ? <CodeText language={language} text={r.text} /> : (r.text || ' '), 'bg-surface-raised text-surface-fg-muted', ' ')}
+                    {sideCell(r.newNo, language ? <CodeText language={language} text={r.text} /> : (r.text || ' '), 'bg-surface-raised text-surface-fg-muted', ' ')}
                   </div>
                 ))}
               </Reveal>
@@ -346,8 +416,8 @@ function SplitRows({
           const r = item.row
           return (
             <div key={`c-${i}`} className="flex divide-x divide-surface-border-subtle/30">
-              {sideCell(r.oldNo, r.text || ' ', 'bg-surface-raised text-surface-fg-muted', ' ')}
-              {sideCell(r.newNo, r.text || ' ', 'bg-surface-raised text-surface-fg-muted', ' ')}
+              {sideCell(r.oldNo, language ? <CodeText language={language} text={r.text} /> : (r.text || ' '), 'bg-surface-raised text-surface-fg-muted', ' ')}
+              {sideCell(r.newNo, language ? <CodeText language={language} text={r.text} /> : (r.text || ' '), 'bg-surface-raised text-surface-fg-muted', ' ')}
             </div>
           )
         }
@@ -358,8 +428,8 @@ function SplitRows({
             {Array.from({ length: n }, (_, k) => {
               const d = item.dels[k]
               const a = item.adds[k]
-              let leftNode: React.ReactNode = d ? d.text || ' ' : ''
-              let rightNode: React.ReactNode = a ? a.text || ' ' : ''
+              let leftNode: React.ReactNode = d ? (language ? <CodeText language={language} text={d.text} /> : (d.text || ' ')) : ''
+              let rightNode: React.ReactNode = a ? (language ? <CodeText language={language} text={a.text} /> : (a.text || ' ')) : ''
               if (d && a) {
                 const w = inlineWords(d.text, a.text)
                 leftNode = w.left
@@ -477,14 +547,26 @@ function flatten(obj: unknown, prefix = '', out: Record<string, string> = {}): R
   return out
 }
 
-function fieldChanges(before: string, after: string): { changes: FieldChange[]; error: string | null } {
+function fieldChanges(
+  before: string,
+  after: string,
+): { changes: FieldChange[]; beforeError: boolean; afterError: boolean } {
   let a: unknown
   let b: unknown
+  let beforeError = false
+  let afterError = false
   try {
     a = JSON.parse(before)
+  } catch {
+    beforeError = true
+  }
+  try {
     b = JSON.parse(after)
   } catch {
-    return { changes: [], error: 'Fields mode needs valid JSON on both sides.' }
+    afterError = true
+  }
+  if (beforeError || afterError) {
+    return { changes: [], beforeError, afterError }
   }
   const fa = flatten(a)
   const fb = flatten(b)
@@ -497,7 +579,7 @@ function fieldChanges(before: string, after: string): { changes: FieldChange[]; 
     else if (!inA && inB) changes.push({ path, kind: 'added', after: fb[path] })
     else if (fa[path] !== fb[path]) changes.push({ path, kind: 'changed', before: fa[path], after: fb[path] })
   }
-  return { changes, error: null }
+  return { changes, beforeError: false, afterError: false }
 }
 
 function FieldsDiff({
@@ -505,16 +587,25 @@ function FieldsDiff({
   after,
   onAcceptHunk,
   onRejectHunk,
+  beforeParseError,
+  afterParseError,
 }: {
   before: string
   after: string
   onAcceptHunk?: (h: DiffHunk) => void
   onRejectHunk?: (h: DiffHunk) => void
+  beforeParseError?: (raw: string) => React.ReactNode
+  afterParseError?: (raw: string) => React.ReactNode
 }) {
-  const { changes, error } = React.useMemo(() => fieldChanges(before, after), [before, after])
+  const { changes, beforeError, afterError } = React.useMemo(() => fieldChanges(before, after), [before, after])
   const hasReview = !!onAcceptHunk || !!onRejectHunk
-  if (error) {
-    return <div className="bg-surface-raised px-ds-04 py-ds-03 text-body-sm text-error-11">{error}</div>
+  if (beforeError || afterError) {
+    return (
+      <div className="flex flex-col gap-ds-02 bg-surface-raised px-ds-04 py-ds-03 text-body-sm text-error-11">
+        {beforeError && (beforeParseError ? beforeParseError(before) : <span>Fields mode needs valid before JSON.</span>)}
+        {afterError && (afterParseError ? afterParseError(after) : <span>Fields mode needs valid after JSON.</span>)}
+      </div>
+    )
   }
   if (changes.length === 0) {
     return <div className="bg-surface-raised px-ds-04 py-ds-03 text-body-sm text-surface-fg-subtle">No field changes.</div>
@@ -577,6 +668,9 @@ interface DiffModel {
   onExpand: (k: number) => void
   onAcceptHunk?: (h: DiffHunk) => void
   onRejectHunk?: (h: DiffHunk) => void
+  language?: string
+  beforeParseError?: (raw: string) => React.ReactNode
+  afterParseError?: (raw: string) => React.ReactNode
 }
 
 const DiffContext = React.createContext<DiffModel | null>(null)
@@ -602,6 +696,9 @@ export interface DiffRootProps
     | 'afterLabel'
     | 'onAcceptHunk'
     | 'onRejectHunk'
+    | 'language'
+    | 'beforeParseError'
+    | 'afterParseError'
   > {
   children: React.ReactNode
 }
@@ -622,6 +719,9 @@ function DiffRoot({
   afterLabel = 'Pending',
   onAcceptHunk,
   onRejectHunk,
+  language,
+  beforeParseError,
+  afterParseError,
   children,
 }: DiffRootProps) {
   const [expanded, setExpanded] = React.useState<Set<number>>(() => new Set())
@@ -687,6 +787,9 @@ function DiffRoot({
     onExpand,
     onAcceptHunk,
     onRejectHunk,
+    language,
+    beforeParseError,
+    afterParseError,
   }
 
   return <DiffContext.Provider value={model}>{children}</DiffContext.Provider>
@@ -716,13 +819,20 @@ function DiffBody({ className }: { className?: string }) {
   return (
     <div className={cn('overflow-x-auto', className)}>
       {m.mode === 'fields' ? (
-        <FieldsDiff before={m.before} after={m.after} onAcceptHunk={m.onAcceptHunk} onRejectHunk={m.onRejectHunk} />
+        <FieldsDiff
+          before={m.before}
+          after={m.after}
+          onAcceptHunk={m.onAcceptHunk}
+          onRejectHunk={m.onRejectHunk}
+          beforeParseError={m.beforeParseError}
+          afterParseError={m.afterParseError}
+        />
       ) : m.isWord ? (
         <WordDiff before={m.before} after={m.after} />
       ) : m.mode === 'split' ? (
-        <SplitRows segs={m.items} collapsibles={m.collapsibles} expanded={m.expanded} onExpand={m.onExpand} onAcceptHunk={m.onAcceptHunk} onRejectHunk={m.onRejectHunk} />
+        <SplitRows segs={m.items} collapsibles={m.collapsibles} expanded={m.expanded} onExpand={m.onExpand} onAcceptHunk={m.onAcceptHunk} onRejectHunk={m.onRejectHunk} language={m.language} />
       ) : (
-        <InlineRows segs={m.items} collapsibles={m.collapsibles} expanded={m.expanded} onExpand={m.onExpand} onAcceptHunk={m.onAcceptHunk} onRejectHunk={m.onRejectHunk} />
+        <InlineRows segs={m.items} collapsibles={m.collapsibles} expanded={m.expanded} onExpand={m.onExpand} onAcceptHunk={m.onAcceptHunk} onRejectHunk={m.onRejectHunk} language={m.language} />
       )}
     </div>
   )
@@ -744,6 +854,9 @@ const Diff = React.forwardRef<HTMLDivElement, DiffProps>(function Diff(
     afterLabel = 'Pending',
     onAcceptHunk,
     onRejectHunk,
+    language,
+    beforeParseError,
+    afterParseError,
     className,
     ...props
   },
@@ -767,6 +880,9 @@ const Diff = React.forwardRef<HTMLDivElement, DiffProps>(function Diff(
         afterLabel={afterLabel}
         onAcceptHunk={onAcceptHunk}
         onRejectHunk={onRejectHunk}
+        language={language}
+        beforeParseError={beforeParseError}
+        afterParseError={afterParseError}
       >
         {(showSummary || mode === 'split') && (
           <div className="flex items-center justify-between gap-ds-03 border-b border-surface-border-subtle/30 bg-surface-raised px-ds-04 py-ds-02">

--- a/packages/core/src/hooks/__tests__/use-viewport-height.test.ts
+++ b/packages/core/src/hooks/__tests__/use-viewport-height.test.ts
@@ -1,10 +1,127 @@
-import { renderHook } from '@testing-library/react'
+import { act, renderHook } from '@testing-library/react'
 
 import { useViewportHeight } from '../use-viewport-height'
 
 describe('useViewportHeight', () => {
+  afterEach(() => {
+    // Ensure no test's window/visualViewport mocking leaks into the next test.
+    // @ts-expect-error - visualViewport is not writable in the lib.dom types
+    delete window.visualViewport
+    vi.restoreAllMocks()
+  })
+
   it('returns window.innerHeight in jsdom', () => {
     const { result } = renderHook(() => useViewportHeight())
     expect(result.current).toBe(window.innerHeight)
+  })
+
+  it('falls back to window.innerHeight when visualViewport is unavailable (SSR-like/older-browser case)', () => {
+    // @ts-expect-error - visualViewport is not writable in the lib.dom types
+    delete window.visualViewport
+    expect(window.visualViewport).toBeUndefined()
+
+    Object.defineProperty(window, 'innerHeight', {
+      value: 742,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useViewportHeight())
+
+    // The hook's initial state is 0 (SSR-safe), but React effects flush
+    // synchronously before renderHook returns in this environment, so by
+    // the time we can observe `result.current` the fallback to
+    // window.innerHeight has already settled.
+    expect(result.current).toBe(742)
+  })
+
+  it('subscribes to Visual Viewport resize events and updates height', () => {
+    const listeners: Record<string, () => void> = {}
+    const fakeVisualViewport = {
+      height: 500,
+      addEventListener: vi.fn((event: string, listener: () => void) => {
+        listeners[event] = listener
+      }),
+      removeEventListener: vi.fn(),
+    }
+
+    Object.defineProperty(window, 'visualViewport', {
+      value: fakeVisualViewport,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() => useViewportHeight())
+
+    expect(result.current).toBe(500)
+    expect(fakeVisualViewport.addEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
+
+    fakeVisualViewport.height = 350
+    act(() => {
+      listeners.resize()
+    })
+
+    expect(result.current).toBe(350)
+  })
+
+  it('falls back to window resize events when visualViewport is absent', () => {
+    // @ts-expect-error - visualViewport is not writable in the lib.dom types
+    delete window.visualViewport
+    expect(window.visualViewport).toBeUndefined()
+
+    const { result } = renderHook(() => useViewportHeight())
+
+    Object.defineProperty(window, 'innerHeight', {
+      value: 900,
+      configurable: true,
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(result.current).toBe(900)
+  })
+
+  it('removes the Visual Viewport resize listener on unmount', () => {
+    const fakeVisualViewport = {
+      height: 500,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }
+
+    Object.defineProperty(window, 'visualViewport', {
+      value: fakeVisualViewport,
+      configurable: true,
+    })
+
+    const { unmount } = renderHook(() => useViewportHeight())
+
+    expect(fakeVisualViewport.removeEventListener).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(fakeVisualViewport.removeEventListener).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
+  })
+
+  it('removes the window resize listener on unmount when visualViewport is absent', () => {
+    // @ts-expect-error - visualViewport is not writable in the lib.dom types
+    delete window.visualViewport
+    expect(window.visualViewport).toBeUndefined()
+
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = renderHook(() => useViewportHeight())
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function),
+    )
   })
 })

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -8,6 +8,7 @@ export type {
   UploadFile,
 } from '../ui/toast-types'
 export { type ColorMode,useColorMode } from './use-color-mode'
+export { type ContainerSize,useContainerSize } from './use-container-size'
 export { useIsMobile } from './use-mobile'
 export { useTouchDevice } from './use-touch-device'
 export { useViewportHeight } from './use-viewport-height'

--- a/packages/core/src/hooks/use-container-size.ts
+++ b/packages/core/src/hooks/use-container-size.ts
@@ -1,0 +1,44 @@
+'use client'
+
+import * as React from 'react'
+
+export interface ContainerSize {
+  width: number
+  height: number
+}
+
+/**
+ * Tracks an element's content-box size via `ResizeObserver`. Attach the
+ * returned `ref` to the element you want to measure.
+ *
+ * SSR-safe: returns `{ width: 0, height: 0 }` until the ref is attached and
+ * the observer fires.
+ */
+export function useContainerSize<T extends Element = HTMLDivElement>(): {
+  ref: React.RefCallback<T>
+  width: number
+  height: number
+} {
+  const [size, setSize] = React.useState<ContainerSize>({ width: 0, height: 0 })
+  const elementRef = React.useRef<T | null>(null)
+  const observerRef = React.useRef<ResizeObserver | null>(null)
+
+  const ref = React.useCallback((node: T | null) => {
+    observerRef.current?.disconnect()
+    elementRef.current = node
+    if (!node) return
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      setSize((prev) => (prev.width === width && prev.height === height ? prev : { width, height }))
+    })
+    observer.observe(node)
+    observerRef.current = observer
+  }, [])
+
+  React.useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  return { ref, width: size.width, height: size.height }
+}

--- a/packages/core/src/shell/__tests__/notification-preferences.test.tsx
+++ b/packages/core/src/shell/__tests__/notification-preferences.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../ui/dialog', () => ({
   DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }))
 
-import { NotificationPreferences } from '../notification-preferences'
+import { type NotificationPreference,NotificationPreferences } from '../notification-preferences'
 
 describe('NotificationPreferences', () => {
   it('renders without crashing', () => {
@@ -45,5 +45,53 @@ describe('NotificationPreferences', () => {
   it('spreads props', () => {
     const { container } = render(<NotificationPreferences data-testid="np" />)
     expect(container.firstChild).toHaveAttribute('data-testid', 'np')
+  })
+
+  it('calls onSave with the default new-rule shape when Save Rule is clicked', () => {
+    const onSave = vi.fn()
+    render(<NotificationPreferences onSave={onSave} />)
+    screen.getByRole('button', { name: 'Save Rule' }).click()
+    expect(onSave).toHaveBeenCalledWith({
+      projectId: null,
+      channel: 'IN_APP',
+      minTier: 'INFO',
+      muted: false,
+    })
+  })
+
+  it('calls onDelete with the preference id', () => {
+    const onDelete = vi.fn()
+    const preferences: NotificationPreference[] = [
+      { id: 'pref-1', projectId: null, channel: 'IN_APP', minTier: 'INFO', muted: false },
+    ]
+    render(<NotificationPreferences preferences={preferences} onDelete={onDelete} />)
+    screen.getByRole('button', { name: 'Delete In-App notification rule' }).click()
+    expect(onDelete).toHaveBeenCalledWith('pref-1')
+  })
+
+  it('calls onToggleMute with the preference', () => {
+    const onToggleMute = vi.fn()
+    const preferences: NotificationPreference[] = [
+      { id: 'pref-1', projectId: null, channel: 'IN_APP', minTier: 'INFO', muted: false },
+    ]
+    render(<NotificationPreferences preferences={preferences} onToggleMute={onToggleMute} />)
+    screen.getByRole('switch', { name: 'Mute In-App for Global (all projects)' }).click()
+    expect(onToggleMute).toHaveBeenCalledWith(preferences[0])
+  })
+
+  it('shows a loading spinner and hides the list when isLoading', () => {
+    const preferences: NotificationPreference[] = [
+      { id: 'pref-1', projectId: null, channel: 'IN_APP', minTier: 'INFO', muted: false },
+    ]
+    render(<NotificationPreferences preferences={preferences} isLoading />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Delete/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the empty-state message when there are no preferences', () => {
+    render(<NotificationPreferences preferences={[]} />)
+    expect(
+      screen.getByText('No custom preferences set. All notifications are delivered by default.'),
+    ).toBeInTheDocument()
   })
 })

--- a/packages/core/src/ui/__tests__/data-table-body.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-body.test.tsx
@@ -1,0 +1,372 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { DataTable } from '../data-table'
+
+// ============================================================
+// DataTableBody / CellEditInput — targeted coverage
+//
+// `CellEditInput` is not exported from data-table-body.tsx, so it is driven
+// through the public <DataTable editable /> surface, the same way
+// data-table-integration.test.tsx exercises the rest of DataTable's features.
+// See GitHub issue #268: inline cell edit, virtual row spacers, and expanded
+// rows had no test coverage.
+// ============================================================
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+interface Person {
+  name: string
+  email: string
+  role: string
+  age: number
+}
+
+const columns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  // enableEditing: false — must never enter edit mode, per DataTable's prop docs.
+  { accessorKey: 'role', header: 'Role', meta: { enableEditing: false } },
+  { accessorKey: 'age', header: 'Age' },
+]
+
+const data: Person[] = [
+  { name: 'Alice Smith', email: 'alice@example.com', role: 'Engineer', age: 28 },
+  { name: 'Bob Jones', email: 'bob@example.com', role: 'Designer', age: 34 },
+  { name: 'Carol White', email: 'carol@example.com', role: 'Manager', age: 42 },
+]
+
+// ============================================================
+// 1. Inline cell edit (Enter / Escape / blur)
+// ============================================================
+
+describe('DataTableBody — inline cell editing', () => {
+  it('double-click on an editable cell enters edit mode with an input pre-filled with the value', async () => {
+    render(<DataTable columns={columns} data={data} editable />)
+    const user = userEvent.setup()
+
+    expect(screen.queryByLabelText('Edit cell value')).not.toBeInTheDocument()
+
+    await user.dblClick(screen.getByText('Alice Smith'))
+
+    const input = screen.getByLabelText('Edit cell value')
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveValue('Alice Smith')
+  })
+
+  it('pressing Enter commits the edit and calls onCellEdit(rowIndex, columnId, value)', async () => {
+    const onCellEdit = vi.fn()
+    render(<DataTable columns={columns} data={data} editable onCellEdit={onCellEdit} />)
+    const user = userEvent.setup()
+
+    await user.dblClick(screen.getByText('Alice Smith'))
+    const input = screen.getByLabelText('Edit cell value')
+    await user.clear(input)
+    await user.type(input, 'Alice Cooper{Enter}')
+
+    expect(onCellEdit).toHaveBeenCalledTimes(1)
+    expect(onCellEdit).toHaveBeenCalledWith(0, 'name', 'Alice Cooper')
+    // Edit mode exits after commit
+    expect(screen.queryByLabelText('Edit cell value')).not.toBeInTheDocument()
+  })
+
+  it('pressing Escape cancels without calling onCellEdit and reverts to the original value', async () => {
+    const onCellEdit = vi.fn()
+    render(<DataTable columns={columns} data={data} editable onCellEdit={onCellEdit} />)
+    const user = userEvent.setup()
+
+    await user.dblClick(screen.getByText('Bob Jones'))
+    const input = screen.getByLabelText('Edit cell value')
+    await user.clear(input)
+    await user.type(input, 'Someone Else')
+    // Sanity: the input actually holds the typed (uncommitted) value before cancel
+    expect(input).toHaveValue('Someone Else')
+
+    await user.type(input, '{Escape}')
+
+    expect(onCellEdit).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText('Edit cell value')).not.toBeInTheDocument()
+    // DataTable never mutates its own `data` prop — since onCellEdit was never
+    // called (and the consumer never re-rendered with new data), the cell is
+    // back to showing the original, un-edited value.
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+    expect(screen.queryByText('Someone Else')).not.toBeInTheDocument()
+  })
+
+  it('blur commits the edit (calls onSave, same as Enter) — CellEditInput has no cancel-on-blur path', async () => {
+    const onCellEdit = vi.fn()
+    render(<DataTable columns={columns} data={data} editable onCellEdit={onCellEdit} />)
+    const user = userEvent.setup()
+
+    await user.dblClick(screen.getByText('Carol White'))
+    const input = screen.getByLabelText('Edit cell value')
+    await user.clear(input)
+    await user.type(input, 'Carol Danvers')
+
+    // Move focus away without pressing Enter/Escape — fires a native blur.
+    await user.tab()
+
+    expect(onCellEdit).toHaveBeenCalledTimes(1)
+    expect(onCellEdit).toHaveBeenCalledWith(2, 'name', 'Carol Danvers')
+    expect(screen.queryByLabelText('Edit cell value')).not.toBeInTheDocument()
+  })
+
+  it('double-click on a column with meta: { enableEditing: false } does not enter edit mode', async () => {
+    const onCellEdit = vi.fn()
+    render(<DataTable columns={columns} data={data} editable onCellEdit={onCellEdit} />)
+    const user = userEvent.setup()
+
+    // 'role' column is disabled for editing
+    await user.dblClick(screen.getAllByText('Engineer')[0])
+
+    expect(screen.queryByLabelText('Edit cell value')).not.toBeInTheDocument()
+    expect(onCellEdit).not.toHaveBeenCalled()
+  })
+
+  it('has no a11y violations while a cell is in edit mode', async () => {
+    const { container } = render(<DataTable columns={columns} data={data} editable />)
+    const user = userEvent.setup()
+
+    await user.dblClick(screen.getByText('Alice Smith'))
+    expect(screen.getByLabelText('Edit cell value')).toBeInTheDocument()
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ============================================================
+// 2. Expanded rows
+// ============================================================
+
+describe('DataTableBody — expanded rows', () => {
+  it('clicking a row expand toggle renders renderExpanded(row) content, toggling again collapses it', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        expandable
+        renderExpanded={(row) => <div data-testid={`detail-${row.name}`}>{row.email}</div>}
+      />,
+    )
+    const user = userEvent.setup()
+
+    expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument()
+
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    const detail = screen.getByTestId('detail-Alice Smith')
+    expect(detail).toBeInTheDocument()
+    // The Email column cell also renders this exact text — scope the query
+    // to the expanded detail panel to avoid an ambiguous multi-match.
+    expect(within(detail).getByText('alice@example.com')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Collapse row'))
+    // Collapse is animated (AnimatePresence exit) — wait for unmount
+    await waitFor(() =>
+      expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('singleExpand: expanding a second row collapses the first', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        expandable
+        singleExpand
+        renderExpanded={(row) => <div data-testid={`detail-${row.name}`}>{row.email}</div>}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    expect(screen.getByTestId('detail-Alice Smith')).toBeInTheDocument()
+
+    // Re-query: Alice's button is now "Collapse row", Bob's is the first "Expand row"
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    expect(screen.getByTestId('detail-Bob Jones')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByTestId('detail-Alice Smith')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('without singleExpand, multiple rows can be expanded at once', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        expandable
+        renderExpanded={(row) => <div data-testid={`detail-${row.name}`}>{row.email}</div>}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+    await user.click(screen.getAllByLabelText('Expand row')[0])
+
+    expect(screen.getByTestId('detail-Alice Smith')).toBeInTheDocument()
+    expect(screen.getByTestId('detail-Bob Jones')).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// 3. Virtual row spacers
+// ============================================================
+
+/**
+ * `@tanstack/react-virtual` reads `offsetHeight` for the scroll viewport and
+ * each measured row group, and bails out entirely when the viewport measures
+ * 0 — which is every element under jsdom. Without this stub a virtualized
+ * table renders only a <thead>, and no virtualization assertion is possible.
+ * Mirrors the stub already used in data-table-integration.test.tsx.
+ */
+function mockVirtualLayout({ viewport = 400, rowGroup = 48 } = {}) {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.tagName === 'TBODY') return rowGroup
+      if (this.style?.overflowY === 'auto') return viewport
+      return 0
+    },
+  })
+  return () => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original)
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight
+    }
+  }
+}
+
+const manyRows: Person[] = Array.from({ length: 60 }, (_, i) => ({
+  name: `Person ${i}`,
+  email: `person${i}@example.com`,
+  role: i % 2 === 0 ? 'Engineer' : 'Designer',
+  age: 20 + (i % 40),
+}))
+
+describe('DataTableBody — virtual row spacers', () => {
+  let restoreLayout: () => void
+
+  beforeEach(() => {
+    restoreLayout = mockVirtualLayout()
+  })
+  afterEach(() => {
+    restoreLayout()
+  })
+
+  it('windows a large dataset: fewer row groups render than total rows', () => {
+    const { container } = render(
+      <DataTable columns={columns} data={manyRows} virtualRows maxHeight={400} />,
+    )
+    const groups = container.querySelectorAll('tbody[data-index]')
+    // The whole point of virtualization: not every row is mounted at once.
+    expect(groups.length).toBeGreaterThan(0)
+    expect(groups.length).toBeLessThan(manyRows.length)
+  })
+
+  it('reserves the un-rendered remainder with a non-zero spacer row group', () => {
+    const { container } = render(
+      <DataTable columns={columns} data={manyRows} virtualRows maxHeight={400} />,
+    )
+    const spacers = container.querySelectorAll('tbody[aria-hidden="true"]')
+    expect(spacers.length).toBeGreaterThan(0)
+
+    // At least one spacer carries real, positive height — the sizing element
+    // that keeps the scroll extent honest without mounting every row.
+    const spacerHeights = Array.from(spacers).map((spacer) => {
+      const cell = spacer.querySelector('td')
+      return cell ? parseFloat(cell.style.height || '0') : 0
+    })
+    expect(spacerHeights.some((h) => h > 0)).toBe(true)
+
+    // Each spacer's <td> spans every column, same as a real data row.
+    for (const spacer of Array.from(spacers)) {
+      const cell = spacer.querySelector('td')!
+      expect(cell.getAttribute('colspan')).toBe(String(columns.length))
+    }
+  })
+
+  it('bottom spacer height plus rendered row groups tracks getTotalSize() growth', () => {
+    // Not asserting exact pixel math (jsdom has no real layout) — just that
+    // a bigger dataset produces a bigger reserved spacer, proving the spacer
+    // is actually driven by size, not a fixed/hardcoded value.
+    const { container: smallContainer } = render(
+      <DataTable columns={columns} data={data} virtualRows maxHeight={400} />,
+    )
+    const { container: bigContainer } = render(
+      <DataTable columns={columns} data={manyRows} virtualRows maxHeight={400} />,
+    )
+
+    const totalSpacerHeight = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('tbody[aria-hidden="true"] td')).reduce(
+        (sum, cell) => sum + parseFloat((cell as HTMLElement).style.height || '0'),
+        0,
+      )
+
+    // 3 rows barely exceed a 400px viewport (or don't), 60 rows definitely do.
+    expect(totalSpacerHeight(bigContainer)).toBeGreaterThan(totalSpacerHeight(smallContainer))
+  })
+
+  it('rows stay accessible via keyboard/DOM traversal despite windowing (no a11y violations)', async () => {
+    const { container } = render(
+      <DataTable columns={columns} data={manyRows} virtualRows maxHeight={400} />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ============================================================
+// 4. Loading state
+// ============================================================
+
+describe('DataTableBody — loading state', () => {
+  it('renders skeleton rows instead of data when loading is true', () => {
+    render(<DataTable columns={columns} data={data} loading pageSize={3} />)
+
+    expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument()
+    // 3 skeleton rows * 4 columns = 12 skeleton elements
+    const skeletonElements = document.querySelectorAll('[aria-hidden="true"]')
+    expect(skeletonElements.length).toBe(12)
+  })
+
+  it('renders actual data rows once loading is false', () => {
+    render(<DataTable columns={columns} data={data} loading={false} />)
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.getByText('Bob Jones')).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// 5. Empty state
+// ============================================================
+
+describe('DataTableBody — empty state', () => {
+  it('renders noResultsText when there is no data', () => {
+    render(<DataTable columns={columns} data={[]} noResultsText="Nothing here." />)
+    expect(screen.getByText('Nothing here.')).toBeInTheDocument()
+  })
+
+  it('renders the default "No results." text when noResultsText is not provided', () => {
+    render(<DataTable columns={columns} data={[]} />)
+    expect(screen.getByText('No results.')).toBeInTheDocument()
+  })
+
+  it('renders a custom emptyState node instead of noResultsText when both are provided', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={[]}
+        noResultsText="Fallback text"
+        emptyState={<div data-testid="custom-empty">Nothing to show</div>}
+      />,
+    )
+    expect(screen.getByTestId('custom-empty')).toBeInTheDocument()
+    expect(screen.queryByText('Fallback text')).not.toBeInTheDocument()
+  })
+})

--- a/packages/core/src/ui/__tests__/data-table-bulk-actions.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-bulk-actions.test.tsx
@@ -1,0 +1,172 @@
+import { IconStar } from '@tabler/icons-react'
+import type { Table } from '@tanstack/react-table'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { type BulkAction, DataTableBulkActions } from '../data-table-bulk-actions'
+
+interface Item {
+  id: string
+  name: string
+}
+
+const selectedRows: Item[] = [
+  { id: '1', name: 'Alpha' },
+  { id: '2', name: 'Beta' },
+]
+
+function createMockTable(): Table<Item> {
+  return { resetRowSelection: vi.fn() } as unknown as Table<Item>
+}
+
+describe('DataTableBulkActions', () => {
+  it('shows the selected row count', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+    expect(screen.getByText(`${selectedRows.length} selected`)).toBeInTheDocument()
+  })
+
+  it('calls the action onClick with the current selectedRows', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    await user.click(screen.getByRole('button', { name: 'Archive' }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(onClick).toHaveBeenCalledWith(selectedRows)
+  })
+
+  it('renders an error-colored action as a solid, color=error Button', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Delete', onClick: vi.fn(), color: 'error' }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' })
+    // variant="solid" + color="error" resolves to the solid/error CVA slice
+    expect(deleteButton).toHaveClass('bg-error-9')
+  })
+
+  it('renders a non-error action as an outline Button', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    const archiveButton = screen.getByRole('button', { name: 'Archive' })
+    // variant="outline" (color undefined -> default accent) resolves to the outline/accent CVA slice
+    expect(archiveButton).toHaveClass('border-accent-7')
+    expect(archiveButton).not.toHaveClass('bg-error-9')
+  })
+
+  it('disables an action button when disabled is true', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn(), disabled: true }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    expect(screen.getByRole('button', { name: 'Archive' })).toBeDisabled()
+  })
+
+  it('does not disable an action button when disabled is omitted', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    expect(screen.getByRole('button', { name: 'Archive' })).not.toBeDisabled()
+  })
+
+  it('calls table.resetRowSelection when Clear selection is clicked', async () => {
+    const user = userEvent.setup()
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    await user.click(screen.getByLabelText('Clear selection'))
+    expect(table.resetRowSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the action icon before the label', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Star', onClick: vi.fn(), icon: IconStar }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    const starButton = screen.getByRole('button', { name: 'Star' })
+    expect(starButton.querySelector('svg')).toBeInTheDocument()
+    expect(starButton).toHaveTextContent('Star')
+  })
+
+  it('does not render an icon slot when the action has no icon', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    expect(screen.getByRole('button', { name: 'Archive' }).querySelector('svg')).not.toBeInTheDocument()
+  })
+
+  it('defaults to the fixed bottom position', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    const { container } = render(
+      <DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />,
+    )
+
+    expect(container.firstChild).toHaveClass('fixed')
+    expect(container.firstChild).toHaveClass('bottom-6')
+  })
+
+  it('renders fixed top classes when position="top"', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    const { container } = render(
+      <DataTableBulkActions
+        table={table}
+        selectedRows={selectedRows}
+        bulkActions={actions}
+        position="top"
+      />,
+    )
+
+    expect(container.firstChild).toHaveClass('fixed')
+    expect(container.firstChild).toHaveClass('top-6')
+    expect(container.firstChild).not.toHaveClass('bottom-6')
+  })
+
+  it('renders relative, non-fixed classes when position="inline"', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    const { container } = render(
+      <DataTableBulkActions
+        table={table}
+        selectedRows={selectedRows}
+        bulkActions={actions}
+        position="inline"
+      />,
+    )
+
+    expect(container.firstChild).toHaveClass('relative')
+    expect(container.firstChild).not.toHaveClass('fixed')
+  })
+
+  it('has role=toolbar and an aria-label of "Bulk actions"', () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [{ label: 'Archive', onClick: vi.fn() }]
+    render(<DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />)
+
+    expect(screen.getByRole('toolbar', { name: 'Bulk actions' })).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const table = createMockTable()
+    const actions: BulkAction<Item>[] = [
+      { label: 'Archive', onClick: vi.fn() },
+      { label: 'Delete', onClick: vi.fn(), color: 'error' },
+    ]
+    const { container } = render(
+      <DataTableBulkActions table={table} selectedRows={selectedRows} bulkActions={actions} />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/ui/__tests__/data-table-card.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-card.test.tsx
@@ -1,0 +1,363 @@
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  getFilteredRowModel,
+  type RowSelectionState,
+  useReactTable,
+} from '@tanstack/react-table'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { DataTableCards } from '../data-table-card'
+import { type DataTableContextValue, DataTableProvider } from '../data-table-context'
+
+// ============================================================
+// Fixtures
+// ============================================================
+
+interface Person {
+  id: string
+  name: string
+  email: string
+  role: string
+}
+
+const columns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'role', header: 'Role' },
+]
+
+const data: Person[] = [
+  { id: 'a1', name: 'Alice Smith', email: 'alice@example.com', role: 'Engineer' },
+  { id: 'b2', name: 'Bob Jones', email: 'bob@example.com', role: 'Designer' },
+  { id: 'c3', name: 'Carol White', email: 'carol@example.com', role: 'Manager' },
+]
+
+// ============================================================
+// Harness
+// ============================================================
+
+/**
+ * DataTableCards is a pure `useDataTableContext` consumer — it takes no `table`
+ * prop. Build a real TanStack table instance and feed it through
+ * `DataTableProvider` directly (mirroring how `data-table.tsx` assembles its
+ * `contextValue`), which tests the component in isolation without needing the
+ * full `<DataTable>` + a `window.matchMedia` viewport mock.
+ */
+function CardsHarness({
+  rows = data,
+  cols = columns,
+  selectable = false,
+  filterable = false,
+  filterableColumns,
+  rowClassName,
+  loading = false,
+  skeletonRowCount = 5,
+  noResultsText,
+  emptyState,
+  onSelectionChange,
+}: {
+  rows?: Person[]
+  cols?: ColumnDef<Person, unknown>[]
+  selectable?: boolean
+  filterable?: boolean
+  filterableColumns?: string[]
+  rowClassName?: (row: Person) => string | undefined
+  loading?: boolean
+  skeletonRowCount?: number
+  noResultsText?: string
+  emptyState?: React.ReactNode
+  onSelectionChange?: (selected: Person[]) => void
+}) {
+  const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
+
+  const table = useReactTable({
+    data: rows,
+    columns: cols,
+    getRowId: (row) => row.id,
+    state: { rowSelection },
+    onRowSelectionChange: setRowSelection,
+    enableRowSelection: true,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+  })
+
+  React.useEffect(() => {
+    if (!onSelectionChange) return
+    const ids = Object.keys(rowSelection).filter((k) => rowSelection[k])
+    onSelectionChange(rows.filter((r) => ids.includes(r.id)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rowSelection])
+
+  const contextValue: DataTableContextValue<Person> = {
+    table,
+    allColumns: cols.map((c) => ({ id: (c as { id?: string }).id, header: c.header })),
+    columnPinningState: {},
+    sortable: false,
+    filterable,
+    filterableColumns,
+    editable: false,
+    expandable: false,
+    virtualRows: false,
+    selectable,
+    mobileView: 'card',
+    editingCell: null,
+    setEditingCell: () => {},
+    rowClassName,
+  }
+
+  return (
+    <DataTableProvider value={contextValue}>
+      <DataTableCards
+        loading={loading}
+        skeletonRowCount={skeletonRowCount}
+        noResultsText={noResultsText}
+        emptyState={emptyState}
+      />
+    </DataTableProvider>
+  )
+}
+
+// ============================================================
+// Loading / skeleton state
+// ============================================================
+
+describe('DataTableCards — loading', () => {
+  it('renders skeletonRowCount card skeletons instead of data', () => {
+    const { container } = render(<CardsHarness loading skeletonRowCount={3} />)
+    // The loading branch's root is a `flex flex-col gap-ds-03` div whose direct
+    // children are the skeleton Cards — one per skeletonRowCount.
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.children).toHaveLength(3)
+    expect(screen.queryByRole('list')).not.toBeInTheDocument()
+    expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument()
+  })
+
+  it('renders 4 skeleton placeholder lines per card (1 title + 3 body lines)', () => {
+    const { container } = render(<CardsHarness loading skeletonRowCount={2} />)
+    expect(container.querySelectorAll('[aria-hidden="true"]')).toHaveLength(2 * 4)
+  })
+
+  it('respects a different skeletonRowCount', () => {
+    const { container } = render(<CardsHarness loading skeletonRowCount={7} />)
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.children).toHaveLength(7)
+  })
+
+  it('does not render the empty state while loading, even with zero rows', () => {
+    render(
+      <CardsHarness rows={[]} loading skeletonRowCount={4} noResultsText="Nothing here" />,
+    )
+    expect(screen.queryByText('Nothing here')).not.toBeInTheDocument()
+  })
+
+  it('has no a11y violations in the loading state', async () => {
+    const { container } = render(<CardsHarness loading skeletonRowCount={3} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ============================================================
+// Empty state
+// ============================================================
+
+describe('DataTableCards — empty state', () => {
+  it('renders default "No results." text when rows are empty', () => {
+    render(<CardsHarness rows={[]} />)
+    expect(screen.getByText('No results.')).toBeInTheDocument()
+  })
+
+  it('renders custom noResultsText when provided', () => {
+    render(<CardsHarness rows={[]} noResultsText="Nothing to show" />)
+    expect(screen.getByText('Nothing to show')).toBeInTheDocument()
+  })
+
+  it('renders custom emptyState ReactNode, taking precedence over noResultsText', () => {
+    render(
+      <CardsHarness
+        rows={[]}
+        noResultsText="Fallback text"
+        emptyState={<div data-testid="custom-empty">Nothing yet!</div>}
+      />,
+    )
+    expect(screen.getByTestId('custom-empty')).toBeInTheDocument()
+    expect(screen.getByText('Nothing yet!')).toBeInTheDocument()
+    expect(screen.queryByText('Fallback text')).not.toBeInTheDocument()
+  })
+
+  it('does not render the empty state when rows are present', () => {
+    render(<CardsHarness emptyState={<div data-testid="custom-empty">Empty</div>} />)
+    expect(screen.queryByTestId('custom-empty')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('has no a11y violations in the empty state', async () => {
+    const { container } = render(<CardsHarness rows={[]} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ============================================================
+// Selection
+// ============================================================
+
+describe('DataTableCards — selection', () => {
+  it('renders a checkbox per card when selectable', () => {
+    render(<CardsHarness selectable />)
+    expect(screen.getAllByLabelText('Select row')).toHaveLength(3)
+  })
+
+  it('does not render checkboxes when selectable is false', () => {
+    render(<CardsHarness selectable={false} />)
+    expect(screen.queryAllByLabelText('Select row')).toHaveLength(0)
+  })
+
+  it('checking a card checkbox drives row selection, same as table view', async () => {
+    const onSelectionChange = vi.fn()
+    render(<CardsHarness selectable onSelectionChange={onSelectionChange} />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getAllByLabelText('Select row')[0])
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith([data[0]])
+  })
+
+  it('unchecking a selected card checkbox clears its selection', async () => {
+    const onSelectionChange = vi.fn()
+    render(<CardsHarness selectable onSelectionChange={onSelectionChange} />)
+    const user = userEvent.setup()
+
+    const checkbox = screen.getAllByLabelText('Select row')[0]
+    await user.click(checkbox)
+    await user.click(checkbox)
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith([])
+  })
+
+  it('applies a selected ring to the checked row card only', async () => {
+    render(<CardsHarness selectable />)
+    const user = userEvent.setup()
+    const cards = screen.getAllByRole('listitem')
+
+    await user.click(screen.getAllByLabelText('Select row')[0])
+
+    expect(cards[0]).toHaveClass('ring-2', 'ring-accent-9')
+    expect(cards[1]).not.toHaveClass('ring-2')
+    expect(cards[2]).not.toHaveClass('ring-2')
+  })
+})
+
+// ============================================================
+// Filterable
+// ============================================================
+
+describe('DataTableCards — filterable', () => {
+  it('renders a filter input above the card list for each filterable column', () => {
+    const { container } = render(<CardsHarness filterable />)
+    const nameFilter = screen.getByPlaceholderText('Filter Name...')
+    expect(nameFilter).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Email...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Role...')).toBeInTheDocument()
+
+    // Document order: the filter input precedes the first card...
+    const firstCard = screen.getAllByRole('listitem')[0]
+    expect(
+      nameFilter.compareDocumentPosition(firstCard) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    // ...and it does not live inside a card either.
+    expect(container.querySelector('[role="listitem"] input')).toBeNull()
+  })
+
+  it('does not render filter inputs when filterable is false', () => {
+    render(<CardsHarness filterable={false} />)
+    expect(screen.queryByPlaceholderText('Filter Name...')).not.toBeInTheDocument()
+  })
+
+  it('typing in a filter input filters the visible cards', async () => {
+    render(<CardsHarness filterable />)
+    const user = userEvent.setup()
+
+    await user.type(screen.getByPlaceholderText('Filter Name...'), 'Alice')
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+
+  it('has no a11y violations with filters + selection', async () => {
+    const { container } = render(<CardsHarness filterable selectable />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+// ============================================================
+// filterableColumns
+// ============================================================
+
+describe('DataTableCards — filterableColumns', () => {
+  it('only renders filter inputs for the listed column IDs', () => {
+    render(<CardsHarness filterable filterableColumns={['name']} />)
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Email...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Role...')).not.toBeInTheDocument()
+  })
+
+  it('a wider filterableColumns list still restricts to just those columns', () => {
+    render(<CardsHarness filterable filterableColumns={['name', 'email']} />)
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Email...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Role...')).not.toBeInTheDocument()
+  })
+
+  it('has no effect when filterable is false', () => {
+    render(<CardsHarness filterable={false} filterableColumns={['name']} />)
+    expect(screen.queryByPlaceholderText('Filter Name...')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// rowClassName
+// ============================================================
+
+describe('DataTableCards — rowClassName', () => {
+  it('applies the returned className to the matching card', () => {
+    render(
+      <CardsHarness
+        rowClassName={(row) => (row.role === 'Engineer' ? 'bg-error-3' : undefined)}
+      />,
+    )
+    const cards = screen.getAllByRole('listitem')
+    // data order: Alice (Engineer), Bob (Designer), Carol (Manager)
+    expect(cards[0]).toHaveClass('bg-error-3')
+    expect(cards[1]).not.toHaveClass('bg-error-3')
+    expect(cards[2]).not.toHaveClass('bg-error-3')
+  })
+
+  it('does not add a class when rowClassName returns undefined', () => {
+    render(<CardsHarness rowClassName={() => undefined} />)
+    const cards = screen.getAllByRole('listitem')
+    expect(cards[0].className).not.toContain('undefined')
+  })
+
+  it('composes with the selected-row ring class', async () => {
+    render(
+      <CardsHarness
+        selectable
+        rowClassName={(row) => (row.role === 'Engineer' ? 'bg-error-3' : undefined)}
+      />,
+    )
+    const user = userEvent.setup()
+    await user.click(screen.getAllByLabelText('Select row')[0])
+
+    const cards = screen.getAllByRole('listitem')
+    expect(cards[0]).toHaveClass('bg-error-3')
+    expect(cards[0]).toHaveClass('ring-2', 'ring-accent-9')
+  })
+})

--- a/packages/core/src/ui/__tests__/data-table-header.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-header.test.tsx
@@ -1,0 +1,308 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { DataTable } from '../data-table'
+
+// ============================================================
+// `DataTableHeader` (internal `DataTableHeaderImpl`, re-exported as
+// `DataTableHeader`) reads everything except `stickyHeader` from
+// `DataTableProvider` context — so the only reliable way to exercise real
+// sort-click / filter-input behavior is through the actual <DataTable>,
+// mirroring the fixture pattern in data-table-integration.test.tsx.
+//
+// Covers the gap called out in GitHub issue #268: aria-sort cycling, sort
+// icons, sticky header, and filter inputs at unit level.
+// ============================================================
+
+interface Person {
+  name: string
+  email: string
+  role: string
+  age: number
+}
+
+const data: Person[] = [
+  { name: 'Alice Smith', email: 'alice@example.com', role: 'Engineer', age: 28 },
+  { name: 'Bob Jones', email: 'bob@example.com', role: 'Designer', age: 34 },
+  { name: 'Carol White', email: 'carol@example.com', role: 'Manager', age: 42 },
+]
+
+const columns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'role', header: 'Role' },
+  { accessorKey: 'age', header: 'Age' },
+]
+
+// A column with the per-column filter opt-out set.
+const columnsWithUnfilterable: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email', enableColumnFilter: false },
+  { accessorKey: 'role', header: 'Role' },
+]
+
+// A column with sorting explicitly disabled.
+const columnsWithUnsortable: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email', enableSorting: false },
+]
+
+function getHeaderCell(name: string) {
+  // The header <th> for a sortable column contains a <button> with this
+  // accessible label; for a non-sortable column it just contains the text.
+  return screen.getByText(name).closest('th')!
+}
+
+// ============================================================
+// aria-sort cycling
+// ============================================================
+
+describe('DataTableHeader — aria-sort cycling', () => {
+  it('has aria-sort="none" on a sortable column before any click', () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    expect(getHeaderCell('Name')).toHaveAttribute('aria-sort', 'none')
+  })
+
+  it('does not set aria-sort when the table is not sortable', () => {
+    render(<DataTable columns={columns} data={data} />)
+    expect(getHeaderCell('Name')).not.toHaveAttribute('aria-sort')
+  })
+
+  it('does not set aria-sort on a column with enableSorting: false', () => {
+    render(<DataTable columns={columnsWithUnsortable} data={data} sortable />)
+    expect(getHeaderCell('Email')).not.toHaveAttribute('aria-sort')
+  })
+
+  it('cycles aria-sort none -> ascending -> descending -> none on repeated clicks', async () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    const user = userEvent.setup()
+    const th = getHeaderCell('Name')
+    const button = screen.getByLabelText('Sort by Name')
+
+    expect(th).toHaveAttribute('aria-sort', 'none')
+
+    await user.click(button)
+    expect(th).toHaveAttribute('aria-sort', 'ascending')
+
+    await user.click(button)
+    expect(th).toHaveAttribute('aria-sort', 'descending')
+
+    // Third click clears sorting entirely (TanStack's default
+    // enableSortingRemoval behavior) rather than cycling straight back to
+    // ascending.
+    await user.click(button)
+    expect(th).toHaveAttribute('aria-sort', 'none')
+  })
+
+  it('sorting one column does not affect aria-sort on another', async () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Sort by Name'))
+    expect(getHeaderCell('Name')).toHaveAttribute('aria-sort', 'ascending')
+    expect(getHeaderCell('Email')).toHaveAttribute('aria-sort', 'none')
+  })
+})
+
+// ============================================================
+// Sort icons
+// ============================================================
+
+describe('DataTableHeader — sort icons', () => {
+  it('shows the unsorted (arrows-sort) icon before any click', () => {
+    const { container } = render(<DataTable columns={columns} data={data} sortable />)
+    const th = getHeaderCell('Name')
+    expect(th.querySelector('.tabler-icon-arrows-sort')).toBeInTheDocument()
+    expect(th.querySelector('.tabler-icon-arrow-up')).not.toBeInTheDocument()
+    expect(th.querySelector('.tabler-icon-arrow-down')).not.toBeInTheDocument()
+    void container
+  })
+
+  it('shows the arrow-up icon when sorted ascending', async () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    const user = userEvent.setup()
+    const th = getHeaderCell('Name')
+
+    await user.click(screen.getByLabelText('Sort by Name'))
+
+    await waitFor(() =>
+      expect(th.querySelector('.tabler-icon-arrow-up')).toBeInTheDocument(),
+    )
+    expect(th.querySelector('.tabler-icon-arrows-sort')).not.toBeInTheDocument()
+  })
+
+  it('shows the arrow-down icon when sorted descending', async () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    const user = userEvent.setup()
+    const th = getHeaderCell('Name')
+    const button = screen.getByLabelText('Sort by Name')
+
+    await user.click(button) // ascending
+    await user.click(button) // descending
+
+    await waitFor(() =>
+      expect(th.querySelector('.tabler-icon-arrow-down')).toBeInTheDocument(),
+    )
+    expect(th.querySelector('.tabler-icon-arrow-up')).not.toBeInTheDocument()
+  })
+
+  it('reverts to the unsorted icon once sorting is cleared', async () => {
+    render(<DataTable columns={columns} data={data} sortable />)
+    const user = userEvent.setup()
+    const th = getHeaderCell('Name')
+    const button = screen.getByLabelText('Sort by Name')
+
+    await user.click(button) // ascending
+    await user.click(button) // descending
+    await user.click(button) // cleared
+
+    await waitFor(() =>
+      expect(th.querySelector('.tabler-icon-arrows-sort')).toBeInTheDocument(),
+    )
+  })
+
+  it('does not render a sort button or icon for a non-sortable column', () => {
+    render(<DataTable columns={columnsWithUnsortable} data={data} sortable />)
+    const th = getHeaderCell('Email')
+    expect(th.querySelector('button')).not.toBeInTheDocument()
+    expect(th.querySelector('.tabler-icon-arrows-sort')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Sticky header
+// ============================================================
+
+describe('DataTableHeader — stickyHeader', () => {
+  it('applies sticky classes to the header row group when stickyHeader is true', () => {
+    render(<DataTable columns={columns} data={data} stickyHeader />)
+    const thead = document.querySelector('thead')!
+    expect(thead).toHaveClass('sticky')
+    expect(thead).toHaveClass('top-0')
+    expect(thead).toHaveClass('z-10')
+    expect(thead).toHaveClass('bg-surface-raised')
+  })
+
+  it('does not apply sticky classes when stickyHeader is omitted', () => {
+    render(<DataTable columns={columns} data={data} />)
+    const thead = document.querySelector('thead')!
+    expect(thead).not.toHaveClass('sticky')
+    expect(thead).not.toHaveClass('top-0')
+    expect(thead).not.toHaveClass('z-10')
+  })
+
+  it('does not apply sticky classes when stickyHeader is explicitly false', () => {
+    render(<DataTable columns={columns} data={data} stickyHeader={false} />)
+    const thead = document.querySelector('thead')!
+    expect(thead).not.toHaveClass('sticky')
+  })
+
+  it('combines with sortable and filterable without losing sticky classes', () => {
+    render(
+      <DataTable columns={columns} data={data} stickyHeader sortable filterable />,
+    )
+    const thead = document.querySelector('thead')!
+    expect(thead).toHaveClass('sticky')
+    // Sort buttons and filter inputs should still be present alongside sticky.
+    expect(screen.getByLabelText('Sort by Name')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Filter inputs
+// ============================================================
+
+describe('DataTableHeader — filter inputs', () => {
+  it('renders a filter input for each filterable column', () => {
+    render(<DataTable columns={columns} data={data} filterable />)
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Email...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Role...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Age...')).toBeInTheDocument()
+  })
+
+  it('does not render filter inputs when filterable is false', () => {
+    render(<DataTable columns={columns} data={data} />)
+    expect(screen.queryByPlaceholderText('Filter Name...')).not.toBeInTheDocument()
+  })
+
+  it('typing into a filter input filters the body rows', async () => {
+    render(<DataTable columns={columns} data={data} filterable />)
+    const user = userEvent.setup()
+
+    await user.type(screen.getByPlaceholderText('Filter Name...'), 'Alice')
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    expect(screen.queryByText('Carol White')).not.toBeInTheDocument()
+  })
+
+  it('does not render a filter input for a column with enableColumnFilter: false', () => {
+    render(<DataTable columns={columnsWithUnfilterable} data={data} filterable />)
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Role...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Email...')).not.toBeInTheDocument()
+  })
+
+  it('filterableColumns restricts filter inputs to the listed column IDs', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        filterable
+        filterableColumns={['name', 'role']}
+      />,
+    )
+    expect(screen.getByPlaceholderText('Filter Name...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Filter Role...')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Email...')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Filter Age...')).not.toBeInTheDocument()
+  })
+
+  it('filterableColumns still filters rows for a listed column', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        filterable
+        filterableColumns={['role']}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.type(screen.getByPlaceholderText('Filter Role...'), 'Engineer')
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    expect(screen.queryByText('Carol White')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Accessibility
+// ============================================================
+
+describe('DataTableHeader — accessibility', () => {
+  it('has no a11y violations with sortable + filterable headers', async () => {
+    const { container } = render(
+      <DataTable columns={columns} data={data} sortable filterable />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no a11y violations with stickyHeader + a sorted column', async () => {
+    const { container } = render(
+      <DataTable columns={columns} data={data} stickyHeader sortable filterable />,
+    )
+    const user = userEvent.setup()
+    await user.click(screen.getByLabelText('Sort by Name'))
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/ui/__tests__/data-table-integration.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-integration.test.tsx
@@ -976,6 +976,57 @@ describe('DataTable — enableExport + onExport', () => {
     expect(onExport).toHaveBeenCalledTimes(1)
     expect(onExport.mock.calls[0][0]).toHaveLength(4)
   })
+
+  // #268 — onExport must receive the currently visible (filtered) rows, not
+  // the full original `data` array, per its own JSDoc ("Receives the
+  // currently visible (filtered) rows...").
+  it('onExport receives only the currently filtered (visible) rows, not all rows', async () => {
+    const onExport = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        toolbar
+        filterable
+        enableExport
+        onExport={onExport}
+      />,
+    )
+    const user = userEvent.setup()
+
+    // Filter down to just Alice — Bob/Carol/Dave should drop out of view.
+    await user.type(screen.getByPlaceholderText('Filter Name...'), 'Alice')
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument()
+    expect(screen.queryByText('Bob Jones')).not.toBeInTheDocument()
+    expect(screen.queryByText('Carol White')).not.toBeInTheDocument()
+    expect(screen.queryByText('Dave Brown')).not.toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Export table as CSV'))
+
+    expect(onExport).toHaveBeenCalledTimes(1)
+    // Exactly the visible subset — not the full 4-row `data` array.
+    expect(onExport.mock.calls[0][0]).toEqual([data[0]])
+  })
+
+  it('onExport receives all rows when no filter is applied (sanity check)', async () => {
+    const onExport = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        toolbar
+        filterable
+        enableExport
+        onExport={onExport}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Export table as CSV'))
+
+    expect(onExport).toHaveBeenCalledTimes(1)
+    expect(onExport.mock.calls[0][0]).toEqual(data)
+  })
 })
 
 // ============================================================

--- a/packages/core/src/ui/__tests__/data-table-pagination.test.tsx
+++ b/packages/core/src/ui/__tests__/data-table-pagination.test.tsx
@@ -1,0 +1,300 @@
+import { type ColumnDef } from '@tanstack/react-table'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { axe } from 'vitest-axe'
+
+import { DataTable } from '../data-table'
+
+// ============================================================
+// Fixtures
+//
+// DataTablePagination is not exported to consumers (see its own file
+// comment), so it's exercised through the real <DataTable paginated />
+// integration rather than a hand-built TanStack `Table` mock — that's
+// the only way to get real getCanPreviousPage/getCanNextPage/getPageCount
+// behaviour instead of guessing at it.
+// ============================================================
+
+interface Person {
+  name: string
+  email: string
+  role: string
+  age: number
+}
+
+const columns: ColumnDef<Person, unknown>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+  { accessorKey: 'role', header: 'Role' },
+  { accessorKey: 'age', header: 'Age' },
+]
+
+// 25 rows — enough for several pages at pageSize 10 (3 pages) and a clean
+// middle page to assert both Previous and Next are enabled simultaneously.
+const manyRows: Person[] = Array.from({ length: 25 }, (_, i) => ({
+  name: `Person ${i}`,
+  email: `person${i}@example.com`,
+  role: i % 2 === 0 ? 'Engineer' : 'Designer',
+  age: 20 + (i % 40),
+}))
+
+// ============================================================
+// Page size selector
+// ============================================================
+
+describe('DataTablePagination — page size selector', () => {
+  it('defaults to [10, 20, 50, 100] when pageSizeOptions is not provided', () => {
+    render(<DataTable columns={columns} data={manyRows} paginated />)
+    const select = screen.getByLabelText('Rows per page') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+    expect(optionValues).toEqual(['10', '20', '50', '100'])
+  })
+
+  it('pageSizeOptions customizes the available choices', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows}
+        paginated
+        pageSizeOptions={[5, 15, 25]}
+      />,
+    )
+    const select = screen.getByLabelText('Rows per page') as HTMLSelectElement
+    const optionValues = Array.from(select.options).map((o) => o.value)
+    expect(optionValues).toEqual(['5', '15', '25'])
+  })
+
+  it('changing the page size selector updates rows shown and page count', async () => {
+    render(
+      <DataTable columns={columns} data={manyRows} paginated pageSize={10} />,
+    )
+    const user = userEvent.setup()
+
+    // 25 rows at pageSize 10 -> 3 pages
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+    expect(screen.getAllByText(/^Person \d+$/)).toHaveLength(10)
+
+    // Switch to 50 rows per page -> everything fits on one page
+    const select = screen.getByLabelText('Rows per page')
+    await user.selectOptions(select, '50')
+
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument()
+    expect(screen.getAllByText(/^Person \d+$/)).toHaveLength(25)
+  })
+
+  it('reducing page size after navigating forward keeps pagination math consistent', async () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows}
+        paginated
+        pageSize={10}
+        pageSizeOptions={[5, 10, 20, 50]}
+      />,
+    )
+    const user = userEvent.setup()
+
+    // Move to page 2 of 3 (rows 10-19)
+    await user.click(screen.getByLabelText('Next page'))
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+
+    // Shrink page size to 5 -> pageCount becomes 5; TanStack clamps/recomputes
+    // pageIndex so it never reports an out-of-range page.
+    const select = screen.getByLabelText('Rows per page')
+    await user.selectOptions(select, '5')
+
+    const pageInfo = screen.getByText(/^Page \d+ of 5$/)
+    expect(pageInfo).toBeInTheDocument()
+    // Exactly 5 rows should be visible on whatever page it landed on
+    expect(screen.getAllByText(/^Person \d+$/)).toHaveLength(5)
+  })
+
+  it('page size selector is hidden entirely under server-side pagination', () => {
+    const onPageChange = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    expect(screen.queryByLabelText('Rows per page')).not.toBeInTheDocument()
+  })
+})
+
+// ============================================================
+// Prev/next disabled states (client-side pagination)
+// ============================================================
+
+describe('DataTablePagination — prev/next disabled states (client)', () => {
+  it('disables Previous and enables Next on the first page', () => {
+    render(
+      <DataTable columns={columns} data={manyRows} paginated pageSize={10} />,
+    )
+    expect(screen.getByLabelText('Previous page')).toBeDisabled()
+    expect(screen.getByLabelText('Next page')).toBeEnabled()
+  })
+
+  it('enables both Previous and Next on a middle page', async () => {
+    render(
+      <DataTable columns={columns} data={manyRows} paginated pageSize={10} />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Next page'))
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Previous page')).toBeEnabled()
+    expect(screen.getByLabelText('Next page')).toBeEnabled()
+  })
+
+  it('disables Next and enables Previous on the last page', async () => {
+    render(
+      <DataTable columns={columns} data={manyRows} paginated pageSize={10} />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Next page'))
+    await user.click(screen.getByLabelText('Next page'))
+    expect(screen.getByText('Page 3 of 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Next page')).toBeDisabled()
+    expect(screen.getByLabelText('Previous page')).toBeEnabled()
+  })
+
+  it('disables both Previous and Next when everything fits on a single page', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 3)}
+        paginated
+        pageSize={10}
+      />,
+    )
+    expect(screen.getByText('Page 1 of 1')).toBeInTheDocument()
+    expect(screen.getByLabelText('Previous page')).toBeDisabled()
+    expect(screen.getByLabelText('Next page')).toBeDisabled()
+  })
+})
+
+// ============================================================
+// Server-side pagination
+// ============================================================
+
+describe('DataTablePagination — server-side pagination', () => {
+  it('clicking Next calls onPageChange with the next 1-based page', async () => {
+    const onPageChange = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Next page'))
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(onPageChange).toHaveBeenCalledWith(2)
+  })
+
+  it('clicking Previous calls onPageChange with the previous 1-based page', async () => {
+    const onPageChange = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(10, 20)}
+        pagination={{ page: 2, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Previous page'))
+    expect(onPageChange).toHaveBeenCalledTimes(1)
+    expect(onPageChange).toHaveBeenCalledWith(1)
+  })
+
+  it('does not page client-side — visible rows are exactly what the server sent', async () => {
+    const onPageChange = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    const user = userEvent.setup()
+
+    await user.click(screen.getByLabelText('Next page'))
+    // The parent only calls onPageChange — it does not slice `data` itself in
+    // this test, so the same 10 server-supplied rows remain on screen. That's
+    // the point: paging is delegated entirely to the caller, not done in-table.
+    expect(screen.getAllByText(/^Person \d+$/)).toHaveLength(10)
+    expect(screen.getByText('Person 0')).toBeInTheDocument()
+  })
+
+  it('totalRowCount and page count reflect server total, not current page row count', () => {
+    const onPageChange = vi.fn()
+    render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    // Only 10 rows are on screen, but the total/page-count math uses the
+    // server-declared total (25), not table.getFilteredRowModel().rows.length.
+    expect(screen.getByText('25 total rows')).toBeInTheDocument()
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument()
+  })
+
+  it('disables Previous on server page 1 and Next on the last server page', () => {
+    const onPageChange = vi.fn()
+    const { rerender } = render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    expect(screen.getByLabelText('Previous page')).toBeDisabled()
+    expect(screen.getByLabelText('Next page')).toBeEnabled()
+
+    rerender(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(20, 25)}
+        pagination={{ page: 3, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    expect(screen.getByText('Page 3 of 3')).toBeInTheDocument()
+    expect(screen.getByLabelText('Next page')).toBeDisabled()
+    expect(screen.getByLabelText('Previous page')).toBeEnabled()
+  })
+})
+
+// ============================================================
+// Accessibility
+// ============================================================
+
+describe('DataTablePagination — accessibility', () => {
+  it('has no a11y violations with client-side pagination controls', async () => {
+    const { container } = render(
+      <DataTable columns={columns} data={manyRows} paginated pageSize={10} />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no a11y violations with server-side pagination controls', async () => {
+    const onPageChange = vi.fn()
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={manyRows.slice(0, 10)}
+        pagination={{ page: 1, pageSize: 10, total: 25, onPageChange }}
+      />,
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/packages/core/src/ui/__tests__/sidebar.test.tsx
+++ b/packages/core/src/ui/__tests__/sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent,render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   Sidebar,
@@ -12,9 +12,15 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarProvider,
+  SidebarRail,
   SidebarTrigger,
   useSidebar,
 } from '../sidebar'
+
+const mockUseIsMobile = vi.fn(() => false)
+vi.mock('../../hooks/use-mobile', () => ({
+  useIsMobile: () => mockUseIsMobile(),
+}))
 
 // Helper: wrap components that require SidebarProvider context
 function renderWithProvider(ui: React.ReactNode, props?: { defaultOpen?: boolean }) {
@@ -117,5 +123,143 @@ describe('useSidebar', () => {
     expect(() => render(<Bomb />)).toThrow(
       'useSidebar must be used within a SidebarProvider.',
     )
+  })
+})
+
+function StateReadout() {
+  const { state, toggleSidebar } = useSidebar()
+  return (
+    <>
+      <span data-testid="state">{state}</span>
+      <button type="button" onClick={toggleSidebar}>toggle</button>
+    </>
+  )
+}
+
+describe('collapsed state toggling', () => {
+  it('toggleSidebar flips state between expanded and collapsed', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }))
+    expect(screen.getByTestId('state')).toHaveTextContent('collapsed')
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }))
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+  })
+
+  it('reflects state via data-state on the Sidebar wrapper', () => {
+    const { container } = render(
+      <SidebarProvider defaultOpen={true}>
+        <Sidebar collapsible="icon">
+          <div>Nav</div>
+        </Sidebar>
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    const wrapper = container.querySelector('[data-state]')
+    expect(wrapper).toHaveAttribute('data-state', 'expanded')
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }))
+    expect(wrapper).toHaveAttribute('data-state', 'collapsed')
+  })
+
+  it('SidebarTrigger click toggles state', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <SidebarTrigger />
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar' }))
+    expect(screen.getByTestId('state')).toHaveTextContent('collapsed')
+  })
+})
+
+describe('keyboard shortcut', () => {
+  it('Cmd/Ctrl+B toggles the sidebar', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+    fireEvent.keyDown(window, { key: 'b', metaKey: true })
+    expect(screen.getByTestId('state')).toHaveTextContent('collapsed')
+    fireEvent.keyDown(window, { key: 'b', ctrlKey: true })
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+  })
+
+  it('ignores the "b" key without a modifier', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    fireEvent.keyDown(window, { key: 'b' })
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+  })
+})
+
+describe('SidebarRail', () => {
+  it('clicking the rail toggles the sidebar', () => {
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <Sidebar collapsible="icon">
+          <div>Nav</div>
+        </Sidebar>
+        <SidebarRail />
+        <StateReadout />
+      </SidebarProvider>,
+    )
+    expect(screen.getByTestId('state')).toHaveTextContent('expanded')
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar' }))
+    expect(screen.getByTestId('state')).toHaveTextContent('collapsed')
+  })
+
+  it('renders with data-sidebar="rail"', () => {
+    render(
+      <SidebarProvider>
+        <SidebarRail />
+      </SidebarProvider>,
+    )
+    expect(screen.getByRole('button', { name: 'Toggle Sidebar' })).toHaveAttribute(
+      'data-sidebar',
+      'rail',
+    )
+  })
+})
+
+describe('mobile Sheet variant', () => {
+  it('renders a Sheet instead of the fixed sidebar markup when isMobile', () => {
+    mockUseIsMobile.mockReturnValue(true)
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <SidebarTrigger />
+        <Sidebar collapsible="offcanvas">
+          <div>Mobile nav</div>
+        </Sidebar>
+      </SidebarProvider>,
+    )
+    // The mobile Sheet starts closed (openMobile defaults to false) — open it first.
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar' }))
+    expect(screen.getByText('Mobile nav')).toBeInTheDocument()
+    const sheetContent = document.querySelector('[data-sidebar="sidebar"][data-mobile="true"]')
+    expect(sheetContent).toBeInTheDocument()
+    mockUseIsMobile.mockReturnValue(false)
+  })
+
+  it('does not render the mobile Sheet markup on desktop', () => {
+    mockUseIsMobile.mockReturnValue(false)
+    render(
+      <SidebarProvider defaultOpen={true}>
+        <Sidebar collapsible="offcanvas">
+          <div>Desktop nav</div>
+        </Sidebar>
+      </SidebarProvider>,
+    )
+    expect(document.querySelector('[data-mobile="true"]')).not.toBeInTheDocument()
   })
 })

--- a/packages/core/src/ui/chat/date-separator.tsx
+++ b/packages/core/src/ui/chat/date-separator.tsx
@@ -6,31 +6,50 @@ export interface DateSeparatorProps {
   date: Date | string
   format?: (date: Date) => string
   className?: string
+  /** BCP 47 locale for the default label's month name. @default 'en-US' */
+  locale?: string
+  /**
+   * IANA time zone used for the "Today"/"Yesterday" day-boundary comparison
+   * and for formatting. Defaults to the browser's local time zone.
+   */
+  timeZone?: string
 }
 
-function defaultFormat(date: Date): string {
+/** Year/month/day of `date` as seen in `timeZone` (or the local zone when omitted). */
+function datePartsIn(date: Date, timeZone?: string): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value)
+  return { year: get('year'), month: get('month'), day: get('day') }
+}
+
+function defaultFormat(date: Date, locale: string, timeZone?: string): string {
   const now = new Date()
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const target = new Date(date.getFullYear(), date.getMonth(), date.getDate())
-  const diffMs = today.getTime() - target.getTime()
-  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24))
+  const today = datePartsIn(now, timeZone)
+  const target = datePartsIn(date, timeZone)
+  const todayUTC = Date.UTC(today.year, today.month - 1, today.day)
+  const targetUTC = Date.UTC(target.year, target.month - 1, target.day)
+  const diffDays = Math.round((todayUTC - targetUTC) / (1000 * 60 * 60 * 24))
 
   if (diffDays === 0) return 'Today'
   if (diffDays === 1) return 'Yesterday'
 
-  const month = date.toLocaleString('en-US', { month: 'short' })
-  const day = date.getDate()
+  const month = date.toLocaleString(locale, { month: 'short', timeZone })
 
-  if (date.getFullYear() !== now.getFullYear()) {
-    return `${month} ${day}, ${date.getFullYear()}`
+  if (target.year !== today.year) {
+    return `${month} ${target.day}, ${target.year}`
   }
 
-  return `${month} ${day}`
+  return `${month} ${target.day}`
 }
 
-function DateSeparator({ date, format, className }: DateSeparatorProps) {
+function DateSeparator({ date, format, className, locale = 'en-US', timeZone }: DateSeparatorProps) {
   const d = typeof date === 'string' ? new Date(date) : date
-  const label = format ? format(d) : defaultFormat(d)
+  const label = format ? format(d) : defaultFormat(d, locale, timeZone)
 
   return (
     <div className={cn('flex items-center gap-ds-03 py-ds-03', className)}>

--- a/packages/core/src/ui/data-table-bulk-actions.tsx
+++ b/packages/core/src/ui/data-table-bulk-actions.tsx
@@ -6,14 +6,26 @@ import React from 'react'
 
 import { Button } from './button'
 import { Icon } from './icon'
+import type { IconInput } from './lib/icon-input'
 import { cn } from './lib/utils'
+
+/** Where the floating bulk-action bar renders. @default 'bottom' */
+export type BulkActionsPosition = 'bottom' | 'top' | 'inline'
 
 /** Bulk action definition for the floating action bar */
 export interface BulkAction<TData> {
   label: string
   onClick: (selectedRows: TData[]) => void
+  /** Icon rendered before the label — useful for compact/mobile bars. */
+  icon?: IconInput
   color?: 'accent' | 'error'
   disabled?: boolean
+}
+
+const POSITION_CLASSES: Record<BulkActionsPosition, string> = {
+  bottom: 'fixed bottom-6 left-1/2 -translate-x-1/2 z-sticky animate-in slide-in-from-bottom-2',
+  top: 'fixed top-6 left-1/2 -translate-x-1/2 z-sticky animate-in slide-in-from-top-2',
+  inline: 'relative animate-in fade-in',
 }
 
 /**
@@ -24,18 +36,19 @@ export function DataTableBulkActions<TData>({
   table,
   selectedRows,
   bulkActions,
+  position = 'bottom',
 }: {
   table: Table<TData>
   selectedRows: TData[]
   bulkActions: BulkAction<TData>[]
+  position?: BulkActionsPosition
 }) {
   return (
     <div
       className={cn(
-        'fixed bottom-6 left-1/2 -translate-x-1/2 z-sticky',
+        POSITION_CLASSES[position],
         'flex items-center gap-ds-04 px-ds-05 py-ds-03',
         'rounded-overlay bg-surface-overlay shadow-floating',
-        'animate-in slide-in-from-bottom-2',
       )}
       role="toolbar"
       aria-label="Bulk actions"
@@ -51,6 +64,7 @@ export function DataTableBulkActions<TData>({
           variant={action.color === 'error' ? 'solid' : 'outline'}
           color={action.color === 'error' ? 'error' : undefined}
           disabled={action.disabled}
+          startIcon={action.icon}
           onClick={() => action.onClick(selectedRows)}
         >
           {action.label}

--- a/packages/core/src/ui/data-table.stories.tsx
+++ b/packages/core/src/ui/data-table.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { within, userEvent, expect, waitFor } from 'storybook/test'
 import { useState } from 'react'
+import { IconArchive } from '@tabler/icons-react'
 import { DataTable } from './data-table'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Badge } from './badge'
@@ -729,8 +730,25 @@ export const BulkActions: Story = {
       selectable
       getRowId={(row) => row.id}
       bulkActions={[
-        { label: 'Archive', onClick: (rows) => alert(`Archive ${rows.length} rows`) },
+        { label: 'Archive', onClick: (rows) => alert(`Archive ${rows.length} rows`), icon: IconArchive },
         { label: 'Add Label', onClick: (rows) => alert(`Label ${rows.length} rows`) },
+        { label: 'Delete', onClick: (rows) => alert(`Delete ${rows.length} rows`), color: 'error' },
+      ]}
+    />
+  ),
+}
+
+export const BulkActionsInline: Story = {
+  name: 'Bulk actions — inline position',
+  render: () => (
+    <DataTable
+      columns={columns}
+      data={filterData}
+      selectable
+      getRowId={(row) => row.id}
+      bulkActionsPosition="inline"
+      bulkActions={[
+        { label: 'Archive', onClick: (rows) => alert(`Archive ${rows.length} rows`), icon: IconArchive },
         { label: 'Delete', onClick: (rows) => alert(`Delete ${rows.length} rows`), color: 'error' },
       ]}
     />

--- a/packages/core/src/ui/data-table.tsx
+++ b/packages/core/src/ui/data-table.tsx
@@ -26,7 +26,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Checkbox } from './checkbox'
 import { DataTableBody } from './data-table-body'
-import { type BulkAction,DataTableBulkActions } from './data-table-bulk-actions'
+import { type BulkAction,type BulkActionsPosition, DataTableBulkActions } from './data-table-bulk-actions'
 import { DataTableCards } from './data-table-card'
 import {
   DataTableProvider,
@@ -214,6 +214,8 @@ export interface DataTableProps<TData, TValue> {
   // --- Bulk actions ---
   /** Actions shown in a floating bar when rows are selected */
   bulkActions?: BulkAction<TData>[]
+  /** Where the bulk-actions bar renders. @default 'bottom' */
+  bulkActionsPosition?: BulkActionsPosition
 
   // --- Mobile view ---
   /** Render rows as stacked cards on small screens (below sm breakpoint). Default 'table'. */
@@ -296,6 +298,7 @@ export function DataTable<TData, TValue>({
   stickyHeader = false,
   onRowClick,
   bulkActions,
+  bulkActionsPosition = 'bottom',
   mobileView = 'table',
   enableExport,
   onExport,
@@ -766,6 +769,7 @@ export function DataTable<TData, TValue>({
             table={table}
             selectedRows={selectedRows}
             bulkActions={bulkActions}
+            position={bulkActionsPosition}
           />
         )}
       </div>

--- a/packages/eslint-plugin/src/configs/flat-recommended.ts
+++ b/packages/eslint-plugin/src/configs/flat-recommended.ts
@@ -27,6 +27,7 @@ const config = {
     'shilp-sutra/no-iconbutton-children': 'error',
     'shilp-sutra/no-bare-shadow': 'warn',
     'shilp-sutra/require-mutation-annotation': 'warn',
+    'shilp-sutra/require-progress-label': 'warn',
     'shilp-sutra/toast-object-syntax': 'warn',
   } as const,
 }

--- a/packages/eslint-plugin/src/configs/flat-strict.ts
+++ b/packages/eslint-plugin/src/configs/flat-strict.ts
@@ -22,6 +22,7 @@ const config = {
     'shilp-sutra/no-iconbutton-children': 'error',
     'shilp-sutra/no-bare-shadow': 'error',
     'shilp-sutra/require-mutation-annotation': 'error',
+    'shilp-sutra/require-progress-label': 'error',
     'shilp-sutra/toast-object-syntax': 'error',
   } as const,
 }

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -27,6 +27,7 @@ const config = {
     // Recommended (warn / advisory)
     'shilp-sutra/no-bare-shadow': 'warn',
     'shilp-sutra/require-mutation-annotation': 'warn',
+    'shilp-sutra/require-progress-label': 'warn',
     'shilp-sutra/toast-object-syntax': 'warn',
   },
 }

--- a/packages/eslint-plugin/src/configs/strict.ts
+++ b/packages/eslint-plugin/src/configs/strict.ts
@@ -16,6 +16,7 @@ const config = {
     'shilp-sutra/no-iconbutton-children': 'error',
     'shilp-sutra/no-bare-shadow': 'error',
     'shilp-sutra/require-mutation-annotation': 'error',
+    'shilp-sutra/require-progress-label': 'error',
     'shilp-sutra/toast-object-syntax': 'error',
   },
 }

--- a/packages/eslint-plugin/src/rules/index.ts
+++ b/packages/eslint-plugin/src/rules/index.ts
@@ -13,6 +13,7 @@ import noIconButtonChildren from './no-iconbutton-children'
 import noTailwindConfigPreset from './no-tailwind-config-preset'
 import preferPerComponentImport from './prefer-per-component-import'
 import requireMutationAnnotation from './require-mutation-annotation'
+import requireProgressLabel from './require-progress-label'
 import toastObjectSyntax from './toast-object-syntax'
 import useToastDeprecated from './use-toast-deprecated'
 
@@ -28,6 +29,7 @@ export const rules = {
   'no-tailwind-config-preset': noTailwindConfigPreset,
   'prefer-per-component-import': preferPerComponentImport,
   'require-mutation-annotation': requireMutationAnnotation,
+  'require-progress-label': requireProgressLabel,
   'toast-object-syntax': toastObjectSyntax,
   'use-toast-deprecated': useToastDeprecated,
 } as const

--- a/packages/eslint-plugin/src/rules/require-progress-label.ts
+++ b/packages/eslint-plugin/src/rules/require-progress-label.ts
@@ -1,0 +1,54 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils'
+
+import { createRule } from '../util/create-rule'
+import { findJSXAttribute, getJSXElementName } from '../util/jsx'
+
+/**
+ * `<Progress>` with no accessible name announces as just "progressbar, 72%" —
+ * the value is already carried by `aria-valuenow`, so what's missing is WHAT
+ * is progressing. The component itself only warns about this at runtime
+ * (dev console); this rule catches it statically at lint time instead.
+ *
+ * Only targets the smart all-in-one `<Progress>` — `<Progress.Track>` and
+ * other compound parts take `aria-label`/`aria-labelledby` directly and
+ * aren't this rule's concern.
+ */
+type MessageIds = 'missingLabel'
+
+const LABEL_ATTRS = ['label', 'aria-label', 'aria-labelledby']
+
+export default createRule<[], MessageIds>({
+  name: 'require-progress-label',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        '<Progress> needs an accessible name via `label`, `aria-label`, or `aria-labelledby` — otherwise it announces as just "progressbar" with a percentage.',
+      category: 'recommended',
+      recommended: 'warn',
+      appliesFrom: '0.4.0',
+    },
+    schema: [],
+    messages: {
+      missingLabel:
+        '<Progress> has no accessible name. Pass `label`, `aria-label`, or `aria-labelledby` so screen readers announce what is progressing.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (getJSXElementName(node) !== 'Progress') return
+        // A spread might carry the label at runtime — can't statically rule it out.
+        const hasSpread = node.attributes.some(
+          (attr) => attr.type === AST_NODE_TYPES.JSXSpreadAttribute,
+        )
+        if (hasSpread) return
+        const hasLabel = LABEL_ATTRS.some((name) => findJSXAttribute(node, name) != null)
+        if (!hasLabel) {
+          context.report({ node, messageId: 'missingLabel' })
+        }
+      },
+    }
+  },
+})

--- a/packages/eslint-plugin/tests/rules/require-progress-label.test.ts
+++ b/packages/eslint-plugin/tests/rules/require-progress-label.test.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from '@typescript-eslint/rule-tester'
+
+import rule from '../../src/rules/require-progress-label'
+
+const tester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true },
+    },
+  },
+})
+
+tester.run('require-progress-label', rule, {
+  valid: [
+    `<Progress value={70} label="Storage used" />`,
+    `<Progress value={70} aria-label="Upload progress" />`,
+    `<Progress value={70} aria-labelledby="storage-heading" />`,
+    `<Progress value={70} {...rest} />`,
+    `<Progress.Root value={70} />`,
+    `<Progress.Track aria-label="Upload progress" />`,
+    `<div value={70} />`,
+  ],
+  invalid: [
+    {
+      code: `<Progress value={70} />`,
+      errors: [{ messageId: 'missingLabel' }],
+    },
+    {
+      code: `<Progress value={70} showValue />`,
+      errors: [{ messageId: 'missingLabel' }],
+    },
+    {
+      code: `<Progress />`,
+      errors: [{ messageId: 'missingLabel' }],
+    },
+  ],
+})


### PR DESCRIPTION
## Summary

Closes #268.

**Missing tests added** (previously zero coverage): `Diff`, `DataTableCards`, `DataTableBulkActions`, `DataTablePagination`, `DataTableHeader`, `DataTableBody` (inline cell edit/expand/virtualization/loading/empty), `BlockShell`.

**Shallow tests expanded**: `Sidebar` (collapsed state, `toggleSidebar`, keyboard shortcut, rail, mobile `Sheet`), `NotificationPreferences` (add/delete/mute callbacks, loading/empty states), `GlobalLoading` (loading-state transitions), `useViewportHeight` (SSR fallback, Visual Viewport resize, window-resize fallback, cleanup), `DatePicker`/`DateRangePicker`/`DateTimePicker` family (keyboard nav, minDate/maxDate, clearing).

**Feature requests from the issue** (additive, non-breaking):
- `BulkAction.icon?: IconInput` — icon before the label in bulk-action buttons
- `DataTable`'s `bulkActionsPosition?: 'bottom' | 'top' | 'inline'` instead of hard-coded fixed positioning
- `DateSeparator` `locale?`/`timeZone?` props (was hard-coded `en-US`, no timezone handling)
- `Diff` `language?: string` — lazy syntax highlighting, same lazy-load + one-dark pattern as `MarkdownViewer`
- `Diff` `beforeParseError?`/`afterParseError?` slot props for `fields`-mode JSON parse failures
- New ESLint rule `require-progress-label` — statically catches `<Progress>` missing an accessible name
- New hook `useContainerSize()` — `ResizeObserver`-based `{ ref, width, height }`

**Also verified with new tests**: `rowClassName` + `filterableColumns` actually work in `mobileView="card"` (previously untested since the changeset that added them), and `onExport` receives filtered/visible rows rather than the full dataset.

Docs (`docs/components/composed/diff.md`, `docs/components/ui/data-table.md`, `docs/components/ui/chat.md`) and Storybook stories (`diff.stories.tsx`, `data-table.stories.tsx`) updated for the new props. Two changesets included (`@devalok/shilp-sutra` minor, `@devalok/eslint-plugin-shilp-sutra` minor).

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 errors; only pre-existing warnings)
- [x] `pnpm test` (core) — 181 test files / 2495 tests passing
- [x] `pnpm test` (eslint-plugin) — 14 test files / 105 tests passing
- [x] `pnpm build` (core) — succeeds, docs/manifest regenerate cleanly
- [x] `pnpm build` (eslint-plugin) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)