### PR TITLE
fix(a11y): repair three colour-contrast failures on real component surfaces

### DIFF
--- a/.changeset/clear-badges-see-clearly.md
+++ b/.changeset/clear-badges-see-clearly.md
@@ -1,0 +1,13 @@
+---
+"@devalok/shilp-sutra": patch
+---
+
+fix three colour-contrast failures found by resolving real component pairs against their actual backgrounds
+
+**Alert's dismiss button was effectively invisible on solid variants.** It was `text-surface-fg-subtle` regardless of variant, so on a saturated step 9 fill it measured 1.07:1 on info, 1.04:1 on error and **1.01:1 on success**, which is no contrast at all. It now inherits the alert's own foreground on solid, exactly as the title and body already do, and measures 4.66 to 7.76 across the five intents.
+
+**Badge category labels failed AA in dark mode.** The seven category colours painted their solid label with a hardcoded `text-white`, but category step 9 *lightens* in dark mode, the opposite of the intent ramps. Light passed at 4.59 to 5.10; dark landed at 3.28 to 3.70 on 10px text. Adds `--color-category-fg`, which resolves to `--neutral-0` in light and `--neutral-1` in dark, so it inverts with the theme. Measured 4.59 to 4.97 in light and 5.55 to 6.24 in dark across all seven.
+
+**Input, Textarea, Select and Combobox placeholders missed AA in light.** `surface-fg-subtle` is compliant on `surface-base` at 4.664:1, but these controls sit on `surface-raised-hover`, where the same token measures 4.14:1. Placeholders are body sized, so the bar is 4.5. The four field controls now use `surface-fg-muted` (6.63:1). The token itself is unchanged, because it is correct on the page canvas and has around 290 other usages.
+
+All three were found by porting the design system into Figma and resolving each component's real foreground-on-background pair through the variable chain, rather than by reading tokens in isolation.

--- a/packages/core/src/tokens/semantic.css
+++ b/packages/core/src/tokens/semantic.css
@@ -264,6 +264,13 @@
   /* ───────────────────────────────────────────────────────────
      CATEGORY COLORS (Sapta Varna — step subsets)
      ─────────────────────────────────────────────────────────── */
+  /* Foreground for solid category fills. Category step 9 LIGHTENS in dark mode,
+     the opposite of the intent ramps, so a fixed white fails AA there. neutral-1
+     inverts with the theme: near-white in light, near-black in dark.
+     Measured: light 4.59-4.97 on all seven, dark 5.55-6.24. Badge labels are 10px,
+     so AA body (4.5) is the bar, not large text. */
+  --color-category-fg:         var(--neutral-0);
+
   --color-category-teal-3:     var(--teal-3);
   --color-category-teal-7:     var(--teal-7);
   --color-category-teal-9:     var(--teal-9);
@@ -591,6 +598,9 @@
   --color-error-fg:     var(--neutral-0);
   --color-success-fg:   var(--neutral-0);
   --color-info-fg:      var(--neutral-0);
+
+  /* Category fills lighten in dark, so their label goes near-black, not white */
+  --color-category-fg:  var(--neutral-1);
 
   /* Warning: amber-bright dark ramp */
   --color-warning-2:  var(--amber-bright-2);

--- a/packages/core/src/ui/alert.tsx
+++ b/packages/core/src/ui/alert.tsx
@@ -159,7 +159,15 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
               <button
                 type="button"
                 onClick={handleDismiss}
-                className="shrink-0 min-h-ds-xs min-w-ds-xs flex items-center justify-center rounded-control-inner text-surface-fg-subtle transition-colors duration-fast-01 ease-productive-standard hover:text-surface-fg-muted hover:bg-surface-raised-hover active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9"
+                className={cn(
+                  'shrink-0 min-h-ds-xs min-w-ds-xs flex items-center justify-center rounded-control-inner transition-colors duration-fast-01 ease-productive-standard active:scale-95 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9',
+                  // On solid the fill is a saturated step 9, where a mid grey
+                  // measures as low as 1.01:1. Inherit the alert's own foreground,
+                  // exactly as the title and body already do.
+                  variant === 'solid'
+                    ? 'text-current opacity-80 hover:opacity-100'
+                    : 'text-surface-fg-subtle hover:text-surface-fg-muted hover:bg-surface-raised-hover',
+                )}
                 aria-label="Dismiss"
               >
                 <Icon icon={IconX} size={dismissIconSize} />

--- a/packages/core/src/ui/badge.tsx
+++ b/packages/core/src/ui/badge.tsx
@@ -22,13 +22,13 @@ const colorMap = {
   warning: { bg: 'bg-warning-3', fg: 'text-warning-11', border: 'border-warning-7', solid: 'bg-warning-9', solidFg: 'text-warning-fg' },
   info:    { bg: 'bg-info-3',    fg: 'text-info-11',    border: 'border-info-7',    solid: 'bg-info-9',    solidFg: 'text-info-fg' },
   neutral: { bg: 'bg-surface-raised-hover', fg: 'text-surface-fg-muted', border: 'border-surface-border-strong', solid: 'bg-neutral-5', solidFg: 'text-surface-fg' },
-  teal:    { bg: 'bg-category-teal-3',    fg: 'text-category-teal-11',    border: 'border-category-teal-7',    solid: 'bg-category-teal-9',    solidFg: 'text-white' },
-  amber:   { bg: 'bg-category-amber-3',   fg: 'text-category-amber-11',   border: 'border-category-amber-7',   solid: 'bg-category-amber-9',   solidFg: 'text-white' },
-  slate:   { bg: 'bg-category-slate-3',   fg: 'text-category-slate-11',   border: 'border-category-slate-7',   solid: 'bg-category-slate-9',   solidFg: 'text-white' },
-  indigo:  { bg: 'bg-category-indigo-3',  fg: 'text-category-indigo-11',  border: 'border-category-indigo-7',  solid: 'bg-category-indigo-9',  solidFg: 'text-white' },
-  cyan:    { bg: 'bg-category-cyan-3',    fg: 'text-category-cyan-11',    border: 'border-category-cyan-7',    solid: 'bg-category-cyan-9',    solidFg: 'text-white' },
-  orange:  { bg: 'bg-category-orange-3',  fg: 'text-category-orange-11',  border: 'border-category-orange-7',  solid: 'bg-category-orange-9',  solidFg: 'text-white' },
-  emerald: { bg: 'bg-category-emerald-3', fg: 'text-category-emerald-11', border: 'border-category-emerald-7', solid: 'bg-category-emerald-9', solidFg: 'text-white' },
+  teal:    { bg: 'bg-category-teal-3',    fg: 'text-category-teal-11',    border: 'border-category-teal-7',    solid: 'bg-category-teal-9',    solidFg: 'text-category-fg' },
+  amber:   { bg: 'bg-category-amber-3',   fg: 'text-category-amber-11',   border: 'border-category-amber-7',   solid: 'bg-category-amber-9',   solidFg: 'text-category-fg' },
+  slate:   { bg: 'bg-category-slate-3',   fg: 'text-category-slate-11',   border: 'border-category-slate-7',   solid: 'bg-category-slate-9',   solidFg: 'text-category-fg' },
+  indigo:  { bg: 'bg-category-indigo-3',  fg: 'text-category-indigo-11',  border: 'border-category-indigo-7',  solid: 'bg-category-indigo-9',  solidFg: 'text-category-fg' },
+  cyan:    { bg: 'bg-category-cyan-3',    fg: 'text-category-cyan-11',    border: 'border-category-cyan-7',    solid: 'bg-category-cyan-9',    solidFg: 'text-category-fg' },
+  orange:  { bg: 'bg-category-orange-3',  fg: 'text-category-orange-11',  border: 'border-category-orange-7',  solid: 'bg-category-orange-9',  solidFg: 'text-category-fg' },
+  emerald: { bg: 'bg-category-emerald-3', fg: 'text-category-emerald-11', border: 'border-category-emerald-7', solid: 'bg-category-emerald-9', solidFg: 'text-category-fg' },
 } as const
 
 type BadgeColor = keyof typeof colorMap | 'custom'

--- a/packages/core/src/ui/combobox.tsx
+++ b/packages/core/src/ui/combobox.tsx
@@ -495,7 +495,7 @@ const Combobox = React.forwardRef<HTMLDivElement, ComboboxProps>(
                     <input
                       ref={searchInputRef}
                       type="text"
-                      className="flex-1 bg-transparent py-ds-03 text-body-md outline-hidden placeholder:text-surface-fg-subtle"
+                      className="flex-1 bg-transparent py-ds-03 text-body-md outline-hidden placeholder:text-surface-fg-muted"
                       placeholder={searchPlaceholder}
                       value={search}
                       onChange={(e) => {

--- a/packages/core/src/ui/input.tsx
+++ b/packages/core/src/ui/input.tsx
@@ -199,7 +199,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           className={cn(
             'flex-1 min-w-0 h-full bg-transparent outline-hidden font-sans',
-            'placeholder:text-surface-fg-subtle',
+            'placeholder:text-surface-fg-muted',
             'disabled:cursor-not-allowed',
             'read-only:cursor-default',
             inputPadding[size],

--- a/packages/core/src/ui/select.tsx
+++ b/packages/core/src/ui/select.tsx
@@ -40,7 +40,7 @@ const SelectGroup = SelectPrimitive.Group
 const SelectValue = SelectPrimitive.Value
 
 export const selectTriggerVariants = cva(
-  'flex w-full items-center justify-between whitespace-nowrap rounded-control placeholder:text-surface-fg-subtle focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-action-disabled [&>span]:line-clamp-1 [&>span]:min-w-0',
+  'flex w-full items-center justify-between whitespace-nowrap rounded-control placeholder:text-surface-fg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-action-disabled [&>span]:line-clamp-1 [&>span]:min-w-0',
   {
     variants: {
       variant: {

--- a/packages/core/src/ui/textarea.tsx
+++ b/packages/core/src/ui/textarea.tsx
@@ -14,7 +14,7 @@ const textareaVariants = cva(
     'flex w-full font-sans resize-y',
     'bg-surface-raised-hover text-surface-fg',
     'border border-surface-border-strong rounded-control',
-    'placeholder:text-surface-fg-subtle',
+    'placeholder:text-surface-fg-muted',
     'hover:bg-surface-raised-active',
     'transition-colors duration-fast-01 ease-productive-standard',
     'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent-9 focus-visible:ring-offset-2 focus-visible:border-accent-7',


### PR DESCRIPTION
Three AA failures, found by porting the design system into Figma and resolving each component's **actual** foreground-on-background pair through the variable chain. Every token involved is defensible in isolation; the pairings were not.

| Component | Light | Dark | After |
|---|---|---|---|
| Alert dismiss on solid | **1.01–2.46:1** | **1.41:1** | 4.66–7.76 |
| Badge category solid | 4.59–5.10 | **3.28–3.70:1** | 4.59–4.97 / 5.55–6.24 |
| Input, Textarea, Select, Combobox placeholder | **4.14:1** | 4.83 | 6.63 |

## Alert

`text-surface-fg-subtle` applied on every variant, so on a saturated step 9 fill it was a mid grey. **Solid success measured 1.01:1** — literally invisible. Now inherits the alert's own foreground on solid, exactly as the title and body already do.

## Badge

The seven category colours hardcoded `text-white`. Category step 9 **lightens** in dark mode, the opposite of the intent ramps, so a fixed white cannot work in both. The intent colours escape this only because they have adaptive `-fg` tokens, which category never had.

Adds one `--color-category-fg`, not seven: `--neutral-0` in light, `--neutral-1` in dark. The neutral ramp already inverts, so it flips with the theme.

`--neutral-1` in light (`#fcfcfc`) was tried first and measured **4.47–4.50** on teal, cyan and emerald — a hair under AA body. `--neutral-0` clears all seven.

## Fields

`surface-fg-subtle` carries a comment saying it measures 4.664:1 on `surface-base`, and that is true. But these four controls sit on `surface-raised-hover`, where it measures **4.14:1**, and placeholders are body sized.

**The token is deliberately unchanged** — it is correct on the page canvas and has ~290 usages across ~100 files. Only the four field controls move to `surface-fg-muted`. The trade is a slightly narrower placeholder-versus-value distinction for AA compliance.

## Verification

Typecheck clean. **300 tests across 17 files pass.** Ratios from Setu (WCAG 2.1 formula). Badge labels are 10px and placeholders 12–14px, so AA body (4.5) is the bar throughout, not large text.

Worth merging before #266 so these ship in 0.57.0. The Figma library has an `Accessibility review` page documenting all three; I'll sync it to match once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
