### PR TITLE
Bound every job, and stop superseded Chromatic runs burning snapshot quota

### DIFF
--- a/.github/workflows/agent-feedback-ack.yml
+++ b/.github/workflows/agent-feedback-ack.yml
@@ -14,6 +14,7 @@ jobs:
   ack:
     if: contains(github.event.issue.labels.*.name, 'ai-agent-feedback')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+# Two pushes to a PR in quick succession ran the whole suite twice and kept both results.
+# GitHub bills every JOB rounded up to a whole minute, so a superseded run is not free.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     # Turborepo remote cache (self-hosted on Railway). PR CI reads+writes the
     # shared cache so unchanged packages restore instead of rebuild. Degrades

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     environment:
       name: github-pages

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,6 +32,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
   # we fail the run BEFORE publishing.
   guard:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       prerelease: ${{ steps.check.outputs.prerelease }}
     steps:
@@ -62,6 +63,7 @@ jobs:
   release:
     needs: guard
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # OIDC trusted publishing: `id-token: write` lets npm verify the publish
     # came from this workflow without a long-lived NPM_TOKEN. `contents: write`
     # lets changesets/action open the Version Packages PR and push tags.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -23,6 +23,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       # contents: write + pull-requests: write let changesets/action open and
       # update the Version Packages PR. NO id-token here — this job cannot and

--- a/.github/workflows/visual-review.yml
+++ b/.github/workflows/visual-review.yml
@@ -23,10 +23,19 @@ on:
         type: boolean
         default: false
 
+# Superseded Chromatic runs still consume SNAPSHOT QUOTA, which is metered on Chromatic's plan,
+# not GitHub's. This repo is public so its Actions minutes are free - the saving here is not
+# GitHub's bill, it is Chromatic's.
+# GitHub bills every JOB rounded up to a whole minute, so a superseded run is not free.
+concurrency:
+  group: visual-review-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   chromatic:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'visual-review')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of the studio-wide Actions sweep after the org hit its **$20 spending limit on 16 August** and CI was refused everywhere for ~46 hours. Analysis lives in [setu#202](https://github.com/devalok-design/setu/pull/202).

**This repo is public, so its Actions minutes are free.** It contributed £0 to the August bill despite burning 3,131 minutes in July. It's here for two reasons that aren't GitHub's invoice:

**`timeout-minutes` on all eight jobs.** The default is 360. A hung job costs nothing here, but it holds a concurrency slot and sits green-pending on a PR for six hours before anyone learns anything.

**`concurrency` on `ci.yml` and `visual-review.yml`** — the only two that lacked it; `deploy-storybook`, `integration`, `release` and `version` already had groups.

`visual-review` is the one that matters. **Superseded Chromatic runs still consume snapshot quota, metered on Chromatic's plan, not GitHub's.** Two pushes to a PR in a minute burned two sets of snapshots and only the last was ever read. That's the only line in this whole sweep that saves money outside GitHub.

## Left alone deliberately

- `visual-review`'s `paths-ignore` and its `visual-review` label gate on `pull_request` are already doing the heavy lifting on snapshot cost — this repo was in better shape than the private ones.
- `agent-feedback-ack` gets no concurrency group: it's per-issue, and cancelling one issue's ack because another arrived would silently drop an acknowledgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHxkn1m7oxnJ1ju8CFD2qg